### PR TITLE
fix(appeals): updating elb with planning-permission-granted to displa…

### DIFF
--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -256,6 +256,14 @@ describe('decision routes', () => {
 				'invalid'
 			],
 			[
+				'enforcementNoticeAppeal',
+				'planning_permission_granted',
+				'Because it is.',
+				enforcementNoticeAppeal,
+				FEEDBACK_FORM_LINKS.ENFORCEMENT_NOTICE,
+				'Enforcement notice'
+			],
+			[
 				'ldcAppeal',
 				'allowed',
 				'',
@@ -306,6 +314,16 @@ describe('decision routes', () => {
 				FEEDBACK_FORM_LINKS.ENFORCEMENT_LISTED_BUILDING,
 				'Enforcement listed building and conservation area',
 				'invalid'
+			],
+			[
+				'appealEnforcementListed',
+				'planning_permission_granted',
+				'Because it is.',
+				appealEnforcementListed,
+				FEEDBACK_FORM_LINKS.ENFORCEMENT_LISTED_BUILDING,
+				'Enforcement listed building and conservation area',
+				'complete',
+				'Listed building consent granted'
 			]
 		])(
 			'returns 200 when all good, appeal type: %s, outcome: %s, reason: %s',
@@ -316,7 +334,8 @@ describe('decision routes', () => {
 				appeal,
 				expectedFeedbackLink,
 				formattedAppealType,
-				nextState = 'complete'
+				nextState = 'complete',
+				overwriteExpectedOutcomeDisplayString = undefined
 			) => {
 				const correctAppealState = {
 					...appeal,
@@ -421,8 +440,12 @@ describe('decision routes', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(4);
 
+				const expectedOutcomeDisplayString = overwriteExpectedOutcomeDisplayString
+					? overwriteExpectedOutcomeDisplayString
+					: capitalize(outcome.replaceAll('_', ' '));
+
 				let details = stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [
-					capitalize(outcome.replaceAll('_', ' '))
+					expectedOutcomeDisplayString
 				]);
 
 				if (invalidReason) {

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -27,6 +27,7 @@ import {
 	ERROR_NO_RECIPIENT_EMAIL
 } from '@pins/appeals/constants/support.js';
 import formatDate from '@pins/appeals/utils/date-formatter.js';
+import { decisionOutcomeToDisplayText } from '@pins/appeals/utils/decision-outcome-display-text.js';
 import { loadEnvironment } from '@pins/platform';
 import {
 	APPEAL_CASE_DECISION_OUTCOME,
@@ -35,7 +36,6 @@ import {
 	APPEAL_CASE_TYPE,
 	APPEAL_DOCUMENT_TYPE
 } from '@planning-inspectorate/data-model';
-import { capitalize } from 'lodash-es';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.InspectorDecision} Decision */
@@ -59,11 +59,12 @@ const hasCostsDocument = (appeal, appealDocumentType) => {
 /**
  *
  * @param {string} outcome
+ * @param {string | undefined} appealType
  * @param {string|null} [invalidDecisionReason]
  * @returns {string}
  */
-const formatIssueDecisionAuditTrail = (outcome, invalidDecisionReason) => {
-	const outcomeFormatted = capitalize(outcome.replaceAll('_', ' '));
+const formatIssueDecisionAuditTrail = (outcome, appealType, invalidDecisionReason) => {
+	const outcomeFormatted = decisionOutcomeToDisplayText(outcome, appealType);
 	return stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [
 		`${outcomeFormatted}${
 			invalidDecisionReason && isFeatureActive(FEATURE_FLAG_NAMES.INVALID_DECISION_LETTER)
@@ -298,7 +299,7 @@ export const publishDecision = async (
 	await createAuditTrail({
 		appealId: appeal.id,
 		azureAdUserId: azureAdUserId,
-		details: formatIssueDecisionAuditTrail(outcome, invalidDecisionReason)
+		details: formatIssueDecisionAuditTrail(outcome, type, invalidDecisionReason)
 	});
 
 	await transitionState(appeal.id, azureAdUserId, nextState);
@@ -337,7 +338,7 @@ export const publishChildDecision = async (
 		await createAuditTrail({
 			appealId,
 			azureAdUserId: azureAdUserId,
-			details: formatIssueDecisionAuditTrail(outcome)
+			details: formatIssueDecisionAuditTrail(outcome, childAppeal.appealType?.type)
 		});
 
 		await transitionState(appealId, azureAdUserId, APPEAL_CASE_STATUS.COMPLETE);

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -38,7 +38,11 @@ import {
 	PROCEDURE_TYPE_NAME
 } from '@pins/appeals/constants/common.js';
 import { parseHtml } from '@pins/platform';
-import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import {
+	APPEAL_CASE_DECISION_OUTCOME,
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_STATUS
+} from '@planning-inspectorate/data-model';
 import { addDays } from 'date-fns';
 import { omit } from 'lodash-es';
 import nock from 'nock';
@@ -2810,6 +2814,64 @@ describe('appeal-details', () => {
 			);
 		});
 
+		it('should render "Listed building consent granted" in the Decision inset panel for ELB appeals', async () => {
+			const appealId = '2';
+
+			nock('http://test/')
+				.get(`/appeals/${appealId}?include=all`)
+				.reply(200, {
+					...appealData,
+					appealType: APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING,
+					decision: {
+						outcome: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED,
+						letterDate: '2026-01-01T00:00:00.000Z',
+						documentId: 'e1e90a49-fab3-44b8-a21a-bb73af089f6b'
+					},
+					appealStatus: 'complete',
+					completedStateList: ['awaiting_event']
+				});
+			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+			nock('http://test/')
+				.get('/appeals/documents/e1e90a49-fab3-44b8-a21a-bb73af089f6b/versions')
+				.reply(200, documentFileVersionInfo);
+			const response = await request.get(`${baseUrl}/${appealId}`);
+
+			const insetTextElementHTML = parseHtml(response.text, {
+				skipPrettyPrint: true,
+				rootElement: '.govuk-inset-text'
+			}).innerHTML;
+			expect(insetTextElementHTML).toContain('<li>Decision: Listed building consent granted</li>');
+		});
+
+		it('should render "Planning permission granted" in the Decision inset panel for enforcement notice appeals', async () => {
+			const appealId = '2';
+
+			nock('http://test/')
+				.get(`/appeals/${appealId}?include=all`)
+				.reply(200, {
+					...appealData,
+					appealType: APPEAL_TYPE.ENFORCEMENT_NOTICE,
+					decision: {
+						outcome: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED,
+						letterDate: '2026-01-01T00:00:00.000Z',
+						documentId: 'e1e90a49-fab3-44b8-a21a-bb73af089f6b'
+					},
+					appealStatus: 'complete',
+					completedStateList: ['awaiting_event']
+				});
+			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+			nock('http://test/')
+				.get('/appeals/documents/e1e90a49-fab3-44b8-a21a-bb73af089f6b/versions')
+				.reply(200, documentFileVersionInfo);
+			const response = await request.get(`${baseUrl}/${appealId}`);
+
+			const insetTextElementHTML = parseHtml(response.text, {
+				skipPrettyPrint: true,
+				rootElement: '.govuk-inset-text'
+			}).innerHTML;
+			expect(insetTextElementHTML).toContain('<li>Decision: Planning permission granted</li>');
+		});
+
 		it('should render the view decision page', async () => {
 			const appealId = '2';
 
@@ -2835,6 +2897,58 @@ describe('appeal-details', () => {
 			expect(innerHTML).toContain(
 				'download href="/documents/1/download/e1e90a49-fab3-44b8-a21a-bb73af089f6b/decision-letter.pdf'
 			);
+		});
+
+		it('should render "Listed building consent granted" on the view decision page for ELB appeals', async () => {
+			const appealId = '2';
+
+			nock('http://test/')
+				.get(`/appeals/${appealId}?include=all`)
+				.reply(200, {
+					...appealData,
+					appealType: APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING,
+					decision: {
+						outcome: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED,
+						letterDate: '2026-01-01T00:00:00.000Z',
+						documentId: 'e1e90a49-fab3-44b8-a21a-bb73af089f6b'
+					},
+					appealStatus: 'complete',
+					completedStateList: ['awaiting_event']
+				});
+			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+			nock('http://test/')
+				.get('/appeals/documents/e1e90a49-fab3-44b8-a21a-bb73af089f6b/versions')
+				.reply(200, documentFileVersionInfo);
+			const response = await request.get(`${baseUrl}/${appealId}/issue-decision/view-decision`);
+
+			const innerHTML = parseHtml(response.text).innerHTML;
+			expect(innerHTML).toContain('Listed building consent granted');
+		});
+
+		it('should render "Planning permission granted" on the view decision page for enforcement notice appeals', async () => {
+			const appealId = '2';
+
+			nock('http://test/')
+				.get(`/appeals/${appealId}?include=all`)
+				.reply(200, {
+					...appealData,
+					appealType: APPEAL_TYPE.ENFORCEMENT_NOTICE,
+					decision: {
+						outcome: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED,
+						letterDate: '2026-01-01T00:00:00.000Z',
+						documentId: 'e1e90a49-fab3-44b8-a21a-bb73af089f6b'
+					},
+					appealStatus: 'complete',
+					completedStateList: ['awaiting_event']
+				});
+			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+			nock('http://test/')
+				.get('/appeals/documents/e1e90a49-fab3-44b8-a21a-bb73af089f6b/versions')
+				.reply(200, documentFileVersionInfo);
+			const response = await request.get(`${baseUrl}/${appealId}/issue-decision/view-decision`);
+
+			const innerHTML = parseHtml(response.text).innerHTML;
+			expect(innerHTML).toContain('Planning permission granted');
 		});
 
 		it('should render a Decision inset panel when the appealStatus is complete and only one version exists', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -250,7 +250,7 @@ exports[`issue-decision GET /decision Linked appeals Linked child appeal should 
                     <form method="POST" novalidate="novalidate">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">Roger Simmons</dd>
+                                <dd class="govuk-summary-list__value">Fred Simmons</dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
                                 <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
@@ -751,7 +751,7 @@ exports[`issue-decision GET /issue-decision/check-your-decision Linked appeals s
 </main>"
 `;
 
-exports[`issue-decision GET /issue-decision/check-your-decision Single appeal should render the check your decision page 1`] = `
+exports[`issue-decision GET /issue-decision/check-your-decision Single appeal - HAS should render the check your decision page with correct text 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -763,7 +763,98 @@ exports[`issue-decision GET /issue-decision/check-your-decision Single appeal sh
             <form method="POST" novalidate="novalidate">
                 <dl class="govuk-summary-list">
                     <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision</dt>
-                        <dd class="govuk-summary-list__value">Allowed</dd>
+                        <dd class="govuk-summary-list__value">Planning permission granted</dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> decision</span></a>
+                        </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
+                        <dd class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/test-document.pdf"
+                            target="_blank">test-document.pdf</a>
+                        </dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> decision letter</span></a>
+                        </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you want to issue the appellant&#39;s costs decision?</dt>
+                        <dd                         class="govuk-summary-list__value">Yes</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/appellant-costs-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> appellant cost decision</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant costs decision letter</dt>
+                        <dd                         class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/2/test-document-appellant.pdf"
+                            target="_blank">test-document-appellant.pdf</a>
+                            </dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/appellant-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> appellant cost decision letter</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you want to issue the LPA&#39;s costs decision?</dt>
+                        <dd                         class="govuk-summary-list__value">Yes</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/lpa-costs-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> lpa cost decision</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA costs decision letter</dt>
+                        <dd                         class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/3/test-document-lpa.pdf"
+                            target="_blank">test-document-lpa.pdf</a>
+                            </dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/lpa-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> lpa costs decision letter</span></a>
+                            </dd>
+                    </div>
+                </dl>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-appellant">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to appellant</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Appellant email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-lpa">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to LPA</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>LPA email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-interested-parties">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to interested parties</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Interested party email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <p class="govuk-body">We'll send an email to the appellant, LPA and any interested parties to
+                    tell them about the decision.</p>
+                <button type="submit" class="govuk-button"
+                data-module="govuk-button">Issue decision</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`issue-decision GET /issue-decision/check-your-decision Single appeal - enforcement listed building should render the check your decision page with correct text 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and issue decision</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST" novalidate="novalidate">
+                <dl class="govuk-summary-list">
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision</dt>
+                        <dd class="govuk-summary-list__value">Listed building consent granted</dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> decision</span></a>
                         </dd>
                     </div>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
@@ -13,6 +13,7 @@ import { createTestEnvironment } from '#testing/index.js';
 import { parseHtml } from '@pins/platform';
 
 import { jest } from '@jest/globals';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_DECISION_OUTCOME } from '@planning-inspectorate/data-model';
 import nock from 'nock';
 import supertest from 'supertest';
@@ -194,7 +195,18 @@ describe('issue-decision', () => {
 				linkedAppealData = structuredClone(appealData);
 				linkedAppealData.appealId = 3;
 				linkedAppealData.isParentAppeal = true;
-				linkedAppealData.linkedAppeals = [{ appealId: 4, appealReference: '351066' }];
+				linkedAppealData.linkedAppeals = [
+					{
+						appealId: 4,
+						appealReference: '351066',
+						appellant: {
+							serviceUserId: 20,
+							firstName: 'Fred',
+							lastName: 'Simmons',
+							email: 'test20@example.com'
+						}
+					}
+				];
 				nock('http://test/').get('/appeals/3?include=all').reply(200, linkedAppealData).persist();
 			});
 
@@ -212,6 +224,8 @@ describe('issue-decision', () => {
 					);
 
 					expect(unprettifiedElement.innerHTML).toContain('Decision for lead appeal 351062</h1>');
+					expect(unprettifiedElement.innerHTML).toContain('Roger');
+					expect(unprettifiedElement.innerHTML).not.toContain('Fred');
 					expect(unprettifiedElement.innerHTML).toContain(
 						'<input class="govuk-radios__input" id="decision" name="decision" type="radio" value="allowed">'
 					);
@@ -242,6 +256,8 @@ describe('issue-decision', () => {
 					);
 
 					expect(unprettifiedElement.innerHTML).toContain('Decision for child appeal 351066</h1>');
+					expect(unprettifiedElement.innerHTML).toContain('Fred');
+					expect(unprettifiedElement.innerHTML).not.toContain('Roger');
 					expect(unprettifiedElement.innerHTML).toContain(
 						'<input class="govuk-radios__input" id="decision" name="decision" type="radio" value="allowed">'
 					);
@@ -885,7 +901,7 @@ describe('issue-decision', () => {
 
 		afterEach(teardown);
 
-		describe('Single appeal', () => {
+		describe('Single appeal - HAS', () => {
 			beforeEach(async () => {
 				nock('http://test/')
 					.get('/appeals/1?include=all')
@@ -900,7 +916,7 @@ describe('issue-decision', () => {
 
 				issueDecisionResponse = await request
 					.post(`${baseUrl}/1/issue-decision/decision`)
-					.send({ decision: APPEAL_CASE_DECISION_OUTCOME.ALLOWED });
+					.send({ decision: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED });
 
 				uploadDecisionLetterResponse = await request
 					.post(`${baseUrl}/1${issueDecisionPath}${decisionLetterUploadPath}`)
@@ -932,7 +948,7 @@ describe('issue-decision', () => {
 					});
 			});
 
-			it('should render the check your decision page', async () => {
+			it('should render the check your decision page with correct text', async () => {
 				expect(issueDecisionResponse.statusCode).toBe(302);
 				expect(uploadDecisionLetterResponse.statusCode).toBe(302);
 				expect(issueAppellantCostsDecisionResponse.statusCode).toBe(302);
@@ -954,7 +970,104 @@ describe('issue-decision', () => {
 				expect(unprettifiedElement.innerHTML).toContain('Check details and issue decision</h1>');
 
 				expect(unprettifiedElement.innerHTML).toContain('Decision</dt>');
-				expect(unprettifiedElement.innerHTML).toContain('Allowed</dd>');
+				expect(unprettifiedElement.innerHTML).toContain('Planning permission granted</dd>');
+				expect(unprettifiedElement.innerHTML).not.toContain('Listed building consent granted</dd>');
+
+				expect(unprettifiedElement.innerHTML).toContain('Decision letter</dt>');
+				expect(unprettifiedElement.innerHTML).toContain('test-document.pdf</a>');
+
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Do you want to issue the appellant&#39;s costs decision?</dt><dd class="govuk-summary-list__value"> Yes</dd>'
+				);
+
+				expect(unprettifiedElement.innerHTML).toContain('Appellant costs decision letter</dt>');
+				expect(unprettifiedElement.innerHTML).toContain('test-document-appellant.pdf</a>');
+
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Do you want to issue the LPA&#39;s costs decision?</dt><dd class="govuk-summary-list__value"> Yes</dd>'
+				);
+
+				expect(unprettifiedElement.innerHTML).toContain('LPA costs decision letter</dt>');
+				expect(unprettifiedElement.innerHTML).toContain('test-document-lpa.pdf</a>');
+
+				expect(unprettifiedElement.innerHTML).toContain('Issue decision</button>');
+			});
+		});
+
+		describe('Single appeal - enforcement listed building', () => {
+			beforeEach(async () => {
+				nock('http://test/')
+					.get('/appeals/1?include=all')
+					.reply(200, {
+						...issueDecisionAppealData,
+						appealType: APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
+					})
+					.persist();
+				nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
+				nock('http://test/').post(`/appeals/validate-business-date`).reply(200, { result: true });
+				nock('http://test/')
+					.get('/appeals/document-redaction-statuses')
+					.reply(200, documentRedactionStatuses)
+					.persist();
+
+				issueDecisionResponse = await request
+					.post(`${baseUrl}/1/issue-decision/decision`)
+					.send({ decision: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED });
+
+				uploadDecisionLetterResponse = await request
+					.post(`${baseUrl}/1${issueDecisionPath}${decisionLetterUploadPath}`)
+					.send({
+						'upload-info':
+							'[{"name": "test-document.pdf", "GUID": "1", "blobStoreUrl": "/", "mimeType": "pdf", "documentType": "caseDecisionLetter", "size": 1, "stage": "appellant-case"}]'
+					});
+
+				issueAppellantCostsDecisionResponse = await request
+					.post(`${baseUrl}/1/issue-decision/appellant-costs-decision`)
+					.send({ appellantCostsDecision: 'true' });
+
+				uploadAppellantCostsDecisionLetterResponse = await request
+					.post(`${baseUrl}/1${issueDecisionPath}${appellantCostsDecisionLetterUploadPath}`)
+					.send({
+						'upload-info':
+							'[{"name": "test-document-appellant.pdf", "GUID": "2", "blobStoreUrl": "/", "mimeType": "pdf", "documentType": "appellantCostsDecisionLetter", "size": 1, "stage": "appellant-case"}]'
+					});
+
+				issueLpaCostsDecisionResponse = await request
+					.post(`${baseUrl}/1/issue-decision/lpa-costs-decision`)
+					.send({ lpaCostsDecision: 'true' });
+
+				uploadLpaCostsDecisionLetterResponse = await request
+					.post(`${baseUrl}/1${issueDecisionPath}${lpaCostsDecisionLetterUploadPath}`)
+					.send({
+						'upload-info':
+							'[{"name": "test-document-lpa.pdf", "GUID": "3", "blobStoreUrl": "/", "mimeType": "pdf", "documentType": "lpaCostsDecisionLetter", "size": 1, "stage": "appellant-case"}]'
+					});
+			});
+
+			it('should render the check your decision page with correct text', async () => {
+				expect(issueDecisionResponse.statusCode).toBe(302);
+				expect(uploadDecisionLetterResponse.statusCode).toBe(302);
+				expect(issueAppellantCostsDecisionResponse.statusCode).toBe(302);
+				expect(uploadAppellantCostsDecisionLetterResponse.statusCode).toBe(302);
+				expect(issueLpaCostsDecisionResponse.statusCode).toBe(302);
+				expect(uploadLpaCostsDecisionLetterResponse.statusCode).toBe(302);
+
+				const response = await request.get(
+					`${baseUrl}/1${issueDecisionPath}${checkYourDecisionPath}`
+				);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Appeal 351062</span>');
+
+				expect(unprettifiedElement.innerHTML).toContain('Check details and issue decision</h1>');
+
+				expect(unprettifiedElement.innerHTML).toContain('Decision</dt>');
+				expect(unprettifiedElement.innerHTML).toContain('Listed building consent granted</dd>');
+				expect(unprettifiedElement.innerHTML).not.toContain('Planning permission granted</dd>');
 
 				expect(unprettifiedElement.innerHTML).toContain('Decision letter</dt>');
 				expect(unprettifiedElement.innerHTML).toContain('test-document.pdf</a>');

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -107,6 +107,7 @@ export const postIssueDecision = async (request, response) => {
 		} else {
 			session.childDecisions.decisions.push({
 				appealId: childAppeal.appealId,
+				appealType: childAppeal.appealType,
 				outcome: body.decision,
 				appealReference: childAppeal.appealReference
 			});

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -26,7 +26,7 @@ import {
 	DECISION_TYPE_LPA_COSTS,
 	LENGTH_300
 } from '@pins/appeals/constants/support.js';
-import { toSentenceCase } from '@pins/appeals/utils/string-case.js';
+import { decisionOutcomeToDisplayText } from '@pins/appeals/utils/decision-outcome-display-text.js';
 import { APPEAL_CASE_DECISION_OUTCOME } from '@planning-inspectorate/data-model';
 
 /**
@@ -37,14 +37,14 @@ import { APPEAL_CASE_DECISION_OUTCOME } from '@planning-inspectorate/data-model'
  * @typedef {import('./issue-decision.types.js').LpaCostsDecisionRequest} LpaCostsDecisionRequest
  * @typedef {import('#appeals/appeal-documents/appeal-documents.types').FileUploadInfoItem} FileUploadInfoItem
  * @typedef {import('@pins/express/types/express.js').Request & {specificDecisionType?: string}} Request
- * @typedef {import('@pins/appeals.api').Appeals.RelatedAppeal} RelatedAppeal
+ * @typedef {import('@pins/appeals.api').Appeals.LinkedAppeal} LinkedAppeal
  * @typedef {{ key: { text: string; }; value?: { html: string; text?: undefined; } | { text: any; html?: undefined; }; actions: { items: { text: string; href: string; visuallyHiddenText: string; }[]; }; }} PageRow
  */
 
 /**
  *
  * @param {Appeal} appealDetails
- * @param {RelatedAppeal|undefined} childAppealDetails
+ * @param {LinkedAppeal|undefined} childAppealDetails
  * @param {InspectorDecisionRequest} inspectorDecision
  * @param {string|undefined} backUrl
  * @param {import("@pins/express").ValidationErrors} [errors]
@@ -57,7 +57,8 @@ export function issueDecisionPage(
 	backUrl,
 	errors
 ) {
-	const { appellant } = appealDetails;
+	const currentPageAppealDetails = childAppealDetails ? childAppealDetails : appealDetails;
+	const { appellant } = currentPageAppealDetails;
 
 	const appellantName =
 		!appellant?.firstName && !appellant?.lastName && appellant?.organisationName
@@ -69,7 +70,7 @@ export function issueDecisionPage(
 		type: 'summary-list',
 		parameters: {
 			rows: [
-				...(appealDetails.appellant
+				...(appellant
 					? [
 							{
 								key: {
@@ -102,7 +103,7 @@ export function issueDecisionPage(
 						text: 'Appeal type'
 					},
 					value: {
-						text: childAppealDetails ? childAppealDetails.appealType : appealDetails.appealType
+						text: currentPageAppealDetails.appealType
 					}
 				}
 			]
@@ -111,10 +112,7 @@ export function issueDecisionPage(
 
 	const fieldName = 'decision';
 
-	const shortAppealReference = appealShortReference(appealDetails.appealReference);
-	const decisionAppealReference = childAppealDetails
-		? childAppealDetails.appealReference
-		: shortAppealReference;
+	const decisionAppealReference = appealShortReference(currentPageAppealDetails.appealReference);
 	const linkType = childAppealDetails ? 'child' : isParentAppeal(appealDetails) ? 'lead' : '';
 
 	const heading = linkType ? `Decision for ${linkType} appeal ${decisionAppealReference}` : '';
@@ -131,8 +129,8 @@ export function issueDecisionPage(
 	} = APPEAL_CASE_DECISION_OUTCOME;
 
 	const decisionTypes =
-		appealDetails.appealType === APPEAL_TYPE.ENFORCEMENT_NOTICE ||
-		appealDetails.appealType === APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
+		currentPageAppealDetails.appealType === APPEAL_TYPE.ENFORCEMENT_NOTICE ||
+		currentPageAppealDetails.appealType === APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
 			? [
 					NOTICE_UPHELD,
 					NOTICE_VARIED_AND_UPHELD,
@@ -145,14 +143,9 @@ export function issueDecisionPage(
 
 	const items = decisionTypes.map((decisionType) => ({
 		value: decisionType,
-		text: toSentenceCase(decisionType),
+		text: decisionOutcomeToDisplayText(decisionType, currentPageAppealDetails.appealType),
 		checked: inspectorDecision?.outcome === decisionType
 	}));
-
-	if (appealDetails.appealType === APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING) {
-		items.filter((item) => item.value === 'planning_permission_granted')[0].text =
-			'Listed building consent granted';
-	}
 
 	if (
 		!isLinkedAppeal(appealDetails) &&
@@ -210,7 +203,7 @@ export function issueDecisionPage(
 
 	/** @type {PageContent} */
 	const pageContent = {
-		title: heading || `Decision - ${shortAppealReference}`,
+		title: heading || `Decision - ${decisionAppealReference}`,
 		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: preHeadingText(appealDetails, 'issue decision'),
 		heading: heading || 'Decision',
@@ -412,7 +405,10 @@ function checkAndConfirmPageRows(appealData, request) {
 
 	if (inspectorDecision) {
 		if (inspectorDecision.outcome) {
-			let outcomeHtml = toSentenceCase(inspectorDecision.outcome);
+			let outcomeHtml = decisionOutcomeToDisplayText(
+				inspectorDecision.outcome,
+				appealData.appealType
+			);
 			if (!isFeatureActive(FEATURE_FLAG_NAMES.INVALID_DECISION_LETTER)) {
 				let invalidReasonHtml = inspectorDecision.invalidReason ? `Reason: ` : '';
 				if (invalidReasonHtml) {
@@ -452,7 +448,7 @@ function checkAndConfirmPageRows(appealData, request) {
 				childDecisions.decisions.forEach((childDecision) => {
 					rows.push({
 						key: `Decision for child appeal ${childDecision.appealReference}`,
-						html: toSentenceCase(childDecision.outcome),
+						html: decisionOutcomeToDisplayText(childDecision.outcome, childDecision.appealType),
 						actions: [
 							{
 								text: 'Change',
@@ -682,7 +678,7 @@ export function checkAndConfirmPage(appealData, request, emailPreviewComponents 
  * @returns {PageRow}[]
  */
 export function viewDecisionPageRows(appealData, request, latestDecsionDocumentText) {
-	const { appealId, decision, costs } = appealData || {};
+	const { appealId, decision, costs, appealType } = appealData || {};
 	const appellantCostsDecision = costs.appellantDecisionFolder?.documents[0];
 	const lpaCostsDecision = costs.lpaDecisionFolder?.documents[0];
 
@@ -691,7 +687,7 @@ export function viewDecisionPageRows(appealData, request, latestDecsionDocumentT
 	if (decision) {
 		const { outcome, documentId, documentName, letterDate, invalidReason } = decision;
 		// @ts-ignore
-		const decisionOutcome = toSentenceCase(outcome);
+		const decisionOutcome = decisionOutcomeToDisplayText(outcome, appealType);
 		let invalidReasonHtml = invalidReason ? `Reason: ` : '';
 		if (invalidReasonHtml) {
 			invalidReasonHtml = renderPageComponentsToHtml([
@@ -714,9 +710,7 @@ export function viewDecisionPageRows(appealData, request, latestDecsionDocumentT
 							appealData.isParentAppeal ? 'lead' : 'child'
 						} appeal ${appealShortReference(appealData.appealReference)}`
 					: 'Decision',
-				html: `${toSentenceCase(decisionOutcome)}${
-					invalidReasonHtml ? `<br><br>${invalidReasonHtml}` : ''
-				}`
+				html: `${decisionOutcome}${invalidReasonHtml ? `<br><br>${invalidReasonHtml}` : ''}`
 			});
 		}
 		if (appealData.isParentAppeal && appealData.linkedAppeals?.length) {
@@ -726,7 +720,10 @@ export function viewDecisionPageRows(appealData, request, latestDecsionDocumentT
 						key: `Decision for ${linkedAppeal.isParentAppeal ? 'lead' : 'child'} appeal ${
 							linkedAppeal.appealReference
 						}`,
-						html: toSentenceCase(linkedAppeal.inspectorDecision)
+						html: decisionOutcomeToDisplayText(
+							linkedAppeal.inspectorDecision,
+							linkedAppeal.appealType
+						)
 					});
 				}
 			});

--- a/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
@@ -4,7 +4,7 @@ import { dateISOStringToDisplayDate, getOriginalAndLatestLetterDatesObject } fro
 import { isLinkedAppealsActive } from '#lib/mappers/utils/is-linked-appeal.js';
 import { renderPageComponentsToHtml } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
-import { toSentenceCase } from '@pins/appeals/utils/string-case.js';
+import { decisionOutcomeToDisplayText } from '@pins/appeals/utils/decision-outcome-display-text.js';
 import { APPEAL_CASE_STATUS, APPEAL_VIRUS_CHECK_STATUS } from '@planning-inspectorate/data-model';
 import { getAppealTypesFromId } from '../change-appeal-type/change-appeal-type.service.js';
 import { getInvalidStatusCreatedDate } from '../invalid-appeal/invalid-appeal.service.js';
@@ -75,7 +75,9 @@ export const generateStatusTags = async (mappedData, appealDetails, request) => 
 		const insetTextRows = [];
 
 		if (appealDetails.decision?.outcome) {
-			insetTextRows.push(`Decision: ${toSentenceCase(appealDetails.decision.outcome)}`);
+			insetTextRows.push(
+				`Decision: ${decisionOutcomeToDisplayText(appealDetails.decision.outcome, appealDetails.appealType)}`
+			);
 			insetTextRows.push(
 				letterDateObject.latestFileVersion && letterDateObject.latestFileVersion?.version > 1
 					? `Decision issued on ${letterDateObject.originalLetterDate} (updated on ${letterDateObject.latestLetterDate})`

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/decision-mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/decision-mapper.test.js
@@ -1,5 +1,7 @@
 // @ts-nocheck
 import { mapDecision } from '#lib/mappers/data/appeal/submappers/decision.mapper.js';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_DECISION_OUTCOME } from '@planning-inspectorate/data-model';
 
 const expectedViewDecisionRow = (params) => ({
 	id: 'decision',
@@ -25,6 +27,64 @@ const expectedViewDecisionRow = (params) => ({
 			},
 			value: {
 				text: 'Split decision'
+			}
+		}
+	}
+});
+
+const expectedPlanningPermissionGrantedRow = (params) => ({
+	id: 'decision',
+	display: {
+		summaryListItem: {
+			actions: {
+				items: [
+					{
+						attributes: {
+							'data-cy': 'view-decision'
+						},
+						href: `/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=${encodeURIComponent(
+							params.request.originalUrl
+						)}`,
+						text: 'View',
+						visuallyHiddenText: 'Decision'
+					}
+				]
+			},
+			classes: 'appeal-decision',
+			key: {
+				text: 'Decision'
+			},
+			value: {
+				text: 'Planning permission granted'
+			}
+		}
+	}
+});
+
+const expectedListedBuildingConsentGrantedRow = (params) => ({
+	id: 'decision',
+	display: {
+		summaryListItem: {
+			actions: {
+				items: [
+					{
+						attributes: {
+							'data-cy': 'view-decision'
+						},
+						href: `/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=${encodeURIComponent(
+							params.request.originalUrl
+						)}`,
+						text: 'View',
+						visuallyHiddenText: 'Decision'
+					}
+				]
+			},
+			classes: 'appeal-decision',
+			key: {
+				text: 'Decision'
+			},
+			value: {
+				text: 'Listed building consent granted'
 			}
 		}
 	}
@@ -70,6 +130,24 @@ const setCaseOutcome = (params) => {
 	params.appealDetails.decision = { outcome: 'Split decision' };
 };
 
+const setElbCaseOutcome = (params) => {
+	params.appealDetails.appealStatus = 'complete';
+	params.completedStateList = ['awaiting_event', 'issue_determination'];
+	params.appealDetails.appealType = APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING;
+	params.appealDetails.decision = {
+		outcome: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED
+	};
+};
+
+const setEnforcementCaseOutcome = (params) => {
+	params.appealDetails.appealStatus = 'complete';
+	params.completedStateList = ['awaiting_event', 'issue_determination'];
+	params.appealDetails.appealType = APPEAL_TYPE.ENFORCEMENT_NOTICE;
+	params.appealDetails.decision = {
+		outcome: APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED
+	};
+};
+
 describe('decision-mapper', () => {
 	let params;
 
@@ -94,6 +172,16 @@ describe('decision-mapper', () => {
 			setCaseOutcome(params);
 			expect(mapDecision(params)).toEqual(expectedViewDecisionRow(params));
 		});
+
+		it('Should display enforcement decision row with "Planning permission granted" text', () => {
+			setEnforcementCaseOutcome(params);
+			expect(mapDecision(params)).toEqual(expectedPlanningPermissionGrantedRow(params));
+		});
+
+		it('Should display ELB decision row with "Listed building consent granted" text', () => {
+			setElbCaseOutcome(params);
+			expect(mapDecision(params)).toEqual(expectedListedBuildingConsentGrantedRow(params));
+		});
 	});
 
 	describe('for child linked appeal', () => {
@@ -108,6 +196,16 @@ describe('decision-mapper', () => {
 		it('Should display decision row with view decision link', () => {
 			setCaseOutcome(params);
 			expect(mapDecision(params)).toEqual(expectedViewDecisionRow(params));
+		});
+
+		it('Should display enforcement decision row with "Planning permission granted" text', () => {
+			setEnforcementCaseOutcome(params);
+			expect(mapDecision(params)).toEqual(expectedPlanningPermissionGrantedRow(params));
+		});
+
+		it('Should display ELB decision row with "Listed building consent granted" text', () => {
+			setElbCaseOutcome(params);
+			expect(mapDecision(params)).toEqual(expectedListedBuildingConsentGrantedRow(params));
 		});
 	});
 });

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
@@ -7,7 +7,7 @@ import { isStatePassed } from '#lib/appeal-status.js';
 import { textSummaryListItem, userHasPermission } from '#lib/mappers/index.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
-import { toSentenceCase } from '@pins/appeals/utils/string-case.js';
+import { decisionOutcomeToDisplayText } from '@pins/appeals/utils/decision-outcome-display-text.js';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
@@ -35,7 +35,9 @@ export const mapDecision = ({ appealDetails, session, request }) => {
 	return textSummaryListItem({
 		id: 'decision',
 		text: 'Decision',
-		value: toSentenceCase(decision?.outcome || '') || 'Not issued',
+		value:
+			decisionOutcomeToDisplayText(decision?.outcome || '', appealDetails.appealType) ||
+			'Not issued',
 		link,
 		editable,
 		actionText: canIssueDecision ? 'Issue' : 'View',

--- a/packages/appeals/utils/decision-outcome-display-text.js
+++ b/packages/appeals/utils/decision-outcome-display-text.js
@@ -1,0 +1,23 @@
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_DECISION_OUTCOME } from '@planning-inspectorate/data-model';
+import { toSentenceCase } from './string-case.js';
+
+/**
+ * @param {string | null | undefined} decisionType
+ * @param {string | null | undefined} appealType
+ * @returns {string}
+ */
+export function decisionOutcomeToDisplayText(decisionType, appealType) {
+	if (!decisionType) {
+		return '';
+	}
+
+	if (
+		decisionType === APPEAL_CASE_DECISION_OUTCOME.PLANNING_PERMISSION_GRANTED &&
+		appealType === APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
+	) {
+		return 'Listed building consent granted';
+	}
+
+	return toSentenceCase(decisionType);
+}


### PR DESCRIPTION
…y correct text (A2-8107)

+ appellant pulled from child appeal on child appeal page

## Describe your changes

- Creating a common decisionOutcomeToDisplayText function so that ELB planning-permission-granted is displayed as 'Listed building consent granted'
- Updating the various locations which display the decision outcome to use that function
- Adding tests for these specific cases
- Updating to pull the appellant from the child appeal on the child appeal page

## Local testing

Tested that for a single appeal, lead appeal and child appeal the decision outcome displays correctly for both an enforcement appeal and an ELB appeal
Tested that the issue decision flow works correctly for a lead and child appeal which are not both ELB (both ways around- child ELB or lead ELB)

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8107)
