### PR TITLE
fix(api): update documents when changing lead (A2-8321)

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -205,6 +205,7 @@ const mockRepresentationCreateMany = jest.fn().mockRejectedValue({});
 const mockRepresentationDeleteMany = jest.fn().mockResolvedValue({});
 const mockRepresentationAttachmentDeleteMany = jest.fn().mockResolvedValue({});
 const mockRepresentationAttachmentCreateMany = jest.fn().mockResolvedValue({});
+const mockRepresentationAttachmentFindMany = jest.fn().mockRejectedValue([]);
 const mockRepresentationCount = jest.fn().mockResolvedValue({});
 const mockLpaFindMany = jest.fn().mockResolvedValue({});
 const mockLpaFindUnique = jest.fn().mockResolvedValue({});
@@ -264,7 +265,8 @@ class MockPrismaClient {
 		return {
 			create: mockRepresentationCreate,
 			createMany: mockRepresentationAttachmentCreateMany,
-			deleteMany: mockRepresentationAttachmentDeleteMany
+			deleteMany: mockRepresentationAttachmentDeleteMany,
+			findMany: mockRepresentationAttachmentFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -489,13 +489,20 @@ describe('appeal linked appeals routes', () => {
 							}
 						];
 						testAppeal.appellantCase.appellantCaseValidationOutcome = { id: 1, name: 'Valid' };
-						databaseConnector.folder.findMany.mockResolvedValue([]);
+						databaseConnector.folder.findMany.mockResolvedValue([{ id: 1 }]);
 						databaseConnector.appealRelationship.deleteMany.mockResolvedValue({});
 						databaseConnector.appealRelationship.create.mockResolvedValue({});
 						// @ts-ignore
 						databaseConnector.appeal.findUnique.mockResolvedValue(testAppeal);
 						databaseConnector.representation.findMany.mockResolvedValue([{ id: 'testId' }]);
 						databaseConnector.representation.update.mockResolvedValue({ id: 'testId' });
+						databaseConnector.representationAttachment.findMany.mockResolvedValue([
+							{ documentGuid: 'testDocGuid' }
+						]);
+						databaseConnector.document.updateMany.mockResolvedValue([]);
+						databaseConnector.document.findMany.mockResolvedValue([
+							{ guid: 'testDocGuid', latestVersionId: 1 }
+						]);
 
 						const response = await request
 							.post(`/appeals/${testAppeal.id}/update-linked-appeals`)
@@ -505,7 +512,23 @@ describe('appeal linked appeals routes', () => {
 							})
 							.set('azureAdUserId', azureAdUserId);
 
-						expect(databaseConnector.folder.findMany).toHaveBeenCalledTimes(2);
+						expect(databaseConnector.folder.findMany).toHaveBeenCalledTimes(3);
+
+						//move and update representation attachments / documents
+						expect(databaseConnector.representationAttachment.findMany).toHaveBeenCalledWith({
+							where: {
+								representationId: 'testId'
+							}
+						});
+						expect(databaseConnector.document.updateMany).toHaveBeenCalledWith({
+							where: {
+								guid: { in: ['testDocGuid'] }
+							},
+							data: {
+								caseId: mockAppealA.id,
+								folderId: 1
+							}
+						});
 
 						expect(databaseConnector.appealRelationship.deleteMany).toHaveBeenCalledTimes(1);
 						expect(databaseConnector.appealRelationship.deleteMany).toHaveBeenCalledWith({
@@ -535,6 +558,12 @@ describe('appeal linked appeals routes', () => {
 						});
 
 						expect(mockBroadcasters.broadcastRepresentation).toHaveBeenCalledTimes(1);
+						expect(mockBroadcasters.broadcastDocument).toHaveBeenCalledTimes(1);
+						expect(mockBroadcasters.broadcastDocument).toHaveBeenCalledWith(
+							'testDocGuid',
+							1,
+							EventType.Update
+						);
 						expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledTimes(3);
 						expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(testAppeal.id);
 						expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(mockAppealA.id);

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -449,6 +449,7 @@ export const updateLinkedAppeals = async (req, res) => {
 		let appealToUnlink;
 		let appealsToBroadcast;
 		let representationsToBroadcast;
+		let documentsToBroadcast;
 		// @ts-ignore
 		let representationBroadcastAction;
 
@@ -463,7 +464,11 @@ export const updateLinkedAppeals = async (req, res) => {
 					replaceLeadAppeal(currentLead, appealToReplaceLead)
 				]);
 				// @ts-ignore
-				representationsToBroadcast = results[0].value;
+				const { movedRepresentations, movedDocuments } = results[0].value;
+				// @ts-ignore
+				representationsToBroadcast = movedRepresentations;
+				// @ts-ignore
+				documentsToBroadcast = movedDocuments;
 				// @ts-ignore
 				representationBroadcastAction = EventType.Update;
 				break;
@@ -570,6 +575,24 @@ export const updateLinkedAppeals = async (req, res) => {
 					.map((representation) =>
 						// @ts-ignore
 						broadcasters.broadcastRepresentation(representation.id, representationBroadcastAction)
+					)
+			);
+		}
+
+		// will broadcast updated documents when reps moved
+		// newly created docs from copy etc are broadcast as part of the copyReps / duplicateFiles
+		if (documentsToBroadcast) {
+			await Promise.allSettled(
+				documentsToBroadcast
+					// @ts-ignore
+					.filter((document) => document.guid !== undefined)
+					// @ts-ignore
+					.map((document) =>
+						broadcasters.broadcastDocument(
+							document.guid,
+							document.latestVersionId,
+							EventType.Update
+						)
 					)
 			);
 		}

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -199,7 +199,29 @@ export const moveRepresentations = async (sourceAppeal, destinationAppeal) => {
 		})
 	);
 
-	return movedRepresentations.filter((rep) => rep.status === 'fulfilled').map((rep) => rep.value);
+	const successfullyMovedRepresentations = movedRepresentations
+		.filter((rep) => rep.status === 'fulfilled')
+		.map((rep) => rep.value);
+
+	const destinationFolders = await getFoldersForAppeal(destinationAppeal.id, 'representation');
+
+	const movedRepresentationAttachmentDocuments = await Promise.allSettled(
+		successfullyMovedRepresentations.map(async (movedRepresentation) => {
+			return await representationRepository.moveRepresentationAttachmentDocuments(
+				movedRepresentation.id,
+				destinationAppeal.id,
+				destinationFolders[0].id
+			);
+		})
+	);
+
+	return {
+		movedRepresentations: successfullyMovedRepresentations,
+		movedDocuments: movedRepresentationAttachmentDocuments
+			.filter((rep) => rep.status === 'fulfilled')
+			.map((rep) => rep.value)
+			.flat()
+	};
 };
 
 /**

--- a/appeals/api/src/server/repositories/representation.repository.js
+++ b/appeals/api/src/server/repositories/representation.repository.js
@@ -309,6 +309,42 @@ const addAttachments = async (repId, attachments) => {
 
 /**
  * @param {number} repId
+ * @param {number} destinationAppealId
+ * @param {number} destinationFolderId
+ */
+const moveRepresentationAttachmentDocuments = async (
+	repId,
+	destinationAppealId,
+	destinationFolderId
+) => {
+	const attachmentsToUpdate = await databaseConnector.representationAttachment.findMany({
+		where: { representationId: repId }
+	});
+
+	const attachmentDocumentGuidArray = attachmentsToUpdate.map(
+		(attachment) => attachment.documentGuid
+	);
+
+	// returns a count rather than an array of documents
+	await databaseConnector.document.updateMany({
+		where: {
+			guid: { in: attachmentDocumentGuidArray }
+		},
+		data: {
+			caseId: destinationAppealId,
+			folderId: destinationFolderId
+		}
+	});
+
+	return databaseConnector.document.findMany({
+		where: {
+			guid: { in: attachmentDocumentGuidArray }
+		}
+	});
+};
+
+/**
+ * @param {number} repId
  * @param {Array<{ id: number, text: string[] }>} rejectionReasons
  */
 const updateRejectionReasons = async (repId, rejectionReasons) => {
@@ -354,5 +390,6 @@ export default {
 	createRepresentation,
 	createRepresentations,
 	addAttachments,
+	moveRepresentationAttachmentDocuments,
 	updateRejectionReasons
 };


### PR DESCRIPTION
## Describe your changes

Representations get moved to the new lead when the lead appeal is changed for linked appeals.  However, documents attached to those reps retained the previous lead appealId and folderId.  This PR amends this so the documents relating to any moved reps are also updated, and the updated rep is broadcast to FO.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8321)
