### PR TITLE
feat(web): removing appeal statement from has, cas adv, cas planning …

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -167,6 +167,62 @@ describe('appellant-case', () => {
 			);
 		});
 
+		it.each([
+			['Householder', appealData],
+			['CAS planning', appealDataCasPlanning],
+			['CAS advert', appealDataCasAdvert]
+		])(
+			'should show Appeal statement in Upload documents for %s appeals submitted before 1 April 2026',
+			async (_, testAppealData) => {
+				nock('http://test/')
+					.get('/appeals/2?include=all')
+					.reply(200, {
+						...testAppealData,
+						appealId: 2
+					});
+				nock('http://test/')
+					.get('/appeals/2/appellant-cases/0')
+					.reply(200, {
+						...appellantCaseDataNotValidated,
+						applicationDate: '2026-03-31T12:00:00.000Z'
+					});
+
+				const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('4. Upload documents</h2>');
+				expect(unprettifiedElement.innerHTML).toContain('Appeal statement');
+			}
+		);
+
+		it.each([
+			['Householder', appealData],
+			['CAS planning', appealDataCasPlanning],
+			['CAS advert', appealDataCasAdvert]
+		])(
+			'should not show Appeal statement in Upload documents for %s appeals submitted from 1 April 2026 onwards',
+			async (_, testAppealData) => {
+				nock('http://test/')
+					.get('/appeals/2?include=all')
+					.reply(200, {
+						...testAppealData,
+						appealId: 2
+					});
+				nock('http://test/')
+					.get('/appeals/2/appellant-cases/0')
+					.reply(200, {
+						...appellantCaseDataNotValidated,
+						applicationDate: '2026-04-01T00:00:00.000Z'
+					});
+
+				const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('4. Upload documents</h2>');
+				expect(unprettifiedElement.innerHTML).not.toContain('Appeal statement');
+			}
+		);
+
 		it('should render the appellant case page with the expected content (Full planning appeal / S78)', async () => {
 			nock('http://test/')
 				.get('/appeals/2?include=all')

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas-advert.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas-advert.mapper.js
@@ -1,3 +1,4 @@
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 import { generateHASComponents } from './has.mapper.js';
 
 /**
@@ -105,7 +106,10 @@ export function generateCASAdvertComponents(
 				},
 				rows: [
 					mappedAppellantCaseData.applicationForm.display.summaryListItem,
-					mappedAppellantCaseData.appealStatement.display.summaryListItem,
+					// we want to hide the appeal statement for appeals submitted 1st April 2026 onwards
+					...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+						? [mappedAppellantCaseData.appealStatement.display.summaryListItem]
+						: []),
 					mappedAppellantCaseData.costsDocument.display.summaryListItem,
 					mappedAppellantCaseData.supportingDocuments.display.summaryListItem
 				]

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
@@ -1,3 +1,4 @@
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 import { generateHASComponents } from './has.mapper.js';
 
 /**
@@ -54,7 +55,10 @@ export function generateCASComponents(
 				rows: [
 					mappedAppellantCaseData.applicationForm.display.summaryListItem,
 					mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-					mappedAppellantCaseData.appealStatement.display.summaryListItem,
+					// we want to hide the appeal statement for appeals submitted 1st April 2026 onwards
+					...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+						? [mappedAppellantCaseData.appealStatement.display.summaryListItem]
+						: []),
 					mappedAppellantCaseData.costsDocument.display.summaryListItem,
 					mappedAppellantCaseData.designAndAccessStatement.display.summaryListItem,
 					mappedAppellantCaseData.supportingDocuments.display.summaryListItem

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
@@ -6,6 +6,7 @@ import {
 } from '#lib/mappers/data/appellant-case/common.js';
 import { removeSummaryListActions } from '#lib/mappers/index.js';
 import { isFolderInfo } from '#lib/ts-utilities.js';
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -174,7 +175,10 @@ export function generateHASComponents(
 			rows: [
 				mappedAppellantCaseData.applicationForm.display.summaryListItem,
 				mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-				mappedAppellantCaseData.appealStatement.display.summaryListItem,
+				// we want to hide the appeal statement for appeals submitted 1st April 2026 onwards
+				...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+					? [mappedAppellantCaseData.appealStatement.display.summaryListItem]
+					: []),
 				mappedAppellantCaseData.costsDocument.display.summaryListItem
 			]
 		}

--- a/packages/appeals/constants/dates.js
+++ b/packages/appeals/constants/dates.js
@@ -4,3 +4,4 @@ export const DAYTIME_HOUR = 10;
 export const DAYTIME_MINUTE = 0;
 export const DEFAULT_TIMEZONE = 'Europe/London';
 export const NUM_DAYS_TO_RESUBMIT_REJECTED_IP_COMMENTS = 3;
+export const EXPEDITED_ORIGINAL_APPLICATION_CUTOFF = new Date('2026-04-01T00:00:00.000Z');

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -4,6 +4,7 @@ import {
 	APPEAL_TYPE_OF_PLANNING_APPLICATION
 } from '@planning-inspectorate/data-model';
 import { APPEAL_TYPE } from '../constants/common.js';
+import { EXPEDITED_ORIGINAL_APPLICATION_CUTOFF } from '../constants/dates.js';
 
 /**
  *
@@ -13,6 +14,19 @@ import { APPEAL_TYPE } from '../constants/common.js';
  */
 export const dateIsAfterDate = (date, afterDate) => {
 	return date.getTime() >= afterDate.getTime();
+};
+
+/**
+ * Returns true if the original application was submitted before the expedited process start date
+ * of 1st April 2026, or if the application date is null or undefined
+ * @param {string | null | undefined} applicationDate
+ * @returns {boolean}
+ */
+export const beforeExpeditedOriginalApplicationCutOff = (applicationDate) => {
+	return (
+		!applicationDate ||
+		!dateIsAfterDate(new Date(applicationDate), EXPEDITED_ORIGINAL_APPLICATION_CUTOFF)
+	);
 };
 
 /**


### PR DESCRIPTION
…from 1st Apr onwards (A2-8390)

## Describe your changes

- Added function to judge whether the appeal statement should show up
- Added constant to store the date 1st April 2026
- Added using that function to control displaying the appeal statement in the HAS, CAS planning and CAS advert mappers
- Updated unit tests to cover this case

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8390)
