### PR TITLE
fix(api): copy ip rejection reasons when copying ip comments (A2-8189)

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -200,6 +200,7 @@ const mockRepresentationRejectionReasonFindMany = jest.fn().mockResolvedValue({}
 const mockRepresentationRejectionReasonsSelectedDeleteMany = jest.fn().mockResolvedValue({});
 const mockRepresentationRejectionReasonTextDeleteMany = jest.fn().mockResolvedValue({});
 const mockRepresentationCreate = jest.fn().mockResolvedValue({});
+const mockRepresentationCreateMany = jest.fn().mockRejectedValue({});
 const mockRepresentationDeleteMany = jest.fn().mockResolvedValue({});
 const mockRepresentationAttachmentDeleteMany = jest.fn().mockResolvedValue({});
 const mockRepresentationAttachmentCreateMany = jest.fn().mockResolvedValue({});
@@ -253,6 +254,7 @@ class MockPrismaClient {
 			updateMany: mockRepUpdateMany,
 			groupBy: mockRepGroupBy,
 			create: mockRepresentationCreate,
+			createMany: mockRepresentationCreateMany,
 			count: mockRepresentationCount,
 			deleteMany: mockRepresentationDeleteMany
 		};

--- a/appeals/api/src/server/endpoints/documents/documents.service.js
+++ b/appeals/api/src/server/endpoints/documents/documents.service.js
@@ -238,6 +238,9 @@ export const getFoldersForStage = (path) => {
 		case 'cancellation': // TODO: use the enum
 			folders = [`cancellation/${APPEAL_DOCUMENT_TYPE.LPA_ENFORCEMENT_NOTICE_WITHDRAWAL}`];
 			break;
+		case 'representation':
+			folders = ['representation/representationAttachments'];
+			break;
 		default:
 			folders = [`${APPEAL_CASE_STAGE.INTERNAL}/${APPEAL_DOCUMENT_TYPE.UNCATEGORISED}`];
 	}
@@ -312,6 +315,7 @@ const addDocumentAndVersion = async (appeal, documents, allowErrors = false) => 
 		documentURI: document.documentURI,
 		dateReceived: document.dateReceived,
 		virusCheckStatus: document.virusCheckStatus,
+		// note - redactionStatusID can be null/undefined here as will be picked up in the addDocumentsBulk call
 		redactionStatusId: document.redactionStatusId,
 		isLateEntry: isLateEntry(document.stage, appeal)
 	}));

--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeals.service.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeals.service.test.js
@@ -1,8 +1,11 @@
 // @ts-nocheck
 import { householdAppeal as appeal } from '#tests/appeals/mocks.js';
+import { jest } from '@jest/globals';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
-import { checkAppealsStatusBeforeLPAQ } from '../link-appeals.service.js';
+import { checkAppealsStatusBeforeLPAQ, copyRepresentations } from '../link-appeals.service.js';
+
+const { databaseConnector } = await import('#utils/database-connector.js');
 
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import {
@@ -14,6 +17,9 @@ import {
 } from '@pins/appeals/constants/support.js';
 
 describe('Link Appeals Service', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
 	describe('checkAppealsStatusBeforeLPAQ', () => {
 		it('should return true where the linked appeal is the parent and it already has linked children and has status before LPA Questionnaire', () => {
 			const linkedAppeal = structuredClone({
@@ -91,6 +97,45 @@ describe('Link Appeals Service', () => {
 				isCurrentAppealParent
 			);
 			expect(result).toBe(false);
+		});
+	});
+
+	describe('copyRepresentations', () => {
+		it('should return an empty array if there are no representations to copy', async () => {
+			databaseConnector.representation.findMany.mockResolvedValue([]);
+
+			const result = await copyRepresentations({ id: 'testSource' }, { id: 'testDestination' });
+			expect(result).toEqual([]);
+			expect(databaseConnector.representation.findMany).toHaveBeenCalledTimes(1);
+			expect(databaseConnector.folder.findMany).not.toHaveBeenCalled();
+			expect(databaseConnector.document.findMany).not.toHaveBeenCalled();
+			expect(databaseConnector.representation.createMany).not.toHaveBeenCalled();
+		});
+
+		it('should return an array of copied representations if there are representations to copy - no attachments', async () => {
+			const testRepsArray = [
+				{
+					id: 'rep1',
+					attachments: [],
+					representationType: 'testType'
+				},
+				{
+					id: 'rep2',
+					attachments: [],
+					representationType: 'testType'
+				}
+			];
+			databaseConnector.representation.findMany.mockResolvedValue(testRepsArray);
+			databaseConnector.folder.findMany.mockResolvedValue([{ id: 1 }]);
+			databaseConnector.document.findMany.mockResolvedValue([]);
+			databaseConnector.representation.createMany.mockResolvedValue([]);
+
+			const result = await copyRepresentations({ id: 'testSource' }, { id: 'testDestination' });
+			expect(result).toEqual(testRepsArray);
+			expect(databaseConnector.representation.findMany).toHaveBeenCalledTimes(2);
+			expect(databaseConnector.folder.findMany).toHaveBeenCalledTimes(2);
+			expect(databaseConnector.document.findMany).toHaveBeenCalledTimes(1);
+			expect(databaseConnector.representation.createMany).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -212,6 +212,7 @@ export const copyRepresentations = async (sourceAppeal, destinationAppeal) => {
 	const { comments: representations } = await representationRepository.getRepresentations([
 		Number(sourceAppeal.id)
 	]);
+	if (representations.length === 0) return [];
 	const stage = 'representation';
 	const sourceFolders = await getFoldersForAppeal(sourceAppeal.id, stage);
 	const destinationFolders = await getFoldersForAppeal(destinationAppeal.id, stage);
@@ -219,7 +220,7 @@ export const copyRepresentations = async (sourceAppeal, destinationAppeal) => {
 		return;
 	}
 	const documents = await getDocumentsInFolder({ folderId: sourceFolders[0].id });
-	const attachmentsByRepresentedId = {};
+	const representationAttachments = {};
 	const copiedRepresentations = await Promise.allSettled(
 		representations.map(async (representation) => {
 			const copyList = representation.attachments
@@ -267,10 +268,26 @@ export const copyRepresentations = async (sourceAppeal, destinationAppeal) => {
 				documentGuid: destinationGuid,
 				version
 			}));
-			if (represented?.id) {
+
+			//	attachments and rejection reasons cannot be added until the representation itself has
+			// been created and so need to be stored against an appropriate key until reps are created
+			// (see below)
+			//	ip comments will retain the original serviceUser id so this can be the key
+			// appellant and lpa rep types should only appear once per appeal, so the type can be the key
+			if (representation.representationType === APPEAL_REPRESENTATION_TYPE.COMMENT) {
 				// @ts-ignore
-				attachmentsByRepresentedId[represented.id] = attachments;
+				representationAttachments[represented.id] = {
+					attachments,
+					rejectionReasons: representation.representationRejectionReasonsSelected
+				};
+			} else {
+				// @ts-ignore
+				representationAttachments[representation.representationType] = {
+					attachments,
+					rejectionReasons: representation.representationRejectionReasonsSelected
+				};
 			}
+
 			return {
 				appealId: destinationAppeal.id,
 				representedId: represented?.id ?? null,
@@ -284,17 +301,44 @@ export const copyRepresentations = async (sourceAppeal, destinationAppeal) => {
 			};
 		})
 	);
+
 	// @ts-ignore
 	await representationRepository.createRepresentations(
 		copiedRepresentations.filter((rep) => rep.status === 'fulfilled').map((rep) => rep.value)
 	);
+
 	const { comments: representationsInDestinationAppeal } =
 		await representationRepository.getRepresentations([Number(destinationAppeal.id)]);
+
 	await Promise.allSettled(
 		representationsInDestinationAppeal.map(async (representation) => {
-			if (!representation.represented?.id) return;
+			const attachmentsListKey =
+				representation.representationType === APPEAL_REPRESENTATION_TYPE.COMMENT
+					? representation.represented?.id
+					: representation.representationType;
+
 			// @ts-ignore
-			const attachments = attachmentsByRepresentedId[representation.represented.id];
+			const { attachments, rejectionReasons } = representationAttachments[attachmentsListKey];
+
+			if (!attachments && !rejectionReasons) return;
+
+			if (rejectionReasons.length > 0) {
+				//@ts-ignore
+				const updateDataArray = rejectionReasons.map((reason) => {
+					//@ts-ignore
+					const textArray = reason.representationRejectionReasonText.map(
+						//@ts-ignore
+						(textObject) => textObject.text
+					);
+					return {
+						id: reason.representationRejectionReason?.id,
+						text: textArray
+					};
+				});
+
+				await representationRepository.updateRejectionReasons(representation.id, updateDataArray);
+			}
+
 			if (attachments)
 				await representationRepository.addAttachments(representation.id, attachments);
 		})

--- a/appeals/api/src/server/repositories/document-metadata.repository.js
+++ b/appeals/api/src/server/repositories/document-metadata.repository.js
@@ -152,29 +152,36 @@ export const addDocumentsBulk = async (documents) => {
 			}
 
 			await tx.documentVersion.createMany({
-				data: chunk.map((document) => ({
-					documentGuid: document.guid,
-					version: 1,
-					lastModified: now,
-					documentType: document.documentType,
-					published: false,
-					draft: false,
-					virusCheckStatus:
-						document.virusCheckStatus ??
-						virusCheckStatusByGuid.get(document.guid) ??
-						APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED,
-					originalFilename: document.originalFilename,
-					fileName: document.fileName,
-					mime: document.mime,
-					size: document.size,
-					stage: document.stage,
-					blobStorageContainer: document.blobStorageContainer,
-					blobStoragePath: document.blobStoragePath,
-					documentURI: document.documentURI,
-					dateReceived: document.dateReceived ?? now,
-					isLateEntry: document.isLateEntry,
-					redactionStatusId: document.redactionStatusId ?? null
-				}))
+				data: chunk.map((document) => {
+					let mappedDocumentVersionData = {
+						documentGuid: document.guid,
+						version: 1,
+						lastModified: now,
+						documentType: document.documentType,
+						published: false,
+						draft: false,
+						virusCheckStatus:
+							document.virusCheckStatus ??
+							virusCheckStatusByGuid.get(document.guid) ??
+							APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED,
+						originalFilename: document.originalFilename,
+						fileName: document.fileName,
+						mime: document.mime,
+						size: document.size,
+						stage: document.stage,
+						blobStorageContainer: document.blobStorageContainer,
+						blobStoragePath: document.blobStoragePath,
+						documentURI: document.documentURI,
+						dateReceived: document.dateReceived ?? now,
+						isLateEntry: document.isLateEntry
+					};
+					// redactionStatusId should only be set if it is non-null/non-undefined
+					if (document.redactionStatusId) {
+						//@ts-ignore
+						mappedDocumentVersionData.redactionStatusId = document.redactionStatusId;
+					}
+					return mappedDocumentVersionData;
+				})
 			});
 
 			await tx.document.updateMany({


### PR DESCRIPTION
## Describe your changes

Representation rejection reasons were not copying over onto copied reps on unlinking a linked appeal.

Reasons are copied and stored locally, then added once representation created.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8189)
