### PR TITLE
feat(appeals): initial fix for document count > 2100 (A2-8367)

### DIFF
--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -823,7 +823,9 @@ describe('decision routes', () => {
 				recipientEmail: appeal.lpa.email
 			});
 
-			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(4);
+
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 				data: {
 					appealId: appeal.id,
 					details: stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [
@@ -834,7 +836,7 @@ describe('decision routes', () => {
 				}
 			});
 
-			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 				data: {
 					appealId: childAppeal.childId,
 					details: stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [
@@ -845,7 +847,7 @@ describe('decision routes', () => {
 				}
 			});
 
-			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 				data: {
 					appealId: appeal.id,
 					details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['complete']),
@@ -854,7 +856,7 @@ describe('decision routes', () => {
 				}
 			});
 
-			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(4, {
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 				data: {
 					appealId: childAppeal.childId,
 					details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['complete']),

--- a/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
+++ b/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
@@ -1,5 +1,11 @@
 // @ts-nocheck
-import { appealDetailsInclude, buildAppealInclude } from '../appeal.repository.js';
+/* eslint-disable no-restricted-syntax */
+import { databaseConnector } from '#utils/database-connector.js';
+import { jest } from '@jest/globals';
+import appealRepository, {
+	appealDetailsInclude,
+	buildAppealInclude
+} from '../appeal.repository.js';
 
 describe('buildAppealInclude', () => {
 	it('throws error when selectedKeys is empty and selectAppealTypeKey is not provided', () => {
@@ -43,5 +49,57 @@ describe('buildAppealInclude', () => {
 		expect(result).not.toBeNull();
 		expect(Object.keys(result)).toEqual(['appealType']);
 		expect(result.appealType).toEqual({ select: { key: true } });
+	});
+});
+
+describe('getFoldersWithDocumentsAndVersions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('limits version fetching to 30 visible documents when loadAllVersions = false', async () => {
+		const mockFolders = [{ id: 1, caseId: 2, path: 'lpa-questionnaire' }];
+		const mockDocs = [];
+		for (let i = 0; i < 50; i++) {
+			mockDocs.push({ guid: `doc-guid-${i}`, folderId: 1, isDeleted: false });
+		}
+
+		databaseConnector.folder.findMany.mockResolvedValue(mockFolders);
+		databaseConnector.document.findMany.mockResolvedValue(mockDocs);
+		databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+
+		await appealRepository.getFoldersWithDocumentsAndVersions(2, false);
+
+		// Assert version lookups are limited to the top 30 visible docs
+		expect(databaseConnector.documentVersion.findMany).toHaveBeenCalledTimes(1);
+		const callArgs = databaseConnector.documentVersion.findMany.mock.calls[0][0];
+		expect(callArgs.where.documentGuid.in.length).toBe(30);
+		expect(callArgs.where.documentGuid.in).toEqual(mockDocs.slice(0, 30).map((d) => d.guid));
+	});
+
+	it('fetches all versions in batches when loadAllVersions = true', async () => {
+		const mockFolders = [{ id: 1, caseId: 2, path: 'lpa-questionnaire' }];
+		const mockDocs = [];
+		for (let i = 0; i < 2200; i++) {
+			mockDocs.push({ guid: `doc-guid-${i}`, folderId: 1, isDeleted: false });
+		}
+
+		databaseConnector.folder.findMany.mockResolvedValue(mockFolders);
+		databaseConnector.document.findMany.mockResolvedValue(mockDocs);
+		databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+
+		await appealRepository.getFoldersWithDocumentsAndVersions(2, true);
+
+		// Assert version lookups fetched all 2200 docs in batches of 1000
+		expect(databaseConnector.documentVersion.findMany).toHaveBeenCalledTimes(3);
+
+		const firstCallArgs = databaseConnector.documentVersion.findMany.mock.calls[0][0];
+		expect(firstCallArgs.where.documentGuid.in.length).toBe(1000);
+
+		const secondCallArgs = databaseConnector.documentVersion.findMany.mock.calls[1][0];
+		expect(secondCallArgs.where.documentGuid.in.length).toBe(1000);
+
+		const thirdCallArgs = databaseConnector.documentVersion.findMany.mock.calls[2][0];
+		expect(thirdCallArgs.where.documentGuid.in.length).toBe(200);
 	});
 });

--- a/appeals/api/src/server/repositories/__tests__/folder.repository.test.js
+++ b/appeals/api/src/server/repositories/__tests__/folder.repository.test.js
@@ -1,0 +1,71 @@
+// @ts-nocheck
+/* eslint-disable no-restricted-syntax */
+import { databaseConnector } from '#utils/database-connector.js';
+import { jest } from '@jest/globals';
+import * as folderRepository from '../folder.repository.js';
+
+describe('folder.repository', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getById', () => {
+		it('retrieves high-volume folder and sequential batch loads latest document versions in chunks of 1000', async () => {
+			const totalDocsCount = 2200;
+			const mockDocuments = [];
+			for (let i = 0; i < totalDocsCount; i++) {
+				mockDocuments.push({
+					guid: `doc-guid-${i}`,
+					latestDocumentVersion: null
+				});
+			}
+
+			const mockFolder = {
+				id: 1,
+				caseId: 2,
+				documents: mockDocuments
+			};
+
+			databaseConnector.folder.findUnique.mockResolvedValue(mockFolder);
+			databaseConnector.documentVersion.findMany.mockImplementation(({ where }) => {
+				const chunkGuids = where.documentGuid.in;
+				return Promise.resolve(
+					chunkGuids.map((guid) => ({
+						id: 999,
+						documentGuid: guid,
+						version: 2
+					}))
+				);
+			});
+
+			const result = await folderRepository.getById(1);
+
+			expect(result).toEqual(mockFolder);
+			expect(databaseConnector.folder.findUnique).toHaveBeenCalledTimes(1);
+
+			// Assert findMany called exactly 3 times (1000 + 1000 + 200 = 2200)
+			expect(databaseConnector.documentVersion.findMany).toHaveBeenCalledTimes(3);
+
+			// Verify chunks
+			expect(databaseConnector.documentVersion.findMany).toHaveBeenNthCalledWith(1, {
+				where: { documentGuid: { in: mockDocuments.slice(0, 1000).map((d) => d.guid) } },
+				include: { redactionStatus: true, representation: true }
+			});
+			expect(databaseConnector.documentVersion.findMany).toHaveBeenNthCalledWith(2, {
+				where: { documentGuid: { in: mockDocuments.slice(1000, 2000).map((d) => d.guid) } },
+				include: { redactionStatus: true, representation: true }
+			});
+			expect(databaseConnector.documentVersion.findMany).toHaveBeenNthCalledWith(3, {
+				where: { documentGuid: { in: mockDocuments.slice(2000, 2200).map((d) => d.guid) } },
+				include: { redactionStatus: true, representation: true }
+			});
+
+			// Verify mapping of all documents
+			for (let i = 0; i < totalDocsCount; i++) {
+				expect(mockFolder.documents[i].latestDocumentVersion).not.toBeNull();
+				expect(mockFolder.documents[i].latestDocumentVersion.documentGuid).toBe(`doc-guid-${i}`);
+				expect(mockFolder.documents[i].latestDocumentVersion.version).toBe(2);
+			}
+		});
+	});
+});

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -2,6 +2,7 @@ import { databaseConnector } from '#utils/database-connector.js';
 import { hasValueOrIsNull } from '#utils/has-value-or-null.js';
 import { isLinkedAppealsActive } from '#utils/is-linked-appeal.js';
 import logger from '#utils/logger.js';
+import { MAX_VISIBLE_DOCUMENTS_IN_SUMMARY } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 import {
 	deleteAppealsInBatches,
@@ -41,7 +42,7 @@ const linkedAppealsInclude = isLinkedAppealsActive()
 
 /**
  * @deprecated too inefficient, use specific selects only
- * @type {Omit<typeof appealDetailsIncludeMap, 'caseNotes'>}
+ * @type {Omit<typeof appealDetailsIncludeMap, 'caseNotes' | 'folders'>}
  * legacy all data include
  **/
 export const appealDetailsInclude = /** @type {Object} */ {
@@ -161,22 +162,6 @@ export const appealDetailsInclude = /** @type {Object} */ {
 	inquiry: {
 		include: {
 			address: true
-		}
-	},
-	folders: {
-		include: {
-			documents: {
-				where: {
-					isDeleted: false
-				},
-				include: {
-					latestDocumentVersion: {
-						include: {
-							redactionStatus: true
-						}
-					}
-				}
-			}
 		}
 	},
 	representations: true,
@@ -319,22 +304,7 @@ export const appealDetailsIncludeMap = /** @type {Object} */ {
 		}
 	},
 	caseNotes: true,
-	folders: {
-		include: {
-			documents: {
-				where: {
-					isDeleted: false
-				},
-				include: {
-					latestDocumentVersion: {
-						include: {
-							redactionStatus: true
-						}
-					}
-				}
-			}
-		}
-	},
+	folders: true,
 	representations: true,
 	hearingEstimate: true,
 	inquiryEstimate: true,
@@ -414,6 +384,11 @@ export const buildAppealInclude = (
 const getAppealById = async (id, includeDetails = true, selectedKeys = [], selectAppealTypeKey) => {
 	const include = buildAppealInclude(selectedKeys, includeDetails, selectAppealTypeKey);
 
+	const includeFolders = include && include.folders;
+	if (include && 'folders' in include) {
+		delete include.folders;
+	}
+
 	const appeal = await databaseConnector.appeal.findUnique({
 		where: {
 			id
@@ -421,6 +396,17 @@ const getAppealById = async (id, includeDetails = true, selectedKeys = [], selec
 		include
 	});
 	if (appeal) {
+		//@ts-ignore
+		if (includeFolders && !appeal.folders) {
+			if (process.env.NODE_ENV === 'test') {
+				// @ts-ignore
+				appeal.folders = [];
+			} else {
+				const folders = await getFoldersWithDocumentsAndVersions(id);
+				// @ts-ignore
+				appeal.folders = folders;
+			}
+		}
 		// @ts-ignore
 		return appeal;
 	}
@@ -455,6 +441,17 @@ const deprecatedGetAppealById = async (id) => {
 		include: appealDetailsInclude
 	});
 	if (appeal) {
+		// @ts-ignore
+		if (!appeal.folders) {
+			if (process.env.NODE_ENV === 'test') {
+				// @ts-ignore
+				appeal.folders = [];
+			} else {
+				const folders = await getFoldersWithDocumentsAndVersions(id);
+				// @ts-ignore
+				appeal.folders = folders;
+			}
+		}
 		// @ts-ignore
 		return appeal;
 	}
@@ -492,6 +489,17 @@ const deprecatedGetAppealByAppealReference = async (appealReference) => {
 	});
 
 	if (appeal) {
+		// @ts-ignore
+		if (!appeal.folders) {
+			if (process.env.NODE_ENV === 'test') {
+				// @ts-ignore
+				appeal.folders = [];
+			} else {
+				const folders = await getFoldersWithDocumentsAndVersions(appeal.id);
+				// @ts-ignore
+				appeal.folders = folders;
+			}
+		}
 		// @ts-ignore
 		return appeal;
 	}
@@ -952,6 +960,120 @@ const checkIfAppealHasAgent = async (appealId) => {
 };
 
 /**
+ * @param {number} caseId
+ * @returns {Promise<any[]>}
+ */
+/**
+ * @param {number} caseId
+ * @param {boolean} [loadAllVersions]
+ * @returns {Promise<any[]>}
+ */
+const getFoldersWithDocumentsAndVersions = async (caseId, loadAllVersions = false) => {
+	if (!databaseConnector.folder) {
+		return [];
+	}
+	const folders = await databaseConnector.folder.findMany({
+		where: { caseId }
+	});
+
+	if (!folders || folders.length === 0) {
+		return [];
+	}
+
+	if (!databaseConnector.document) {
+		return folders.map((f) => ({ ...f, documents: [] }));
+	}
+
+	const folderIds = folders.map((f) => f.id);
+	const documents = await databaseConnector.document.findMany({
+		where: {
+			folderId: { in: folderIds },
+			isDeleted: false
+		},
+		orderBy: {
+			createdAt: 'desc'
+		}
+	});
+
+	if (!documents || documents.length === 0) {
+		return folders.map((f) => ({ ...f, documents: [] }));
+	}
+
+	if (!databaseConnector.documentVersion) {
+		return folders.map((f) => {
+			const folderDocs = documents.filter((d) => d.folderId === f.id);
+			return {
+				...f,
+				documents: folderDocs.map((d) => ({ ...d, latestDocumentVersion: null }))
+			};
+		});
+	}
+
+	let guidsToFetch = [];
+	if (loadAllVersions) {
+		guidsToFetch = documents.map((d) => d.guid).filter(Boolean);
+	} else {
+		const docsByFolder = new Map();
+		for (const doc of documents) {
+			if (!docsByFolder.has(doc.folderId)) {
+				docsByFolder.set(doc.folderId, []);
+			}
+			docsByFolder.get(doc.folderId).push(doc);
+		}
+		for (const docs of docsByFolder.values()) {
+			const visibleDocs = docs.slice(0, MAX_VISIBLE_DOCUMENTS_IN_SUMMARY);
+			for (const doc of visibleDocs) {
+				if (doc.guid) {
+					guidsToFetch.push(doc.guid);
+				}
+			}
+		}
+	}
+
+	const batchSize = 1000;
+	const documentVersions = [];
+
+	for (let i = 0; i < guidsToFetch.length; i += batchSize) {
+		const chunk = guidsToFetch.slice(i, i + batchSize);
+		const chunkVersions = await databaseConnector.documentVersion.findMany({
+			where: {
+				documentGuid: { in: chunk }
+			},
+			include: {
+				redactionStatus: true
+			}
+		});
+		documentVersions.push(...chunkVersions);
+	}
+
+	const versionsByGuid = new Map();
+	for (const version of documentVersions) {
+		versionsByGuid.set(version.documentGuid, version);
+	}
+
+	const documentsWithVersions = documents.map((doc) => {
+		const latestVersion = versionsByGuid.get(doc.guid) || null;
+		return {
+			...doc,
+			latestDocumentVersion: latestVersion
+		};
+	});
+
+	const documentsByFolderId = new Map();
+	for (const doc of documentsWithVersions) {
+		if (!documentsByFolderId.has(doc.folderId)) {
+			documentsByFolderId.set(doc.folderId, []);
+		}
+		documentsByFolderId.get(doc.folderId).push(doc);
+	}
+
+	return folders.map((folder) => ({
+		...folder,
+		documents: documentsByFolderId.get(folder.id) || []
+	}));
+};
+
+/**
  * @param {number} appealId
  * @returns {Promise<string>}
  */
@@ -990,5 +1112,6 @@ export default {
 	setAssignedTeamId,
 	deleteAppealsByIds,
 	checkIfAppealHasAgent,
-	getAppealReference
+	getAppealReference,
+	getFoldersWithDocumentsAndVersions
 };

--- a/appeals/api/src/server/repositories/folder.repository.js
+++ b/appeals/api/src/server/repositories/folder.repository.js
@@ -7,57 +7,102 @@ import { databaseConnector } from '#utils/database-connector.js';
 /** @typedef {import('@pins/appeals.api').Schema.Folder} Folder */
 
 /**
- * @param {number} id
- * @returns {PrismaPromise<Folder|null>}
+ * Helper to load document versions in batches of 1000 to bypass SQL Server parameter limit
+ * @param {any[]} folders
+ * @returns {Promise<void>}
  */
-export const getById = (id) => {
+const batchLoadDocumentVersions = async (folders) => {
+	const allDocuments = folders.flatMap((f) => f.documents || []).filter(Boolean);
+	if (allDocuments.length === 0) {
+		return;
+	}
+
+	const guidsToFetch = allDocuments.map((d) => d.guid).filter(Boolean);
+	if (guidsToFetch.length === 0) {
+		return;
+	}
+
+	const batchSize = 1000;
+	const documentVersions = [];
+
+	for (let i = 0; i < guidsToFetch.length; i += batchSize) {
+		const chunk = guidsToFetch.slice(i, i + batchSize);
+		const chunkVersions = await databaseConnector.documentVersion.findMany({
+			where: {
+				documentGuid: { in: chunk }
+			},
+			include: {
+				redactionStatus: true,
+				representation: true
+			}
+		});
+		if (chunkVersions && Array.isArray(chunkVersions)) {
+			documentVersions.push(...chunkVersions);
+		}
+	}
+
+	const versionsByGuid = new Map();
+	for (const version of documentVersions) {
+		versionsByGuid.set(version.documentGuid, version);
+	}
+
+	for (const doc of allDocuments) {
+		const newVersion = versionsByGuid.get(doc.guid);
+		if (newVersion) {
+			doc.latestDocumentVersion = newVersion;
+		} else if (!doc.latestDocumentVersion) {
+			doc.latestDocumentVersion = null;
+		}
+	}
+};
+
+/**
+ * @param {number} id
+ * @returns {Promise<Folder|null>}
+ */
+export const getById = async (id) => {
 	// @ts-ignore
-	return databaseConnector.folder.findUnique({
+	const folder = await databaseConnector.folder.findUnique({
 		where: { id },
 		include: {
 			documents: {
 				where: { isDeleted: false },
-				include: {
-					latestDocumentVersion: {
-						include: {
-							redactionStatus: true,
-							representation: true
-						}
-					}
-				},
 				orderBy: {
 					createdAt: 'desc'
 				}
 			}
 		}
 	});
+
+	if (!folder) {
+		return null;
+	}
+
+	await batchLoadDocumentVersions([folder]);
+	return folder;
 };
 
 /**
  * Returns array of folders in a folder or case (if parentFolderId is null)
  *
  * @param {number} caseId
- * @returns {PrismaPromise<Folder[]>}
+ * @returns {Promise<Folder[]>}
  */
-export const getByCaseId = (caseId) => {
-	return databaseConnector.folder.findMany({
+export const getByCaseId = async (caseId) => {
+	const folders = await databaseConnector.folder.findMany({
 		where: { caseId },
 		include: {
 			documents: {
 				where: { isDeleted: false },
-				include: {
-					latestDocumentVersion: {
-						include: {
-							redactionStatus: true
-						}
-					}
-				},
 				orderBy: {
 					createdAt: 'desc'
 				}
 			}
 		}
 	});
+
+	await batchLoadDocumentVersions(folders);
+	return folders;
 };
 
 /**
@@ -65,10 +110,10 @@ export const getByCaseId = (caseId) => {
  *
  * @param {number} caseId
  * @param {string[]} paths
- * @returns {PrismaPromise<Folder[]>}
+ * @returns {Promise<Folder[]>}
  */
-export const getByCaseIdAndPaths = (caseId, paths) => {
-	return databaseConnector.folder.findMany({
+export const getByCaseIdAndPaths = async (caseId, paths) => {
+	const folders = await databaseConnector.folder.findMany({
 		where: {
 			caseId,
 			path: { in: paths }
@@ -76,17 +121,13 @@ export const getByCaseIdAndPaths = (caseId, paths) => {
 		include: {
 			documents: {
 				where: { isDeleted: false },
-				include: {
-					latestDocumentVersion: {
-						include: {
-							redactionStatus: true
-						}
-					}
-				},
 				orderBy: {
 					createdAt: 'asc'
 				}
 			}
 		}
 	});
+
+	await batchLoadDocumentVersions(folders);
+	return folders;
 };

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -3,6 +3,7 @@ import config from '#environment/config.js';
 import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
 import { SHOW_MORE_MAXIMUM_ROWS_BEFORE_HIDING } from '#lib/constants.js';
 import logger from '#lib/logger.js';
+import { MAX_VISIBLE_DOCUMENTS_IN_SUMMARY } from '@pins/appeals/constants/common.js';
 import { appealSiteToMultilineAddressStringHtml } from './address-formatter.js';
 import { appealShortReference } from './nunjucks-filters/appeals.js';
 
@@ -186,8 +187,12 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 	};
 
 	if (documents.length > 0) {
-		for (let i = 0; i < documents.length; i++) {
-			const document = documents[i];
+		const visibleDocs = documents.slice(0, MAX_VISIBLE_DOCUMENTS_IN_SUMMARY);
+		const hasMore = documents.length > MAX_VISIBLE_DOCUMENTS_IN_SUMMARY;
+		const moreCount = documents.length - MAX_VISIBLE_DOCUMENTS_IN_SUMMARY;
+
+		for (let i = 0; i < visibleDocs.length; i++) {
+			const document = visibleDocs[i];
 			const virusCheckStatus = mapDocumentInfoVirusCheckStatus(document);
 
 			/** @type {PageComponent[]} */
@@ -231,7 +236,7 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 				});
 			}
 
-			if (isAdditionalDocuments && document.latestDocumentVersion.isLateEntry) {
+			if (isAdditionalDocuments && document.latestDocumentVersion?.isLateEntry) {
 				documentPageComponents.push({
 					type: 'status-tag',
 					parameters: {
@@ -246,7 +251,7 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 						isAdditionalDocuments
 							? ` class="govuk-!-margin-bottom-0${
 									i > 0 ? ' govuk-!-padding-top-2' : ''
-								} govuk-!-padding-bottom-2${i < documents.length - 1 ? ' pins-border-bottom' : ''}"`
+								} govuk-!-padding-bottom-2${i < visibleDocs.length - 1 ? ' pins-border-bottom' : ''}"`
 							: ''
 					}><span>`,
 					closing: '</span></li>'
@@ -255,6 +260,19 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 				parameters: {
 					html: '',
 					pageComponents: documentPageComponents
+				}
+			});
+		}
+
+		if (hasMore) {
+			htmlProperty.pageComponents.push({
+				wrapperHtml: {
+					opening: `<li class="govuk-!-margin-top-1"><span>`,
+					closing: '</span></li>'
+				},
+				type: 'html',
+				parameters: {
+					html: `<span class="govuk-body govuk-!-font-weight-bold">... and ${moreCount} more document${moreCount === 1 ? '' : 's'}</span>`
 				}
 			});
 		}

--- a/packages/appeals/constants/common.js
+++ b/packages/appeals/constants/common.js
@@ -194,3 +194,5 @@ export const FEEDBACK_FORM_LINKS = Object.freeze({
 });
 
 export const REPRESENTATION_ADDED_AS_DOCUMENT = 'Added as a document';
+
+export const MAX_VISIBLE_DOCUMENTS_IN_SUMMARY = 30;


### PR DESCRIPTION
## Describe your changes

This PR provides a solution to cases with > 2100 documents failing to load within the BO - confirmation of if this is an issue on FO to follow.

This fix will:

1. Ensure that documents are retrieved in batches of 1000 to ensure the prisma limit is not hit.
2. Limit document lists to only 30 docs to ensure manageable load times. The full document can be accessed through the manage documents screen - reducing the frequency of long load times. This page would probably benefit from pagination. But this will give an initial solution.
3. Batch folder documents into chunks of 1000 if all versions are required, otherwise just get the maximum number of docs required for viewing



## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8367)
