### PR TITLE
feat(web): added appeal type turnery to determine display name for procedure select (a2-8392)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/__snapshots__/start-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/__snapshots__/start-case.test.js.snap
@@ -25,7 +25,7 @@ exports[`start-case GET /start-case/select-procedure should render the select pr
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure-2" name="appealProcedure"
                                         type="radio" value="written">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure-2">Written representations (Part 2)</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure-2">Written representations</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure-3" name="appealProcedure"
@@ -64,7 +64,7 @@ exports[`start-case GET /start-case/select-procedure/check-and-confirm should re
                     <form method="POST" novalidate="novalidate">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
+                                <dd class="govuk-summary-list__value">Written representations</dd>
                             </div>
                         </dl>
                         <p class="govuk-body">We’ll start the timetable now and send emails to the relevant parties.</p>
@@ -110,7 +110,7 @@ exports[`start-case GET /start-case/select-procedure/check-and-confirm should re
                     <form method="POST" novalidate="novalidate">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
+                                <dd class="govuk-summary-list__value">Written representations</dd>
                             </div>
                         </dl>
                         <p class="govuk-body">We’ll start the timetable now and send emails to the relevant parties.</p>
@@ -208,7 +208,7 @@ exports[`start-case POST /start-case/select-procedure should re-render the selec
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure" name="appealProcedure"
                                         type="radio" value="written">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Written representations (Part 2)</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Written representations</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure-2" name="appealProcedure"

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
@@ -155,7 +155,7 @@ export function selectProcedurePage(
 		) {
 			radioItems.push({
 				value: item.case,
-				text: appealProcedureKeyToLabelText(item.case),
+				text: appealProcedureKeyToLabelText(item.case, appealType),
 				checked:
 					storedSessionData?.appealProcedure && storedSessionData?.appealProcedure === item.case
 			});
@@ -229,7 +229,7 @@ export function confirmProcedurePage(
 						textSummaryListItem({
 							id: 'appeal-procedure',
 							text: 'Appeal procedure',
-							value: appealProcedureKeyToLabelText(procedureType) || 'No data',
+							value: appealProcedureKeyToLabelText(procedureType, appealType) || 'No data',
 							link: editLink(
 								`/appeals-service/appeal-details/${appealId}/start-case/select-procedure`
 							),

--- a/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
+++ b/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
@@ -1,4 +1,4 @@
-import { PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
+import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
 import { capitalizeFirstLetter } from '@pins/appeals/utils/string-case.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
@@ -22,12 +22,15 @@ export function appealProcedureNameToLabelText(procedureTypeName) {
 
 /**
  * @param {string} procedureTypeKey
+ * @param {string} appealType
  * @returns string
  */
-export function appealProcedureKeyToLabelText(procedureTypeKey) {
+export function appealProcedureKeyToLabelText(procedureTypeKey, appealType) {
 	switch (procedureTypeKey) {
 		case APPEAL_CASE_PROCEDURE.WRITTEN:
-			return 'Written representations (Part 2)';
+			return appealType !== APPEAL_TYPE.S78 || appealType !== APPEAL_TYPE.S78_EXPEDITED
+				? 'Written representations'
+				: 'Written representations (Part 2)';
 		case APPEAL_CASE_PROCEDURE.WRITTEN_PART_1:
 			return 'Written representations (Part 1)';
 		case APPEAL_CASE_PROCEDURE.HEARING:


### PR DESCRIPTION
- Added turnery in mapper - This determines the displayed procedure type names when viewing the start case procedure select radio buttons. The condition ensures "Part 1" & "Part 2" only displays for s78 case types which are eligible for expedited.
-  Updated snap

https://pins-ds.atlassian.net/browse/A2-8392
