### PR TITLE
fix(web): simplified filtering logic and corrected filtering for has and cas cases (a2-8149)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -7161,7 +7161,7 @@ exports[`appellant-case GET /appellant-case/check-your-answers should render the
 </main>"
 `;
 
-exports[`appellant-case GET /appellant-case/incomplete should render the incomplete reason page and content 1`] = `
+exports[`appellant-case GET /appellant-case/incomplete should render the incomplete reason page and content for a CAS advertisement case submitted before 1st April 2026 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -7328,6 +7328,894 @@ exports[`appellant-case GET /appellant-case/incomplete should render the incompl
                             </div>
                             <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                             id="conditional-incomplete-reason-11">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-10-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-10-1" name="incompleteReason-10" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appellant-case GET /appellant-case/incomplete should render the incomplete reason page and content for a CAS advertisement case submitted from 1st April 2026 onwards 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal incomplete?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason" name="incompleteReason"
+                                type="checkbox" value="1">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason">Appellant name is not the same on the application form and appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-2" name="incompleteReason"
+                                type="checkbox" value="3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-2">LPA&#39;s decision notice is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-3" name="incompleteReason"
+                                type="checkbox" value="4" data-aria-controls="conditional-incomplete-reason-3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-3">LPA&#39;s decision notice is incorrect or incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-3">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-4-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-4-1" name="incompleteReason-4" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-4" name="incompleteReason"
+                                type="checkbox" value="5" data-aria-controls="conditional-incomplete-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-4">Documents and/or plans referred in the application form, decision notice
+                                    and appeal covering letter are missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-5-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-5-1" name="incompleteReason-5" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-5" name="incompleteReason"
+                                type="checkbox" value="6">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-5">Agricultural holding certificate and declaration have not been completed
+                                    on the appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-6" name="incompleteReason"
+                                type="checkbox" value="7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-6">The original application form is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-7" name="incompleteReason"
+                                type="checkbox" value="8" data-aria-controls="conditional-incomplete-reason-7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-7">The original application form is incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-7">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-8-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-8-1" name="incompleteReason-8" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-8" name="incompleteReason"
+                                type="checkbox" value="11">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-8">Draft statement of common ground is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-9" name="incompleteReason"
+                                type="checkbox" value="10" data-aria-controls="conditional-incomplete-reason-9">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-9">Other</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-9">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-10-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-10-1" name="incompleteReason-10" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appellant-case GET /appellant-case/incomplete should render the incomplete reason page and content for a CAS planning case submitted before 1st April 2026 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal incomplete?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason" name="incompleteReason"
+                                type="checkbox" value="1">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason">Appellant name is not the same on the application form and appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-2" name="incompleteReason"
+                                type="checkbox" value="2" data-aria-controls="conditional-incomplete-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-2">Attachments and/or appendices have not been included to the full statement
+                                    of case</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-2-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-2-1" name="incompleteReason-2" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-3" name="incompleteReason"
+                                type="checkbox" value="3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-3">LPA&#39;s decision notice is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-4" name="incompleteReason"
+                                type="checkbox" value="4" data-aria-controls="conditional-incomplete-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-4">LPA&#39;s decision notice is incorrect or incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-4-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-4-1" name="incompleteReason-4" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-5" name="incompleteReason"
+                                type="checkbox" value="5" data-aria-controls="conditional-incomplete-reason-5">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-5">Documents and/or plans referred in the application form, decision notice
+                                    and appeal covering letter are missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-5">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-5-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-5-1" name="incompleteReason-5" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-6" name="incompleteReason"
+                                type="checkbox" value="6">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-6">Agricultural holding certificate and declaration have not been completed
+                                    on the appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-7" name="incompleteReason"
+                                type="checkbox" value="7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-7">The original application form is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-8" name="incompleteReason"
+                                type="checkbox" value="8" data-aria-controls="conditional-incomplete-reason-8">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-8">The original application form is incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-8">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-8-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-8-1" name="incompleteReason-8" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-9" name="incompleteReason"
+                                type="checkbox" value="9">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-9">Statement of case and ground of appeal are missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-10" name="incompleteReason"
+                                type="checkbox" value="11">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-10">Draft statement of common ground is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-11" name="incompleteReason"
+                                type="checkbox" value="10" data-aria-controls="conditional-incomplete-reason-11">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-11">Other</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-11">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-10-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-10-1" name="incompleteReason-10" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appellant-case GET /appellant-case/incomplete should render the incomplete reason page and content for a CAS planning case submitted from 1st April 2026 onwards 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal incomplete?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason" name="incompleteReason"
+                                type="checkbox" value="1">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason">Appellant name is not the same on the application form and appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-2" name="incompleteReason"
+                                type="checkbox" value="3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-2">LPA&#39;s decision notice is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-3" name="incompleteReason"
+                                type="checkbox" value="4" data-aria-controls="conditional-incomplete-reason-3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-3">LPA&#39;s decision notice is incorrect or incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-3">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-4-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-4-1" name="incompleteReason-4" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-4" name="incompleteReason"
+                                type="checkbox" value="5" data-aria-controls="conditional-incomplete-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-4">Documents and/or plans referred in the application form, decision notice
+                                    and appeal covering letter are missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-5-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-5-1" name="incompleteReason-5" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-5" name="incompleteReason"
+                                type="checkbox" value="6">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-5">Agricultural holding certificate and declaration have not been completed
+                                    on the appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-6" name="incompleteReason"
+                                type="checkbox" value="7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-6">The original application form is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-7" name="incompleteReason"
+                                type="checkbox" value="8" data-aria-controls="conditional-incomplete-reason-7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-7">The original application form is incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-7">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-8-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-8-1" name="incompleteReason-8" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-8" name="incompleteReason"
+                                type="checkbox" value="11">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-8">Draft statement of common ground is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-9" name="incompleteReason"
+                                type="checkbox" value="10" data-aria-controls="conditional-incomplete-reason-9">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-9">Other</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-9">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-10-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-10-1" name="incompleteReason-10" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appellant-case GET /appellant-case/incomplete should render the incomplete reason page and content for a HAS case submitted before 1st April 2026 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal incomplete?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason" name="incompleteReason"
+                                type="checkbox" value="1">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason">Appellant name is not the same on the application form and appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-2" name="incompleteReason"
+                                type="checkbox" value="2" data-aria-controls="conditional-incomplete-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-2">Attachments and/or appendices have not been included to the full statement
+                                    of case</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-2-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-2-1" name="incompleteReason-2" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-3" name="incompleteReason"
+                                type="checkbox" value="3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-3">LPA&#39;s decision notice is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-4" name="incompleteReason"
+                                type="checkbox" value="4" data-aria-controls="conditional-incomplete-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-4">LPA&#39;s decision notice is incorrect or incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-4-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-4-1" name="incompleteReason-4" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-5" name="incompleteReason"
+                                type="checkbox" value="5" data-aria-controls="conditional-incomplete-reason-5">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-5">Documents and/or plans referred in the application form, decision notice
+                                    and appeal covering letter are missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-5">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-5-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-5-1" name="incompleteReason-5" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-6" name="incompleteReason"
+                                type="checkbox" value="6">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-6">Agricultural holding certificate and declaration have not been completed
+                                    on the appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-7" name="incompleteReason"
+                                type="checkbox" value="7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-7">The original application form is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-8" name="incompleteReason"
+                                type="checkbox" value="8" data-aria-controls="conditional-incomplete-reason-8">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-8">The original application form is incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-8">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-8-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-8-1" name="incompleteReason-8" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-9" name="incompleteReason"
+                                type="checkbox" value="9">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-9">Statement of case and ground of appeal are missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-10" name="incompleteReason"
+                                type="checkbox" value="11">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-10">Draft statement of common ground is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-11" name="incompleteReason"
+                                type="checkbox" value="10" data-aria-controls="conditional-incomplete-reason-11">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-11">Other</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-11">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-10-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-10-1" name="incompleteReason-10" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appellant-case GET /appellant-case/incomplete should render the incomplete reason page and content for a HAS case submitted from 1st April 2026 onwards 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal incomplete?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason" name="incompleteReason"
+                                type="checkbox" value="1">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason">Appellant name is not the same on the application form and appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-2" name="incompleteReason"
+                                type="checkbox" value="3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-2">LPA&#39;s decision notice is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-3" name="incompleteReason"
+                                type="checkbox" value="4" data-aria-controls="conditional-incomplete-reason-3">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-3">LPA&#39;s decision notice is incorrect or incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-3">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-4-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-4-1" name="incompleteReason-4" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-4" name="incompleteReason"
+                                type="checkbox" value="5" data-aria-controls="conditional-incomplete-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-4">Documents and/or plans referred in the application form, decision notice
+                                    and appeal covering letter are missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-5-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-5-1" name="incompleteReason-5" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-5" name="incompleteReason"
+                                type="checkbox" value="6">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-5">Agricultural holding certificate and declaration have not been completed
+                                    on the appeal form</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-6" name="incompleteReason"
+                                type="checkbox" value="7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-6">The original application form is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-7" name="incompleteReason"
+                                type="checkbox" value="8" data-aria-controls="conditional-incomplete-reason-7">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-7">The original application form is incomplete</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-7">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="incomplete-reason-8-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="incomplete-reason-8-1" name="incompleteReason-8" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-8" name="incompleteReason"
+                                type="checkbox" value="11">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-8">Draft statement of common ground is missing</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="incomplete-reason-9" name="incompleteReason"
+                                type="checkbox" value="10" data-aria-controls="conditional-incomplete-reason-9">
+                                <label class="govuk-label govuk-checkboxes__label" for="incomplete-reason-9">Other</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-incomplete-reason-9">
                                 <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -2580,10 +2580,13 @@ describe('appellant-case', () => {
 	});
 
 	describe('GET /appellant-case/incomplete', () => {
+		const expeditedAppealTypes = [
+			['HAS', appealData],
+			['CAS advertisement', appealDataCasAdvert],
+			['CAS planning', appealDataCasPlanning]
+		];
+
 		beforeEach(() => {
-			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataNotValidated);
 			nock('http://test/')
 				.get('/appeals/appellant-case-incomplete-reasons')
 				.reply(200, appellantCaseIncompleteReasons);
@@ -2593,43 +2596,109 @@ describe('appellant-case', () => {
 			nock.cleanAll();
 		});
 
-		it('should render the incomplete reason page and content', async () => {
-			const response = await request.get(
-				`${baseUrl}/1${appellantCasePagePath}${incompleteOutcomePagePath}`
-			);
-			const element = parseHtml(response.text);
+		it.each(expeditedAppealTypes)(
+			'should render the incomplete reason page and content for a %s case submitted from 1st April 2026 onwards',
+			async (_, testAppealData) => {
+				nock('http://test/').get('/appeals/1?include=all').reply(200, {
+					testAppealData,
+					appealId: 1
+				});
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, {
+						...appellantCaseDataNotValidated,
+						applicationDate: '2026-04-01T00:00:00.000Z'
+					});
 
-			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Why is the appeal incomplete?</h1>');
-			expect(element.innerHTML).toContain('data-module="govuk-checkboxes">');
+				const response = await request.get(
+					`${baseUrl}/1${appellantCasePagePath}${incompleteOutcomePagePath}`
+				);
+				const element = parseHtml(response.text);
 
-			// Checkbox content check
-			if (!element.textContent) {
-				throw new Error('Test setup failed: The main element was not found in the HTML');
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Why is the appeal incomplete?</h1>');
+				expect(element.innerHTML).toContain('data-module="govuk-checkboxes">');
+
+				// Checkbox content check
+				if (!element.textContent) {
+					throw new Error('Test setup failed: The main element was not found in the HTML');
+				}
+				const textContent = element.textContent.replace(/\s+/g, ' ').trim();
+				expect(textContent).toContain(
+					'Appellant name is not the same on the application form and appeal form'
+				);
+				expect(textContent).not.toContain(
+					'Attachments and/or appendices have not been included to the full statement of case'
+				);
+				expect(textContent).toContain("LPA's decision notice is missing");
+				expect(textContent).toContain("LPA's decision notice is incorrect or incomplete");
+				expect(textContent).toContain(
+					'Documents and/or plans referred in the application form, decision notice and appeal covering letter are missing'
+				);
+				expect(textContent).toContain(
+					'Agricultural holding certificate and declaration have not been completed on the appeal form'
+				);
+				expect(textContent).toContain('The original application form is missing');
+				expect(textContent).toContain('The original application form is incomplete');
+				expect(textContent).not.toContain('Statement of case and ground of appeal are missing');
+				expect(textContent).toContain('Draft statement of common ground is missing');
+				expect(textContent).toContain('Other');
+
+				expect(element.innerHTML).toContain('Continue</button>');
 			}
-			const textContent = element.textContent.replace(/\s+/g, ' ').trim();
-			expect(textContent).toContain(
-				'Appellant name is not the same on the application form and appeal form'
-			);
-			expect(textContent).toContain(
-				'Attachments and/or appendices have not been included to the full statement of case'
-			);
-			expect(textContent).toContain("LPA's decision notice is missing");
-			expect(textContent).toContain("LPA's decision notice is incorrect or incomplete");
-			expect(textContent).toContain(
-				'Documents and/or plans referred in the application form, decision notice and appeal covering letter are missing'
-			);
-			expect(textContent).toContain(
-				'Agricultural holding certificate and declaration have not been completed on the appeal form'
-			);
-			expect(textContent).toContain('The original application form is missing');
-			expect(textContent).toContain('The original application form is incomplete');
-			expect(textContent).toContain('Statement of case and ground of appeal are missing');
-			expect(textContent).toContain('Draft statement of common ground is missing');
-			expect(textContent).toContain('Other');
+		);
 
-			expect(element.innerHTML).toContain('Continue</button>');
-		});
+		it.each(expeditedAppealTypes)(
+			'should render the incomplete reason page and content for a %s case submitted before 1st April 2026',
+			async (_, testAppealData) => {
+				nock('http://test/').get('/appeals/1?include=all').reply(200, {
+					testAppealData,
+					appealId: 1
+				});
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, {
+						...appellantCaseDataNotValidated,
+						applicationDate: '2026-03-02T00:00:00.000Z'
+					});
+
+				const response = await request.get(
+					`${baseUrl}/1${appellantCasePagePath}${incompleteOutcomePagePath}`
+				);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Why is the appeal incomplete?</h1>');
+				expect(element.innerHTML).toContain('data-module="govuk-checkboxes">');
+
+				// Checkbox content check
+				if (!element.textContent) {
+					throw new Error('Test setup failed: The main element was not found in the HTML');
+				}
+				const textContent = element.textContent.replace(/\s+/g, ' ').trim();
+				expect(textContent).toContain(
+					'Appellant name is not the same on the application form and appeal form'
+				);
+				expect(textContent).toContain(
+					'Attachments and/or appendices have not been included to the full statement of case'
+				);
+				expect(textContent).toContain("LPA's decision notice is missing");
+				expect(textContent).toContain("LPA's decision notice is incorrect or incomplete");
+				expect(textContent).toContain(
+					'Documents and/or plans referred in the application form, decision notice and appeal covering letter are missing'
+				);
+				expect(textContent).toContain(
+					'Agricultural holding certificate and declaration have not been completed on the appeal form'
+				);
+				expect(textContent).toContain('The original application form is missing');
+				expect(textContent).toContain('The original application form is incomplete');
+				expect(textContent).toContain('Statement of case and ground of appeal are missing');
+				expect(textContent).toContain('Draft statement of common ground is missing');
+				expect(textContent).toContain('Other');
+
+				expect(element.innerHTML).toContain('Continue</button>');
+			}
+		);
 	});
 
 	describe('POST /appellant-case/incomplete', () => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-incomplete/__tests__/outcome-incomplete.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-incomplete/__tests__/outcome-incomplete.test.js
@@ -10,6 +10,7 @@ import {
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import { jest } from '@jest/globals';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { parseHtml } from '@pins/platform';
 import nock from 'nock';
 import supertest from 'supertest';
@@ -1133,7 +1134,8 @@ describe('getFilteredReasons', () => {
 		];
 		// Expedited appeal conditions
 		const appellantCase = {
-			applicationDate: '2027-04-02',
+			appellantCaseDataNotValidated,
+			applicationDate: '2026-04-01',
 			applicationDecision: 'refused',
 			typeOfPlanningApplication: 'full-appeal'
 		};
@@ -1142,4 +1144,39 @@ describe('getFilteredReasons', () => {
 		expect(reason2).toBeUndefined();
 		expect(filtered.some((r) => r.name === forbiddenString)).toBe(false);
 	});
+
+	it.each([
+		['Householder', APPEAL_TYPE.HOUSEHOLDER],
+		['CAS', APPEAL_TYPE.CAS_PLANNING],
+		['CAS advert', APPEAL_TYPE.CAS_ADVERTISEMENT]
+	])(
+		'should not display the statement of case related options for %s appeals from 1st April 2026 onwards',
+		(_appealTypeLabel, appealType) => {
+			const forbiddenStatementOfCaseString = 'Statement of case and ground of appeal are missing';
+			const forbiddenAttachmentsString =
+				'Attachments and/or appendices have not been included to the full statement of case';
+			const incompleteReasonOptions = [
+				{ id: 1, name: 'Appellant name is not the same on the application form and appeal form' },
+				{ id: 2, name: forbiddenAttachmentsString },
+				{ id: 9, name: forbiddenStatementOfCaseString },
+				{ id: 10, name: 'Other' },
+				{ id: 11, name: 'Draft statement of common ground is missing' }
+			];
+			const appellantCase = {
+				appellantCaseDataNotValidated,
+				applicationDate: '2026-04-01',
+				applicationDecision: 'refused',
+				typeOfPlanningApplication: 'Listed building consent'
+			};
+
+			const filtered = getFilteredReasons(incompleteReasonOptions, appealType, appellantCase);
+			const reason2 = filtered.find((r) => r.id === 2);
+			const reason9 = filtered.find((r) => r.id === 9);
+
+			expect(reason2).toBeUndefined();
+			expect(reason9).toBeUndefined();
+			expect(filtered.some((r) => r.name === forbiddenAttachmentsString)).toBe(false);
+			expect(filtered.some((r) => r.name === forbiddenStatementOfCaseString)).toBe(false);
+		}
+	);
 });

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-incomplete/outcome-incomplete.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-incomplete/outcome-incomplete.service.js
@@ -2,7 +2,7 @@ import { dayMonthYearHourMinuteToISOString } from '#lib/dates.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { DEADLINE_HOUR, DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js';
 import {
-	isAnyEnforcementAppealType,
+	beforeExpeditedOriginalApplicationCutOff,
 	isS78ExpeditedAppealType
 } from '@pins/appeals/utils/appeal-type-checks.js';
 
@@ -125,31 +125,44 @@ export async function setReviewOutcomeForEnforcementNoticeAppellantCase(
 /**
  * @param {Array<{id: number, name: string, hasText: Boolean}>} incompleteReasonOptions
  * @param {string} appealType
- * @param {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} [appellantCase]
+ * @param {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse | undefined} appellantCase
  * @returns {Array<{id: number, name: string, hasText: Boolean}>}
  */
 export function getFilteredReasons(incompleteReasonOptions, appealType, appellantCase) {
-	if (isAnyEnforcementAppealType(appealType)) {
-		if (appealType === APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING) {
+	let isExpedited;
+	switch (appealType) {
+		case APPEAL_TYPE.S78:
+		case APPEAL_TYPE.S78_EXPEDITED:
+			isExpedited = isS78ExpeditedAppealType(
+				appealType,
+				appellantCase?.applicationDate,
+				appellantCase?.applicationDecision,
+				appellantCase?.typeOfPlanningApplication
+			);
+			if (isExpedited) {
+				return incompleteReasonOptions.filter(
+					(reason) => (reason.id !== 2 && reason.id <= 10) || reason.id === 11
+				);
+			} else {
+				return incompleteReasonOptions.filter((reason) => reason.id <= 10 || reason.id === 11);
+			}
+		case APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING:
 			return incompleteReasonOptions.filter(
 				(reason) => reason.id > 9 && reason.id !== 11 && reason.id !== 14
 			);
-		} else {
+		case APPEAL_TYPE.ENFORCEMENT_NOTICE:
 			return incompleteReasonOptions.filter((reason) => reason.id > 9 && reason.id !== 11);
-		}
-	} else {
-		const isExpedited = isS78ExpeditedAppealType(
-			appealType,
-			appellantCase?.applicationDate,
-			appellantCase?.applicationDecision,
-			appellantCase?.typeOfPlanningApplication
-		);
-		if (isExpedited) {
-			return incompleteReasonOptions.filter(
-				(reason) => (reason.id !== 2 && reason.id <= 10) || reason.id === 11
-			);
-		} else {
+		case APPEAL_TYPE.CAS_ADVERTISEMENT:
+		case APPEAL_TYPE.CAS_PLANNING:
+		case APPEAL_TYPE.HOUSEHOLDER:
+			if (beforeExpeditedOriginalApplicationCutOff(appellantCase?.applicationDate)) {
+				return incompleteReasonOptions.filter((reason) => reason.id <= 10 || reason.id === 11);
+			} else {
+				return incompleteReasonOptions.filter(
+					(reason) => (reason.id <= 10 || reason.id === 11) && reason.id !== 9 && reason.id !== 2
+				);
+			}
+		default:
 			return incompleteReasonOptions.filter((reason) => reason.id <= 10 || reason.id === 11);
-		}
 	}
 }

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -552,6 +552,7 @@ export const appealDataEnforcementListedBuilding = {
 
 export const appellantCaseDataNotValidated = {
 	appealId: 1,
+	applicationDate: '',
 	appealReference: 'TEST/919276',
 	typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
 	appealSite: {


### PR DESCRIPTION
- Changed filtering determination logic from IF to SWITCH using appealType condition to improve readability 
- Added extra filtering conditions for HAS, CAS_AD & CAS_PLANNING cases
- Added condition to above-mentioned cases to ensure correct filtering for cases submitted after April 1st
- Updated tests
- Added test
- Updated snapshot

https://pins-ds.atlassian.net/browse/A2-8419