### PR TITLE
fix(infrastructure): accepted cipher suite added to front door now re…

### DIFF
--- a/infrastructure/front-door-docs.tf
+++ b/infrastructure/front-door-docs.tf
@@ -41,8 +41,12 @@ resource "azurerm_cdn_frontdoor_custom_domain" "docs" {
   provider                 = azurerm.front_door
 
   tls {
-    certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS12"
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
+
+    cipher_suite {
+      type = "TLS12_2023"
+    }
   }
 }
 

--- a/infrastructure/front-door-web.tf
+++ b/infrastructure/front-door-web.tf
@@ -42,8 +42,12 @@ resource "azurerm_cdn_frontdoor_custom_domain" "web" {
   provider                 = azurerm.front_door
 
   tls {
-    certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS12"
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
+
+    cipher_suite {
+      type = "TLS12_2023"
+    }
   }
 }
 


### PR DESCRIPTION
…quired (no-ticket)

## Describe your changes

Sets front door domain defaults to avoid unexpected changes
- cipher suite block appears to have become mandatory in azurerm v4.72