### PR TITLE
fix(api): handle failed ip comment emails on decisions (a2-8382)

### DIFF
--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -1195,6 +1195,141 @@ describe('decision routes', () => {
 
 			expect(response.status).toEqual(201);
 		});
+
+		test('de-dupes exact duplicate commenter emails', async () => {
+			const appeal = {
+				...fullPlanningAppeal,
+				appealStatus: [
+					{
+						status: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+						valid: true
+					}
+				]
+			};
+
+			const outcome = 'allowed';
+			databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+			databaseConnector.inspectorDecision.create.mockResolvedValue({});
+			databaseConnector.representation.findMany.mockResolvedValue([
+				{ represented: { email: 'dup@test.com' } },
+				{ represented: { email: 'dup@test.com' } }
+			]);
+
+			await request
+				.post(`/appeals/${appeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome,
+							documentDate: new Date().toISOString(),
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			const recipients = mockNotifySend.mock.calls.map(([arg]) => arg.recipientEmail);
+			expect(recipients.filter((e) => e === 'dup@test.com')).toHaveLength(1);
+		});
+
+		test('trims and normalizes commenter emails before de-duping', async () => {
+			const appeal = {
+				...fullPlanningAppeal,
+				appealStatus: [
+					{
+						status: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+						valid: true
+					}
+				]
+			};
+
+			const outcome = 'allowed';
+			databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+			databaseConnector.inspectorDecision.create.mockResolvedValue({});
+			databaseConnector.representation.findMany.mockResolvedValue([
+				{ represented: { email: ' Dup@Test.com ' } },
+				{ represented: { email: 'dup@test.com' } },
+				{ represented: { email: 'DUP@test.com' } }
+			]);
+
+			await request
+				.post(`/appeals/${appeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome,
+							documentDate: new Date().toISOString(),
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			const recipients = mockNotifySend.mock.calls.map(([arg]) => arg.recipientEmail);
+			expect(recipients.filter((e) => e === 'dup@test.com')).toHaveLength(1);
+			expect(recipients).not.toContain(' Dup@Test.com ');
+			expect(recipients).not.toContain('DUP@test.com');
+		});
+
+		test('handles error from notify for interested party', async () => {
+			const appeal = {
+				...fullPlanningAppeal,
+				appealStatus: [
+					{
+						status: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+						valid: true
+					}
+				]
+			};
+
+			const outcome = 'allowed';
+			databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+			databaseConnector.inspectorDecision.create.mockResolvedValue({});
+			databaseConnector.representation.findMany.mockResolvedValue([
+				{ represented: { email: 'a@test.com' } },
+				{ represented: { email: 'b@test.com' } },
+				{ represented: { email: 'c@test.com' } }
+			]);
+
+			mockNotifySend.mockImplementation(({ recipientEmail }) => {
+				if (recipientEmail === 'a@test.com' || recipientEmail === 'b@test.com') {
+					return Promise.reject(new Error('Notify error'));
+				}
+
+				return Promise.resolve({});
+			});
+
+			await request
+				.post(`/appeals/${appeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome,
+							documentDate: new Date().toISOString(),
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(mockNotifySend).toHaveBeenCalledTimes(5);
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						appealId: appeal.id,
+						details: expect.stringContaining(
+							`Failed to send decision email to the following interested parties: a@test.com, b@test.com`
+						)
+					})
+				})
+			);
+		});
 	});
 
 	describe('sendNewDecisionLetter', () => {
@@ -1354,6 +1489,65 @@ describe('decision routes', () => {
 			expect(recipients.filter((e) => e === 'dup@test.com')).toHaveLength(1);
 		});
 
+		test('trims and normalizes commenter emails before de-duping', async () => {
+			databaseConnector.representation.findMany.mockResolvedValue([
+				{ represented: { email: ' Dup@Test.com ' } },
+				{ represented: { email: 'dup@test.com' } },
+				{ represented: { email: 'DUP@test.com' } }
+			]);
+
+			await sendNewDecisionLetter(
+				correctAppealState,
+				correctionNotice,
+				azureAdUserId,
+				mockNotifyClient,
+				decisionDate
+			);
+
+			const recipients = mockNotifySend.mock.calls.map(([arg]) => arg.recipientEmail);
+			expect(recipients.filter((e) => e === 'dup@test.com')).toHaveLength(1);
+			expect(recipients).not.toContain(' Dup@Test.com ');
+			expect(recipients).not.toContain('DUP@test.com');
+		});
+
+		test('handles error from notify for interested party', async () => {
+			databaseConnector.representation.findMany.mockResolvedValue([
+				{ represented: { email: 'a@test.com' } },
+				{ represented: { email: 'b@test.com' } },
+				{ represented: { email: 'c@test.com' } }
+			]);
+
+			mockNotifySend.mockImplementation(({ recipientEmail }) => {
+				if (recipientEmail === 'a@test.com' || recipientEmail === 'b@test.com') {
+					return Promise.reject(new Error('Notify error'));
+				}
+
+				return Promise.resolve({});
+			});
+
+			await expect(
+				sendNewDecisionLetter(
+					correctAppealState,
+					correctionNotice,
+					azureAdUserId,
+					mockNotifyClient,
+					decisionDate
+				)
+			).resolves.not.toThrow();
+
+			expect(mockNotifySend).toHaveBeenCalledTimes(5);
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						appealId: correctAppealState.id,
+						details: expect.stringContaining(
+							`Failed to send correction notice email to the following interested parties: a@test.com, b@test.com`
+						)
+					})
+				})
+			);
+		});
+
 		test('falls back to inspectorDecision date when decisionDate is missing', async () => {
 			const caseDecisionOutcomeDate = new Date('2024-06-15');
 			correctAppealState.inspectorDecision = { caseDecisionOutcomeDate };
@@ -1412,12 +1606,14 @@ describe('decision routes', () => {
 				decisionDate
 			);
 
-			expect(databaseConnector.representation.count).toHaveBeenCalledWith({
-				where: {
-					appealId: { in: [appealWithMissingEmails.id, ...childAppeals.map((a) => a.childId)] },
-					representationType: { in: ['comment'] }
-				}
-			});
+			expect(databaseConnector.representation.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: {
+						appealId: { in: [appealWithMissingEmails.id, ...childAppeals.map((a) => a.childId)] },
+						representationType: 'comment'
+					}
+				})
+			);
 		});
 	});
 });

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -3,7 +3,7 @@ import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.j
 import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { duplicateFiles } from '#endpoints/link-appeals/link-appeals.service.js';
-import { getRepresentations } from '#endpoints/representations/representations.service.js';
+import { getInterestedPartyEmails } from '#endpoints/representations/representations.service.js';
 import { generateNotifyPreview } from '#notify/emulate-notify.js';
 import { notifySend, renderTemplate } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
@@ -12,6 +12,7 @@ import transitionState from '#state/transition-state.js';
 import { isFeatureActive } from '#utils/feature-flags.js';
 import { getFeedbackLinkFromAppealTypeKey } from '#utils/feedback-form-link.js';
 import { getEnforcementReference } from '#utils/get-enforcement-reference.js';
+import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { trimAppealType } from '#utils/string-utils.js';
 import { updatePersonalList } from '#utils/update-personal-list.js';
@@ -42,6 +43,14 @@ import {
 /** @typedef {import('@pins/appeals.api').Schema.Document} Document */
 
 const environment = loadEnvironment(process.env.NODE_ENV);
+
+const INTERESTED_PARTY_NOTIFY_BATCH_SIZE = 20;
+const INTERESTED_PARTY_NOTIFY_BATCH_DELAY_MS = 250;
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  *
@@ -199,12 +208,7 @@ export const publishDecision = async (
 
 	const lpaEmail = appeal.lpa?.email || '';
 
-	const representations = await getRepresentations([appeal.id], 1, 1000, {
-		representationType: ['comment']
-	});
-	const interestedPartyEmails = representations?.comments
-		.map((comment) => comment.represented?.email)
-		.filter(Boolean);
+	const interestedPartyEmails = await getInterestedPartyEmails([appeal.id]);
 
 	const nextState =
 		outcome === APPEAL_CASE_DECISION_OUTCOME.INVALID
@@ -278,24 +282,6 @@ export const publishDecision = async (
 		}
 	}
 
-	if (interestedPartyEmails.length > 0) {
-		for (const email of interestedPartyEmails) {
-			await notifySend({
-				azureAdUserId,
-				templateName: invalidDecisionReason
-					? 'decision-is-invalid-interested-party'
-					: 'decision-is-allowed-split-dismissed-interested-party',
-				notifyClient,
-				recipientEmail: email,
-				personalisation: {
-					...personalisation,
-					feedback_link: feedbackLinkForInterestedParty,
-					case_team_email_address: caseTeamEmail
-				}
-			});
-		}
-	}
-
 	await createAuditTrail({
 		appealId: appeal.id,
 		azureAdUserId: azureAdUserId,
@@ -304,6 +290,37 @@ export const publishDecision = async (
 
 	await transitionState(appeal.id, azureAdUserId, nextState);
 	await broadcasters.broadcastAppeal(appeal.id);
+
+	/** @type {string[]} */
+	if (interestedPartyEmails.length > 0) {
+		try {
+			await batchSendNotifyToInterestedParties(
+				interestedPartyEmails,
+				(email) =>
+					notifySend({
+						azureAdUserId,
+						templateName: invalidDecisionReason
+							? 'decision-is-invalid-interested-party'
+							: 'decision-is-allowed-split-dismissed-interested-party',
+						notifyClient,
+						recipientEmail: email,
+						personalisation: {
+							...personalisation,
+							feedback_link: feedbackLinkForInterestedParty,
+							case_team_email_address: caseTeamEmail
+						}
+					}),
+				appeal.id,
+				azureAdUserId,
+				'decision'
+			);
+		} catch (err) {
+			logger.error(
+				err,
+				`Error sending decision email to interested parties on appeal: ${appeal.id}`
+			);
+		}
+	}
 
 	return result;
 };
@@ -481,15 +498,7 @@ export const sendNewDecisionLetter = async (
 		Number(appeal.id),
 		...childAppeals.map((childAppeal) => Number(childAppeal?.childId))
 	];
-	const representations = await getRepresentations(appealIds, 1, 1000, {
-		representationType: ['comment']
-	});
-
-	const interestedPartyEmails = [
-		...new Set(
-			representations.comments.map((comment) => comment.represented?.email).filter(Boolean)
-		)
-	];
+	const interestedPartyEmails = await getInterestedPartyEmails(appealIds);
 
 	const lpaEmail = appeal.lpa?.email;
 
@@ -544,24 +553,6 @@ export const sendNewDecisionLetter = async (
 		});
 	}
 
-	if (interestedPartyEmails.length > 0) {
-		const interestedParyPersonalisation = {
-			...personalisation,
-			feedback_link: FEEDBACK_FORM_LINKS.COMMENT_ON_APPEAL
-		};
-		await Promise.all(
-			interestedPartyEmails.map(async (email) => {
-				await notifySend({
-					azureAdUserId,
-					templateName: 'correction-notice-decision-interested-party',
-					notifyClient,
-					recipientEmail: email,
-					personalisation: interestedParyPersonalisation
-				});
-			})
-		);
-	}
-
 	await createAuditTrail({
 		appealId: appeal.id,
 		azureAdUserId,
@@ -569,4 +560,89 @@ export const sendNewDecisionLetter = async (
 	});
 
 	await broadcasters.broadcastAppeal(appeal.id);
+
+	/** @type {string[]} */
+	if (interestedPartyEmails.length > 0) {
+		try {
+			const interestedPartyPersonalisation = {
+				...personalisation,
+				feedback_link: FEEDBACK_FORM_LINKS.COMMENT_ON_APPEAL
+			};
+			await batchSendNotifyToInterestedParties(
+				interestedPartyEmails,
+				(email) =>
+					notifySend({
+						azureAdUserId,
+						templateName: 'correction-notice-decision-interested-party',
+						notifyClient,
+						recipientEmail: email,
+						personalisation: interestedPartyPersonalisation
+					}),
+				appeal.id,
+				azureAdUserId,
+				'correction notice'
+			);
+		} catch (err) {
+			logger.error(
+				err,
+				`Error sending correction notice email to interested parties on appeal: ${appeal.id}`
+			);
+		}
+	}
+};
+
+/**
+ * @param {string[]} emails
+ * @param {function(string): Promise<void>} notifyFunction
+ * @param {number} appealId
+ * @param {string} azureAdUserId
+ * @param {string} emailTypeLabel
+ */
+const batchSendNotifyToInterestedParties = async (
+	emails,
+	notifyFunction,
+	appealId,
+	azureAdUserId,
+	emailTypeLabel
+) => {
+	if (emails.length === 0) {
+		return;
+	}
+
+	const uniqueEmails = [
+		...new Set(emails.map((email) => email.trim().toLowerCase()).filter(Boolean))
+	];
+
+	/** @type {string[]} */
+	const failedEmails = [];
+	for (let i = 0; i < uniqueEmails.length; i += INTERESTED_PARTY_NOTIFY_BATCH_SIZE) {
+		const emailBatch = uniqueEmails.slice(i, i + INTERESTED_PARTY_NOTIFY_BATCH_SIZE);
+
+		const results = await Promise.allSettled(emailBatch.map((email) => notifyFunction(email)));
+
+		results.forEach((res, index) => {
+			if (res.status === 'rejected') {
+				const email = emailBatch[index];
+				logger.error(
+					res.reason,
+					`Error sending ${emailTypeLabel} email to interested party email: ${email}`
+				);
+				failedEmails.push(email);
+			}
+		});
+
+		if (i + INTERESTED_PARTY_NOTIFY_BATCH_SIZE < uniqueEmails.length) {
+			await delay(INTERESTED_PARTY_NOTIFY_BATCH_DELAY_MS);
+		}
+	}
+
+	if (failedEmails.length > 0) {
+		await createAuditTrail({
+			appealId: appealId,
+			azureAdUserId: azureAdUserId,
+			details:
+				`Failed to send ${emailTypeLabel} email to the following interested parties: ` +
+				failedEmails.join(', ')
+		});
+	}
 };

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -77,6 +77,14 @@ export const getRepresentations = async (
 
 /**
  * @param {number[]} appealIds
+ * @returns {Promise<string[]>}
+ */
+export const getInterestedPartyEmails = async (appealIds) => {
+	return representationRepository.getInterestedPartyEmails(appealIds);
+};
+
+/**
+ * @param {number[]} appealIds
  * @param {{ status?: string }} [options]
  * */
 export const getRepresentationCounts = async (appealIds, options = {}) => {

--- a/appeals/api/src/server/repositories/representation.repository.js
+++ b/appeals/api/src/server/repositories/representation.repository.js
@@ -380,8 +380,37 @@ const updateRejectionReasons = async (repId, rejectionReasons) => {
 	});
 };
 
+/**
+ * @param {number[]} appealIds
+ * @returns {Promise<string[]>}
+ */
+const getInterestedPartyEmails = async (appealIds) => {
+	if (appealIds.length === 0) {
+		return [];
+	}
+
+	const ipReps = await databaseConnector.representation.findMany({
+		where: {
+			appealId: { in: appealIds },
+			representationType: APPEAL_REPRESENTATION_TYPE.COMMENT
+		},
+		select: {
+			represented: {
+				select: {
+					email: true
+				}
+			}
+		}
+	});
+
+	return ipReps
+		.map((comment) => comment.represented?.email)
+		.filter((email) => email !== undefined && email !== null);
+};
+
 export default {
 	getById,
+	getInterestedPartyEmails,
 	getRepresentations,
 	getRepresentationCounts,
 	updateRepresentationById,


### PR DESCRIPTION
## Describe your changes

IP comments could be a large number, has failed in prod causing the decision to fail and rollback leading the case officer to retry multiple times spamming users with emails

- improves performance of email lookup
- handles sending in batches with delay to hopefully help avoid any notify limits
- errors don't fail the decision process, logs + write to audit instead

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-8382
