### PR TITLE
feat(api): add state transitions for expedited appeals (A2-8101)

### DIFF
--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -25,6 +25,7 @@ import {
 import {
 	APPEAL_ALLOCATION_LEVEL,
 	APPEAL_APPELLANT_PROCEDURE_PREFERENCE,
+	APPEAL_CASE_PROCEDURE,
 	APPEAL_CASE_STATUS,
 	APPEAL_CASE_TYPE
 } from '@planning-inspectorate/data-model';
@@ -607,6 +608,47 @@ const newS78Appeals = [
 		assignCaseOfficer: true,
 		agent: false,
 		procedureType: APPEAL_APPELLANT_PROCEDURE_PREFERENCE.INQUIRY
+	}),
+	// S78 Expedited (Part 1) Seed Appeals for manual testing
+	appealFactory({
+		typeShorthand: APPEAL_CASE_TYPE.W,
+		procedureType: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+		status: { status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, createdAt: getPastDate({ weeks: 1 }) },
+		lpaQuestionnaire: true,
+		startedAt: getPastDate({ weeks: 1 }),
+		validAt: getPastDate({ weeks: 1 }),
+		assignCaseOfficer: true,
+		agent: false
+	}),
+	appealFactory({
+		typeShorthand: APPEAL_CASE_TYPE.W,
+		procedureType: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+		status: { status: APPEAL_CASE_STATUS.EVENT, createdAt: getPastDate({ weeks: 1 }) },
+		lpaQuestionnaire: true,
+		startedAt: getPastDate({ weeks: 1 }),
+		validAt: getPastDate({ weeks: 1 }),
+		assignCaseOfficer: true,
+		agent: false
+	}),
+	appealFactory({
+		typeShorthand: APPEAL_CASE_TYPE.W,
+		procedureType: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+		status: { status: APPEAL_CASE_STATUS.AWAITING_EVENT, createdAt: getPastDate({ weeks: 1 }) },
+		lpaQuestionnaire: true,
+		startedAt: getPastDate({ weeks: 1 }),
+		validAt: getPastDate({ weeks: 1 }),
+		assignCaseOfficer: true,
+		agent: false
+	}),
+	appealFactory({
+		typeShorthand: APPEAL_CASE_TYPE.W,
+		procedureType: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+		status: { status: APPEAL_CASE_STATUS.AWAITING_EVENT, createdAt: getPastDate({ weeks: 1 }) },
+		lpaQuestionnaire: true,
+		startedAt: getPastDate({ weeks: 1 }),
+		validAt: getPastDate({ weeks: 1 }),
+		assignCaseOfficer: true,
+		agent: false
 	})
 ];
 
@@ -1429,6 +1471,42 @@ export async function seedTestData(databaseConnector) {
 		const appealType =
 			appealTypes.filter(({ id }) => id === appealTypeId)[0].key || APPEAL_CASE_TYPE.D;
 
+		const currentStatusRec = appealStatus.find((s) => s.appealId === id && s.valid);
+
+		if (currentStatusRec) {
+			const pastStatuses = [];
+			const cur = currentStatusRec.status;
+
+			if (
+				cur !== APPEAL_CASE_STATUS.VALIDATION &&
+				cur !== APPEAL_CASE_STATUS.READY_TO_START &&
+				cur !== APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER
+			) {
+				pastStatuses.push(APPEAL_CASE_STATUS.VALIDATION, APPEAL_CASE_STATUS.READY_TO_START);
+			}
+			if (
+				[
+					APPEAL_CASE_STATUS.EVENT,
+					APPEAL_CASE_STATUS.AWAITING_EVENT,
+					APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+					APPEAL_CASE_STATUS.COMPLETE
+					//@ts-ignore
+				].includes(cur)
+			) {
+				pastStatuses.push(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE);
+			}
+
+			if (pastStatuses.length > 0) {
+				await databaseConnector.appealStatus.createMany({
+					data: pastStatuses.map((status) => ({
+						appealId: id,
+						status,
+						valid: false
+					}))
+				});
+			}
+		}
+
 		if (caseStartedDate) {
 			const appealTimetable = await calculateTimetable(appealType, caseStartedDate);
 
@@ -1485,6 +1563,11 @@ export async function seedTestData(databaseConnector) {
 				[APPEAL_CASE_STATUS.ISSUE_DETERMINATION, APPEAL_CASE_STATUS.COMPLETE].includes(status)
 		);
 
+		const awaitingEventStatus = appealStatus.find(
+			({ appealId, status, valid }) =>
+				appealId === id && valid && status === APPEAL_CASE_STATUS.AWAITING_EVENT
+		);
+
 		const today = new Date();
 
 		if (statusWithSiteVisitSet) {
@@ -1497,6 +1580,31 @@ export async function seedTestData(databaseConnector) {
 					siteVisitTypeId: siteVisitType[pickRandom(siteVisitType)].id
 				}
 			});
+		} else if (awaitingEventStatus) {
+			const dbAppeal = await databaseConnector.appeal.findUnique({
+				where: { id },
+				include: { procedureType: true }
+			});
+
+			if (dbAppeal && dbAppeal.procedureType?.key === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1) {
+				const isPast = id % 2 === 0;
+				const targetDate = new Date();
+				if (isPast) {
+					targetDate.setDate(targetDate.getDate() - 2);
+				} else {
+					targetDate.setDate(targetDate.getDate() + 2);
+				}
+
+				await databaseConnector.siteVisit.create({
+					data: {
+						appealId: id,
+						visitDate: targetDate,
+						visitEndTime: `${targetDate.toISOString().split('T')[0]}T16:00:00.000Z`,
+						visitStartTime: `${targetDate.toISOString().split('T')[0]}T14:00:00.000Z`,
+						siteVisitTypeId: siteVisitType[pickRandom(siteVisitType)].id
+					}
+				});
+			}
 		}
 	}
 

--- a/appeals/api/src/server/state/__tests__/state-machine.test.js
+++ b/appeals/api/src/server/state/__tests__/state-machine.test.js
@@ -740,4 +740,91 @@ describe('State Machine Transitions', () => {
 			).toBe(APPEAL_CASE_STATUS.TRANSFERRED);
 		});
 	});
+
+	describe('Expedited (WR Part 1) transitions', () => {
+		/**
+		 * @param {string} initial
+		 * @param {string} event
+		 * @param {boolean} [siteVisitElapsed]
+		 * @return {import('xstate').StateValue}
+		 */
+		const nextStateExpedited = (initial, event, siteVisitElapsed = false) => {
+			const machine = createStateMachine(
+				APPEAL_CASE_TYPE.W,
+				APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+				initial,
+				siteVisitElapsed
+			);
+			const service = interpret(machine).start();
+
+			service.send(event);
+			return service.state.value;
+		};
+
+		test('transitions from LPA_QUESTIONNAIRE to EVENT on VALIDATION_OUTCOME_COMPLETE', () => {
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, VALIDATION_OUTCOME_COMPLETE)
+			).toBe(APPEAL_CASE_STATUS.EVENT);
+		});
+
+		test('transitions from LPA_QUESTIONNAIRE to closed and withdrawn states', () => {
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, APPEAL_CASE_STATUS.CLOSED)
+			).toBe(APPEAL_CASE_STATUS.CLOSED);
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, APPEAL_CASE_STATUS.WITHDRAWN)
+			).toBe(APPEAL_CASE_STATUS.WITHDRAWN);
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, VALIDATION_OUTCOME_INVALID)
+			).toBe(APPEAL_CASE_STATUS.INVALID);
+		});
+
+		test('transitions from AWAITING_EVENT to EVENT on VALIDATION_OUTCOME_CANCEL', () => {
+			expect(nextStateExpedited(APPEAL_CASE_STATUS.AWAITING_EVENT, VALIDATION_OUTCOME_CANCEL)).toBe(
+				APPEAL_CASE_STATUS.EVENT
+			);
+		});
+
+		test('transitions from AWAITING_EVENT to closed and withdrawn states', () => {
+			expect(nextStateExpedited(APPEAL_CASE_STATUS.AWAITING_EVENT, APPEAL_CASE_STATUS.CLOSED)).toBe(
+				APPEAL_CASE_STATUS.CLOSED
+			);
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.AWAITING_EVENT, APPEAL_CASE_STATUS.WITHDRAWN)
+			).toBe(APPEAL_CASE_STATUS.WITHDRAWN);
+		});
+
+		test('validates and maps procedure types using isAppealTypeAndProcedureTypeValid guard', () => {
+			expect(nextStateExpedited(APPEAL_CASE_STATUS.STATEMENTS, VALIDATION_OUTCOME_COMPLETE)).toBe(
+				APPEAL_CASE_STATUS.FINAL_COMMENTS
+			);
+		});
+	});
+
+	describe('Expedited (WR Part 2) transitions', () => {
+		/**
+		 * @param {string} initial
+		 * @param {string} event
+		 * @param {boolean} [siteVisitElapsed]
+		 * @return {import('xstate').StateValue}
+		 */
+		const nextStateExpeditedPart2 = (initial, event, siteVisitElapsed = false) => {
+			const machine = createStateMachine(
+				APPEAL_CASE_TYPE.W,
+				APPEAL_CASE_PROCEDURE.WRITTEN_PART_2,
+				initial,
+				siteVisitElapsed
+			);
+			const service = interpret(machine).start();
+
+			service.send(event);
+			return service.state.value;
+		};
+
+		test('validates and maps procedure types using isAppealTypeAndProcedureTypeValid guard', () => {
+			expect(
+				nextStateExpeditedPart2(APPEAL_CASE_STATUS.STATEMENTS, VALIDATION_OUTCOME_COMPLETE)
+			).toBe(APPEAL_CASE_STATUS.FINAL_COMMENTS);
+		});
+	});
 });

--- a/appeals/api/src/server/state/create-state-machine.js
+++ b/appeals/api/src/server/state/create-state-machine.js
@@ -16,6 +16,7 @@ import { createMachine } from 'xstate';
 /**
  * @typedef {import('@planning-inspectorate/data-model').APPEAL_CASE_TYPE} AppealType
  * @typedef {import('@planning-inspectorate/data-model').APPEAL_CASE_PROCEDURE} ProcedureType
+ * @typedef {import('@planning-inspectorate/data-model').APPEAL_CASE_STATUS} CaseStatus
  * @typedef {object} AdditionalCheckObject
  * */
 
@@ -25,8 +26,14 @@ import { createMachine } from 'xstate';
  * @param {string} currentState
  * @param {boolean} [eventElapsed]
  */
-const createStateMachine = (appealType, procedureType, currentState, eventElapsed = false) =>
-	createMachine({
+const createStateMachine = (appealType, procedureType, currentState, eventElapsed = false) => {
+	const normalizedProcedureType =
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_2
+			? APPEAL_CASE_PROCEDURE.WRITTEN
+			: procedureType;
+
+	return createMachine({
 		id: 'appeals-state-machine',
 		initial: currentState || APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
 		context: {
@@ -104,8 +111,7 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 			[APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE]: {
 				on: {
 					[VALIDATION_OUTCOME_COMPLETE]: {
-						//@ts-ignore
-						target: targetStateOnLpaqComplete[appealType]
+						target: targetStateOnLpaqComplete(appealType, procedureType)
 					},
 					[VALIDATION_OUTCOME_INCOMPLETE]: undefined,
 					[APPEAL_CASE_STATUS.CLOSED]: { target: APPEAL_CASE_STATUS.CLOSED },
@@ -131,7 +137,7 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 					//@ts-ignore
 					[VALIDATION_OUTCOME_COMPLETE]: {
 						//@ts-ignore
-						target: targetStateOnStatementsComplete[procedureType],
+						target: targetStateOnStatementsComplete[normalizedProcedureType],
 						cond: isAppealTypeAndProcedureTypeValid
 					},
 					[APPEAL_CASE_STATUS.CLOSED]: {
@@ -364,6 +370,7 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 			}
 		}
 	});
+};
 
 /**
  * @typedef {{ appealType: string, procedureType: string, eventElapsed: boolean }} Ctx
@@ -381,9 +388,16 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 const isAppealTypeAndProcedureTypeValid = (ctx, _evt, { state }) => {
 	const meta = state.meta[`appeals-state-machine.${state.value}`];
 	const appealType = ctx.appealType;
-	const procedureType = ctx.procedureType;
+	let procedureType = ctx.procedureType;
 
 	if (!appealType || !procedureType || !meta) return false;
+
+	if (
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_2
+	) {
+		procedureType = APPEAL_CASE_PROCEDURE.WRITTEN;
+	}
 
 	return (
 		meta.validAppealTypes.includes(appealType) && meta.validProcedureTypes.includes(procedureType)
@@ -420,12 +434,25 @@ const targetStateOnStatementsComplete = {
 const targetStateOnEventCancelled = {
 	[APPEAL_CASE_PROCEDURE.HEARING]: APPEAL_CASE_STATUS.EVENT,
 	[APPEAL_CASE_PROCEDURE.INQUIRY]: APPEAL_CASE_STATUS.EVENT,
-	[APPEAL_CASE_PROCEDURE.WRITTEN]: APPEAL_CASE_STATUS.FINAL_COMMENTS
+	[APPEAL_CASE_PROCEDURE.WRITTEN]: APPEAL_CASE_STATUS.FINAL_COMMENTS,
+	[APPEAL_CASE_PROCEDURE.WRITTEN_PART_1]: APPEAL_CASE_STATUS.EVENT,
+	[APPEAL_CASE_PROCEDURE.WRITTEN_PART_2]: APPEAL_CASE_STATUS.EVENT
 };
 
-const targetStateOnLpaqComplete = {
-	[APPEAL_CASE_TYPE.W]: APPEAL_CASE_STATUS.STATEMENTS,
-	[APPEAL_CASE_TYPE.D]: APPEAL_CASE_STATUS.EVENT
+/**
+ * Determins the next state after the LPAQ is complete based on the appeal type and procedure type.
+ * @param {AppealType} appealType
+ * @param {ProcedureType} procedureType
+ * @returns {CaseStatus}
+ */
+const targetStateOnLpaqComplete = (appealType, procedureType) => {
+	if (appealType === APPEAL_CASE_TYPE.D || procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1) {
+		return APPEAL_CASE_STATUS.EVENT;
+	}
+	if (appealType === APPEAL_CASE_TYPE.W) {
+		return APPEAL_CASE_STATUS.STATEMENTS;
+	}
+	return APPEAL_CASE_STATUS.STATEMENTS;
 };
 
 export default createStateMachine;


### PR DESCRIPTION
## Describe your changes
### Changes:
Added new seed data for expedited appeals, to test state transitions
Added transition logic for expedited appeals on lpaq complete, and normalised the procedure type for other transitions.

### Testing:
Added testing for transitions

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8101)
