### PR TITLE
fix(api): don't error if there is no LPAQ to update (A2-8333)

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -27,6 +27,7 @@ const mocklPAQuestionnaireDeleteMany = jest.fn().mockResolvedValue({});
 const mocklPAQuestionnaireFindMany = jest.fn().mockResolvedValue([]);
 const mocklPAQuestionnaireCreate = jest.fn().mockResolvedValue({});
 const mocklPAQuestionnaireUpdate = jest.fn().mockResolvedValue({});
+const mocklPAQuestionnaireUpdateMany = jest.fn().mockResolvedValue({ count: 0 });
 const mockAppealStatusFindMany = jest.fn().mockResolvedValue([]);
 const mockAppealStatusUpdateMany = jest.fn().mockResolvedValue({});
 const mockAppealStatusCreate = jest.fn().mockResolvedValue({});
@@ -356,6 +357,7 @@ class MockPrismaClient {
 		return {
 			create: mocklPAQuestionnaireCreate,
 			update: mocklPAQuestionnaireUpdate,
+			updateMany: mocklPAQuestionnaireUpdateMany,
 			findMany: mocklPAQuestionnaireFindMany,
 			deleteMany: mocklPAQuestionnaireDeleteMany
 		};

--- a/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
+++ b/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
@@ -698,6 +698,7 @@ describe('appeals documents', () => {
 			jest.clearAllMocks();
 			jest.resetAllMocks();
 			databaseConnector.appellantCase.update = jest.fn().mockResolvedValue({});
+			databaseConnector.lPAQuestionnaire.updateMany.mockResolvedValue({ count: 1 });
 		});
 
 		test.each([
@@ -740,7 +741,7 @@ describe('appeals documents', () => {
 				true
 			);
 
-			expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
+			expect(databaseConnector.lPAQuestionnaire.updateMany).toHaveBeenCalledWith({
 				data: {
 					lpaCostsAppliedFor: true
 				},
@@ -758,7 +759,7 @@ describe('appeals documents', () => {
 				false
 			);
 
-			expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
+			expect(databaseConnector.lPAQuestionnaire.updateMany).toHaveBeenCalledWith({
 				data: {
 					lpaCostsAppliedFor: false
 				},

--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -604,8 +604,14 @@ export const updateDocumentVisibilityBooleans = async (
 
 	if (lpaCostApplicationDocument && appealId) {
 		// if adding or removing an LPA cost document, then set lpaCostsAppliedFor accordingly
-		await lpaQuestionnaireRepository.updateLpaCostsAppliedFor(appealId, visible);
-		await broadcasters.broadcastAppeal(appealId);
+		const { count } = await lpaQuestionnaireRepository.updateLpaCostsAppliedFor(appealId, visible);
+		if (count) {
+			logger.info(`LPAQ for ${appealId} updated, with lpaCostsAppliedFor=${visible}`);
+			await broadcasters.broadcastAppeal(appealId);
+		} else {
+			// don't error if there isn't an LPAQ
+			logger.warn(`no LPAQ for ${appealId}, lpaCostsAppliedFor not updated`);
+		}
 	}
 };
 

--- a/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
+++ b/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
@@ -116,10 +116,11 @@ const updateLPAQuestionnaireById = (id, data) => {
 /**
  * @param {number} appealId
  * @param {boolean} visible
- * @returns {Promise<object>}
+ * @returns {Promise<{count: number}>}
  */
 const updateLpaCostsAppliedFor = (appealId, visible) => {
-	return databaseConnector.lPAQuestionnaire.update({
+	// use updateMany to avoid errors if there is no LPAQ for this appeal
+	return databaseConnector.lPAQuestionnaire.updateMany({
 		where: { appealId },
 		data: {
 			lpaCostsAppliedFor: visible


### PR DESCRIPTION
## Describe your changes

Follow up to fix a bug if there is no LPAQ yet. We can't create the LPAQ with the field set, as the integration would then fail/not update with the real data.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8333)
