### PR TITLE
fix(web): add download link to enf notice withdrawal audit (A2-8154)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
@@ -22,6 +22,7 @@ import {
 	AUDIT_TRIAL_RULE_6_PARTY_ID
 } from '@pins/appeals/constants/support.js';
 import { parseHtml } from '@pins/platform';
+import { APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 import nock from 'nock';
 import supertest from 'supertest';
 
@@ -112,6 +113,22 @@ describe('audit', () => {
 		it('should include the redaction status in the audit log display text for a supporting document', async () => {
 			const result = await tryMapDocument(1, auditTrailEntryText, docInfo, null);
 			expect(result).toMatch(/unredacted|no redaction required|redacted/);
+		});
+
+		it('should return audit trail entry with download link for enforcement notice withdrawal', async () => {
+			const auditTrailEntryText = `Document enforcementNoticeWithdrawal.docx uploaded (version 1, ${randomRedactStatus})`;
+			const docInfo = {
+				name: 'enforcementNoticeWithdrawal.docx',
+				documentGuid: 'efac1b7f-71c6-4780-bf22-edd0b0531914',
+				stage: 'cancellation',
+				folderId: 61306,
+				documentType: APPEAL_DOCUMENT_TYPE.LPA_ENFORCEMENT_NOTICE_WITHDRAWAL
+			};
+
+			const result = await tryMapDocument(1, auditTrailEntryText, docInfo, null);
+			expect(result).toEqual(
+				`Document <a class="govuk-link" href="/documents/1/download/${docInfo.documentGuid}/${docInfo.name}">${docInfo.name}</a> uploaded (version 1, ${randomRedactStatus})`
+			);
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
@@ -203,6 +203,10 @@ export const tryMapDocument = (appealId, log, docInfo, lpaqId) => {
 			const repAuditDisplayName = name.replace(/[a-f\d-]{36}_/, '');
 			return log.replace(name, `<a class="govuk-link" href="#">${repAuditDisplayName}</a>`);
 		}
+		case APPEAL_CASE_STAGE.CANCELLATION: {
+			const url = `/documents/${appealId}/download/${documentGuid}/${name}`;
+			return log.replace(name, `<a class="govuk-link" href="${url}">${name}</a>`);
+		}
 	}
 
 	return log;


### PR DESCRIPTION
## Describe your changes

Adds a download href to the doc name / link in audit trail message in case history when an enforcement notice is withdrawn.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8154)
