### PR TITLE
fix(api): add appellant case to to lpaq patch for notify checks (A2-7883)

### DIFF
--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.routes.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.routes.js
@@ -83,6 +83,7 @@ router.patch(
 			'childAppeals',
 			'appealStatus',
 			'appealType',
+			'appellantCase',
 			'lpa',
 			'appellant',
 			'agent',


### PR DESCRIPTION
## Describe your changes

Adding appellant case to appeal to get the correct notify to send when appeal is expedited

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7883)
