### PR TITLE
fix(appeals): display written or vebal permission for ELB (A2-8037)

### DIFF
--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -1721,6 +1721,7 @@ export async function seedTestData(databaseConnector) {
 				where: { appealId: appealId },
 				data: {
 					contactAddressId: address.id,
+					enforcementNotice: true,
 					enforcementNoticeListedBuilding: false,
 					enforcementIssueDate: getPastDate({ days: 10 }),
 					enforcementEffectiveDate: new Date(),

--- a/appeals/api/src/server/mappers/api/enforcement-listed/map-appellant-case.js
+++ b/appeals/api/src/server/mappers/api/enforcement-listed/map-appellant-case.js
@@ -43,6 +43,9 @@ export const mapEnforcementListedAppellantCase = (data) => {
 				: null,
 			reference: hasEnforcementData ? appellantCase?.enforcementReference : null,
 			interestInLand: appellantCase?.interestInLand ?? null,
+			writtenOrVerbalPermission: hasEnforcementData
+				? appellantCase?.writtenOrVerbalPermission
+				: null,
 			descriptionOfAllegedBreach: hasEnforcementData
 				? appellantCase?.descriptionOfAllegedBreach
 				: null,

--- a/appeals/api/src/server/mappers/integration/enforcement-listed/map-appellant-case.js
+++ b/appeals/api/src/server/mappers/integration/enforcement-listed/map-appellant-case.js
@@ -7,6 +7,21 @@ import { mapAppellantCaseSharedFields } from '#mappers/integration/shared/s20s78
 import { capitalize } from 'lodash-es';
 
 /**
+ * @param {string | null | undefined} writtenOrVerbalPermission
+ * @returns {boolean | null}`
+ */
+const mapToBool = (writtenOrVerbalPermission) => {
+	switch (writtenOrVerbalPermission) {
+		case 'yes':
+			return true;
+		case 'no':
+			return false;
+		default:
+			return null;
+	}
+};
+
+/**
  *
  * @param {AppealGround} appealGround
  * @returns {any}
@@ -26,6 +41,7 @@ export const mapAppellantCase = (data) => {
 	const { appellantCase, appealGrounds } = data.appeal || {};
 	const {
 		interestInLand,
+		writtenOrVerbalPermission,
 		enforcementEffectiveDate,
 		enforcementIssueDate,
 		enforcementReference,
@@ -39,6 +55,7 @@ export const mapAppellantCase = (data) => {
 	return {
 		...mapAppellantCaseSharedFields(data),
 		ownerOccupancyStatus: interestInLand ? capitalize(interestInLand) : null,
+		occupancyConditionsMet: mapToBool(writtenOrVerbalPermission),
 		applicationElbAppealGroundsDetails: appealGrounds?.length
 			? appealGrounds.filter(({ isDeleted }) => !isDeleted).map(mapAppealGround)
 			: null,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-listed.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-listed.mapper.js
@@ -26,22 +26,6 @@ export function generateEnforcementListedComponents(
 		userHasUpdateCasePermission
 	);
 
-	const landComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' && component.parameters.attributes?.id === 'site-details'
-	);
-
-	if (landComponentIndex !== -1) {
-		const rows = pageComponents[landComponentIndex].parameters.rows;
-		const rowIndex = rows.findIndex(
-			(/** @type {{ key: { text: string; }; }} */ row) =>
-				row?.key?.text === 'Do you have written or verbal permission to use the land?'
-		);
-		if (rowIndex !== -1) {
-			rows.splice(rowIndex, 1);
-		}
-	}
-
 	const groundsAndFactsComponentIndex = pageComponents.findIndex(
 		(component) =>
 			component.type === 'summary-list' &&

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/__tests__/enforcement.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/__tests__/enforcement.test.js
@@ -6,7 +6,6 @@ import { submaps as s78Submaps } from '../s78.js';
 describe('Enforcement vs Enforcement Listed Building (ELB) Submap Architecture', () => {
 	const enforcementSpecificKeys = [
 		'otherAppellants',
-		'writtenOrVerbalPermission',
 		'retrospectiveApplication',
 		'groundAFeeReceipt',
 		'applicationDevelopmentAllOrPart',
@@ -16,6 +15,7 @@ describe('Enforcement vs Enforcement Listed Building (ELB) Submap Architecture',
 	const commonKeys = [
 		'contactAddress',
 		'interestInLand',
+		'writtenOrVerbalPermission',
 		'enforcementNotice',
 		'descriptionOfAllegedBreach'
 	];

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/enforcement-listed.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/enforcement-listed.js
@@ -1,3 +1,4 @@
+import { mapWrittenOrVerbalPermission } from '#lib/mappers/data/appellant-case/submappers/written-or-verbal-permission.js';
 import { submaps as s78Submaps } from './s78.js';
 import { mapContactAddress } from './submappers/contact-address.js';
 import { mapContactPlanningInspectorateDate } from './submappers/contact-planning-inspectorate-date.js';
@@ -26,6 +27,7 @@ export const submaps = {
 	enforcementReference: mapEnforcementReference,
 	contactAddress: mapContactAddress,
 	interestInLand: mapInterestInLand,
+	writtenOrVerbalPermission: mapWrittenOrVerbalPermission,
 	descriptionOfAllegedBreach: mapDescriptionOfAllegedBreach,
 	groundsForAppeal: mapGroundsForAppeal,
 	factsForGrounds: mapFactsForGrounds,

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/enforcement-notice.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/enforcement-notice.js
@@ -4,13 +4,11 @@ import { mapGroundAFeeReceipt } from '#lib/mappers/data/appellant-case/submapper
 import { submaps as enforcementListedSubmaps } from './enforcement-listed.js';
 import { mapOtherAppellants } from './submappers/other-appellants.js';
 import { mapRetrospectiveApplication } from './submappers/retrospective-application.js';
-import { mapWrittenOrVerbalPermission } from './submappers/written-or-verbal-permission.js';
 
 /** @type {Record<string, import('./mapper.js').SubMapper | import('./mapper.js').SubMapperList>} */
 export const submaps = {
 	...enforcementListedSubmaps,
 	otherAppellants: mapOtherAppellants,
-	writtenOrVerbalPermission: mapWrittenOrVerbalPermission,
 	retrospectiveApplication: mapRetrospectiveApplication,
 	groundAFeeReceipt: mapGroundAFeeReceipt,
 	applicationDevelopmentAllOrPart: mapApplicationDevelopmentAllOrPart,


### PR DESCRIPTION
## Describe your changes

This PR makes ELB appeals consistently include and display the “written or verbal permission” field, instead of treating it as enforcement-only in some places. It also updates the integration mapping so that value is passed through in the expected format.
- Adds writtenOrVerbalPermission to the ELB API/appellant-case mapping
- Converts that field to a boolean/null occupancyConditionsMet value in the integration mapper
- Moves the field into shared/common appellant-case submapping so ELB and enforcement notice flows handle it consistently
- Removes web-page logic that was explicitly deleting the permission row from ELB appeal details
- Updates test mapping expectations to reflect the field now being common/shared
- Tweaks seed test data to include enforcement notice data needed for this scenario as it was causing the question to not show for seeded Enf cases

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8340)
