### PR TITLE
fix: update empty state copy for accepted and rejected IP comment tabs

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/interested-party-comments.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/interested-party-comments.test.js
@@ -206,7 +206,7 @@ describe('interested-party-comments', () => {
 			expect(awaitingMessage?.textContent?.trim()).toBe('Awaiting comments');
 		});
 
-		it('should render interestedPartyComments page with "No valid comments" message when no valid data', async () => {
+		it('should render interestedPartyComments page with "No accepted comments" message when no valid data', async () => {
 			const response = await request.get(`${baseUrl}/2/interested-party-comments`);
 
 			expect(response.statusCode).toBe(200);
@@ -217,10 +217,10 @@ describe('interested-party-comments', () => {
 
 			const validMessage = validTable?.querySelector('p');
 			expect(validMessage).not.toBeNull();
-			expect(validMessage?.textContent?.trim()).toBe('No valid comments');
+			expect(validMessage?.textContent?.trim()).toBe('No accepted comments');
 		});
 
-		it('should render interestedPartyComments page with "No invalid comments" message when no invalid data', async () => {
+		it('should render interestedPartyComments page with "No rejected comments" message when no invalid data', async () => {
 			const response = await request.get(`${baseUrl}/2/interested-party-comments`);
 
 			expect(response.statusCode).toBe(200);
@@ -231,7 +231,7 @@ describe('interested-party-comments', () => {
 
 			const invalidMessage = invalidTable?.querySelector('p');
 			expect(invalidMessage).not.toBeNull();
-			expect(invalidMessage?.textContent?.trim()).toBe('No invalid comments');
+			expect(invalidMessage?.textContent?.trim()).toBe('No rejected comments');
 		});
 	});
 

--- a/appeals/web/src/server/views/appeals/appeal/interested-party-comments.njk
+++ b/appeals/web/src/server/views/appeals/appeal/interested-party-comments.njk
@@ -64,14 +64,14 @@
             label: "Accepted",
             id: "valid",
             panel: {
-              html: govukTable(pageContent.validTable) | safe if pageContent.validTable | length else '<p class="govuk-body">No valid comments</p>'
+              html: govukTable(pageContent.validTable) | safe if pageContent.validTable | length else '<p class="govuk-body">No accepted comments</p>'
             }
           },
           {
             label: "Rejected",
             id: "invalid",
             panel: {
-              html: govukTable(pageContent.invalidTable) | safe if pageContent.invalidTable | length else '<p class="govuk-body">No invalid comments</p>'
+              html: govukTable(pageContent.invalidTable) | safe if pageContent.invalidTable | length else '<p class="govuk-body">No rejected comments</p>'
             }
           }
         ]


### PR DESCRIPTION
Replace 'No valid comments' with 'No accepted comments' on the Accepted tab and 'No invalid comments' with 'No rejected comments' on the Rejected tab. Update corresponding unit test descriptions and assertions to match. Resolves A2-8320

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8320)
