### PR TITLE
fix(web): removing use of the original decision date for reissued dec…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { createTestEnvironment } from '#testing/index.js';
+import { jest } from '@jest/globals';
 import { parseHtml } from '@pins/platform';
 import nock from 'nock';
 import supertest from 'supertest';
@@ -195,6 +196,11 @@ describe('update-decision-letter', () => {
 	describe('GET /issue-decision/check-your-decision', () => {
 		let issueDecisionAppealData = appealDataIssuedDecision;
 
+		beforeEach(() => {
+			jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'performance'] });
+			jest.setSystemTime(new Date('2026-01-02T00:00:00.000Z'));
+		});
+
 		beforeEach(async () => {
 			nock.cleanAll();
 			nock('http://test/')
@@ -244,7 +250,7 @@ describe('update-decision-letter', () => {
 				});
 		});
 
-		afterEach(teardown);
+		afterEach(teardown); // this includes jest.useRealTimers();
 
 		it('should render the check your details page', async () => {
 			nock('http://test/')
@@ -275,7 +281,7 @@ describe('update-decision-letter', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Update decision letter');
 		});
 
-		it('should use the original decision letterDate in the email preview, not the upload date', async () => {
+		it('should use the new file upload date in the notifies', async () => {
 			expect(uploadDecisionLetterResponse.statusCode).toBe(302);
 			expect(correctionNoticeResponse.statusCode).toBe(302);
 
@@ -317,10 +323,10 @@ describe('update-decision-letter', () => {
 
 			await request.get(`${baseUrl}/1/update-decision-letter/check-details`);
 
-			expect(capturedPreviewBody.decision_date).toBe('25 December 2023');
+			expect(capturedPreviewBody.decision_date).toBe('2 January 2026');
 		});
 
-		it('should submit the original decision letterDate as receivedDate, not the upload date', async () => {
+		it('should submit the upload date as receivedDate', async () => {
 			expect(uploadDecisionLetterResponse.statusCode).toBe(302);
 			expect(correctionNoticeResponse.statusCode).toBe(302);
 
@@ -337,7 +343,7 @@ describe('update-decision-letter', () => {
 				.send({});
 
 			expect(response.statusCode).toBe(302);
-			expect(capturedApiBody.document.receivedDate).toBe('2023-12-25T00:00:00.000Z');
+			expect(capturedApiBody.document.receivedDate).toBe('2026-01-02T00:00:00.000Z');
 		});
 
 		it('should render the view-decision page after submit', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
@@ -85,7 +85,7 @@ export const renderUpdateDocumentCheckDetails = async (request, response) => {
 		site_address: appealSiteToAddressString(appealSite),
 		lpa_reference: planningApplicationReference,
 		correction_notice_reason: correctionNotice,
-		decision_date: dateISOStringToDisplayDate(decision.letterDate || file.receivedDate),
+		decision_date: dateISOStringToDisplayDate(file.receivedDate),
 		team_email_address: assignedTeamEmail,
 		feedback_link: getFeedbackLinkFromAppealTypeName(appealType)
 	};
@@ -237,7 +237,7 @@ export const postUpdateDocumentCheckDetails = async (request, response) => {
 				stage: uploadInfo.stage,
 				folderId: inspectorDecision.folderId,
 				GUID: uploadInfo.GUID,
-				receivedDate: currentDecision.letterDate || uploadInfo.receivedDate,
+				receivedDate: uploadInfo.receivedDate,
 				redactionStatusId: notRedactedStatusID,
 				blobStoragePath: uploadInfo.blobStoreUrl
 			},


### PR DESCRIPTION
…ision date (A2-8219)

## Describe your changes

- Removing the use of currentDecision.letterDate as this is the original decision date
- Correct the test titles and test cases to check that the new date is used rather than the original decision date

Tested locally:

<img width="907" height="417" alt="image" src="https://github.com/user-attachments/assets/e54e5c45-4ec3-4b22-8ab0-676368f142b3" />
<img width="947" height="413" alt="image" src="https://github.com/user-attachments/assets/7cbbc936-f2ed-4bf9-ab93-46cc645af0d5" />
<img width="923" height="967" alt="image" src="https://github.com/user-attachments/assets/a7b7b6fc-4172-4186-98e8-d056b85716a1" />
<img width="1165" height="1151" alt="image" src="https://github.com/user-attachments/assets/b8bfb570-cecc-4fb2-ba4c-9fc881353376" />


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8219)
