### PR TITLE
fix(api): amend default caseStartedDate hour to 10am from 00 (A2-7916)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -1286,7 +1286,8 @@ describe('appeal timetables routes', () => {
 				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
 						appealId: id,
-						details: 'Appeal started\nAppeal procedure: Part 1',
+						details:
+							'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: Part 1',
 						loggedAt: expect.any(Date),
 						userId: 1
 					}
@@ -1425,7 +1426,10 @@ describe('appeal timetables routes', () => {
 
 						const auditDetails =
 							appealType === 'fullPlanning'
-								? ['The case timeline was created', 'Appeal started\nAppeal procedure: hearing']
+								? [
+										'The case timeline was created',
+										'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: hearing'
+									]
 								: ['The case timeline was created'];
 
 						auditDetails.forEach((details) => {
@@ -1553,7 +1557,7 @@ describe('appeal timetables routes', () => {
 						expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 							where: { id },
 							data: {
-								caseStartedDate: '2024-06-04T23:00:00.000Z',
+								caseStartedDate: '2024-06-05T09:00:00.000Z',
 								caseUpdatedDate: new Date('2024-06-05T22:50:00.000Z'),
 								hearing: {
 									upsert: {
@@ -1580,7 +1584,10 @@ describe('appeal timetables routes', () => {
 
 						const auditDetails =
 							appealType === 'fullPlanning'
-								? ['The case timeline was created', 'Appeal started\nAppeal procedure: hearing']
+								? [
+										'The case timeline was created',
+										'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: hearing'
+									]
 								: ['The case timeline was created'];
 
 						auditDetails.forEach((details) => {
@@ -1709,7 +1716,7 @@ describe('appeal timetables routes', () => {
 						expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 							where: { id },
 							data: {
-								caseStartedDate: '2024-06-04T23:00:00.000Z',
+								caseStartedDate: '2024-06-05T09:00:00.000Z',
 								caseUpdatedDate: new Date('2024-06-05T22:50:00.000Z'),
 								hearing: {
 									upsert: {
@@ -1764,7 +1771,10 @@ describe('appeal timetables routes', () => {
 
 						const auditDetails =
 							appealType === 'fullPlanning'
-								? ['The case timeline was created', 'Appeal started\nAppeal procedure: hearing']
+								? [
+										'The case timeline was created',
+										'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: hearing'
+									]
 								: ['The case timeline was created'];
 
 						auditDetails.forEach((details) => {
@@ -1893,7 +1903,10 @@ describe('appeal timetables routes', () => {
 
 						const auditDetails =
 							appealType === 'fullPlanning'
-								? ['The case timeline was created', 'Appeal started\nAppeal procedure: hearing']
+								? [
+										'The case timeline was created',
+										'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: hearing'
+									]
 								: ['The case timeline was created'];
 
 						auditDetails.forEach((details) => {
@@ -2087,7 +2100,7 @@ describe('appeal timetables routes', () => {
 
 					const auditDetails = [
 						'The case timeline was created',
-						'Appeal started\nAppeal procedure: written'
+						'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: written'
 					];
 
 					auditDetails.forEach((details) => {
@@ -2242,7 +2255,7 @@ describe('appeal timetables routes', () => {
 
 					const auditDetails = [
 						'The case timeline was created',
-						'Appeal started\nAppeal procedure: written'
+						'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: written'
 					];
 
 					auditDetails.forEach((details) => {
@@ -2380,7 +2393,7 @@ describe('appeal timetables routes', () => {
 
 					const auditDetails = [
 						'The case timeline was created',
-						'Appeal started\nAppeal procedure: written'
+						'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: written'
 					];
 
 					auditDetails.forEach((details) => {
@@ -2530,7 +2543,7 @@ describe('appeal timetables routes', () => {
 
 					const auditDetails = [
 						'The case timeline was created',
-						'Appeal started\nAppeal procedure: written'
+						'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: written'
 					];
 
 					auditDetails.forEach((details) => {
@@ -2659,7 +2672,7 @@ describe('appeal timetables routes', () => {
 
 					const auditDetails = [
 						'The case timeline was created',
-						'Appeal started\nAppeal procedure: written'
+						'Appeal started with caseStartedDate of 2024-06-05T09:00:00.000Z\nAppeal procedure: written'
 					];
 
 					auditDetails.forEach((details) => {

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -15,7 +15,12 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { trimAppealType } from '#utils/string-utils.js';
 import { updatePersonalList } from '#utils/update-personal-list.js';
 import { PROCEDURE_TYPE_ID_MAP, PROCEDURE_TYPE_MAP } from '@pins/appeals/constants/common.js';
-import { DEADLINE_HOUR, DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js';
+import {
+	DAYTIME_HOUR,
+	DAYTIME_MINUTE,
+	DEADLINE_HOUR,
+	DEADLINE_MINUTE
+} from '@pins/appeals/constants/dates.js';
 import {
 	AUDIT_TRAIL_CASE_STARTED,
 	AUDIT_TRAIL_CASE_TIMELINE_CREATED,
@@ -430,7 +435,7 @@ const startCase = async (
 			null,
 			isS78Expedited
 		);
-		const startDateWithTimeCorrection = setTimeInTimeZone(startedAt, 0, 0);
+		const startDateWithTimeCorrection = setTimeInTimeZone(startedAt, DAYTIME_HOUR, DAYTIME_MINUTE);
 
 		const procedureTypeId = procedureType && PROCEDURE_TYPE_ID_MAP[procedureType];
 
@@ -462,6 +467,7 @@ const startCase = async (
 				appealId: appeal.id,
 				azureAdUserId,
 				details: stringTokenReplacement(AUDIT_TRAIL_CASE_STARTED, [
+					startDateWithTimeCorrection.toISOString(),
 					mapProcedureTypeForAudit(procedureType)
 				])
 			});

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -104,7 +104,8 @@ export const AUDIT_TRAIL_UNASSIGNED_INSPECTOR =
 	'The inspector {replacement0} was unassigned from the case';
 export const AUDIT_TRAIL_MODIFIED_APPEAL = 'The {replacement0} property was updated';
 export const AUDIT_TRAIL_ENVIRONMENTAL_SERVICES_TEAM_REVIEW = 'Environmental services team review';
-export const AUDIT_TRAIL_CASE_STARTED = 'Appeal started\nAppeal procedure: {replacement0}';
+export const AUDIT_TRAIL_CASE_STARTED =
+	'Appeal started with caseStartedDate of {replacement0}\nAppeal procedure: {replacement1}';
 export const AUDIT_TRAIL_CASE_TIMELINE_CREATED = 'The case timeline was created';
 export const AUDIT_TRAIL_CASE_TIMELINE_UPDATED = 'The case timeline was updated';
 export const AUDIT_TRAIL_TIMETABLE_DUE_DATE_CHANGED =


### PR DESCRIPTION
## Describe your changes

Uses the DAYTIME_HOUR constant when setting caseStarted date - this is time corrected and prevents cases started in BST having a caseStartedDate of 23:00 the day before.

caseStartedDate is also added to the relevant audit trail message.

NOTE - this does **not** amend the calculation of the appeal timetable.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7916)
