### PR TITLE
feat(web): changing bys rows for enforcement and elb appellant case (…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-main.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-main.test.js.snap
@@ -2583,14 +2583,11 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="before-you-start">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have you received an enforcement notice?</dt>
-                            <dd                             class="govuk-summary-list__value">Yes</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Local planning authority</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is your enforcement notice about a listed building?</dt>
-                            <dd                             class="govuk-summary-list__value">Yes</dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                            <dd                             class="govuk-summary-list__value">Enforcement listed building and conservation area</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the issue date on your enforcement notice?</dt>
                             <dd                             class="govuk-summary-list__value">1 January 2021</dd>
@@ -2895,21 +2892,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="before-you-start">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have you received an enforcement notice?</dt>
-                            <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/enforcement-notice/change">Change<span class="govuk-visually-hidden"> Have you received an enforcement notice? (Before you start)</span></a>
-                                </dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Local planning authority</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/change-appeal-details/local-planning-authority"
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Local planning authority (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is your enforcement notice about a listed building?</dt>
-                            <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/enforcement-notice-listed-building/change">Change<span class="govuk-visually-hidden"> Is your enforcement notice about a listed building? (Before you start)</span></a>
-                                </dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                            <dd                             class="govuk-summary-list__value">Enforcement listed building and conservation area</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the issue date on your enforcement notice?</dt>
                             <dd                             class="govuk-summary-list__value">1 January 2021</dd>
@@ -3349,17 +3339,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="before-you-start">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have you received an enforcement notice?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Local planning authority</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/change-appeal-details/local-planning-authority"
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Local planning authority (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is your enforcement notice about a listed building?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                            <dd                             class="govuk-summary-list__value">Full planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the issue date on your enforcement notice?</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
@@ -4381,21 +4368,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="before-you-start">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have you received an enforcement notice?</dt>
-                            <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/enforcement-notice/change">Change<span class="govuk-visually-hidden"> Have you received an enforcement notice? (Before you start)</span></a>
-                                </dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Local planning authority</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/change-appeal-details/local-planning-authority"
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Local planning authority (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is your enforcement notice about a listed building?</dt>
-                            <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/enforcement-notice-listed-building/change">Change<span class="govuk-visually-hidden"> Is your enforcement notice about a listed building? (Before you start)</span></a>
-                                </dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                            <dd                             class="govuk-summary-list__value">Enforcement listed building and conservation area</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the issue date on your enforcement notice?</dt>
                             <dd                             class="govuk-summary-list__value">1 January 2021</dd>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-main.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-main.test.js
@@ -36,6 +36,10 @@ const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 const appellantCasePagePath = '/appellant-case';
 const notificationBannerElement = '.govuk-notification-banner';
+const appellantCaseDataNotValidatedNoEnforcementNotice = {
+	...JSON.parse(JSON.stringify(appellantCaseDataNotValidated)),
+	enforcementNotice: { isReceived: false, isListedBuilding: false }
+};
 
 describe('appellant-case-main', () => {
 	beforeEach(installMockApi);
@@ -50,7 +54,7 @@ describe('appellant-case-main', () => {
 		beforeEach(() => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataNotValidated);
+				.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
@@ -62,7 +66,7 @@ describe('appellant-case-main', () => {
 		it('should render the appellant case page with the expected common Before you start content', async () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataNotValidated);
+				.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
 			const element = parseHtml(response.text);
@@ -87,7 +91,7 @@ describe('appellant-case-main', () => {
 		it('should render the appellant case page with the expected content (Householder)', async () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataNotValidated);
+				.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
 			const element = parseHtml(response.text);
@@ -136,7 +140,7 @@ describe('appellant-case-main', () => {
 				nock('http://test/')
 					.get('/appeals/2/appellant-cases/0')
 					.reply(200, {
-						...appellantCaseDataNotValidated,
+						...appellantCaseDataNotValidatedNoEnforcementNotice,
 						applicationDate: '2026-03-31T12:00:00.000Z'
 					});
 
@@ -164,7 +168,7 @@ describe('appellant-case-main', () => {
 				nock('http://test/')
 					.get('/appeals/2/appellant-cases/0')
 					.reply(200, {
-						...appellantCaseDataNotValidated,
+						...appellantCaseDataNotValidatedNoEnforcementNotice,
 						applicationDate: '2026-04-01T00:00:00.000Z'
 					});
 
@@ -186,7 +190,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL
 				});
 
@@ -242,7 +246,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/3/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.LISTED_BUILDING
 				});
 
@@ -296,7 +300,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					typeOfPlanningApplication:
 						APPEAL_TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
 				});
@@ -345,7 +349,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.ADVERTISEMENT
 				});
 
@@ -407,7 +411,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.ADVERTISEMENT
 				});
 
@@ -482,7 +486,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					typeOfPlanningApplication:
 						APPEAL_TYPE_OF_PLANNING_APPLICATION.LAWFUL_DEVELOPMENT_CERTIFICATE
 				});
@@ -568,7 +572,7 @@ describe('appellant-case-main', () => {
 				});
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
-				.reply(200, appellantCaseDataNotValidated);
+				.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 
 			const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
 			const element = parseHtml(response.text);
@@ -607,7 +611,7 @@ describe('appellant-case-main', () => {
 					});
 				nock('http://test/')
 					.get('/appeals/2/appellant-cases/0')
-					.reply(200, appellantCaseDataNotValidated);
+					.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 
 				const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
 				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
@@ -639,7 +643,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					enforcementNotice: {
 						isReceived: true,
 						isListedBuilding: true,
@@ -743,7 +747,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					enforcementNotice: {
 						isReceived: true,
 						isListedBuilding: true,
@@ -846,7 +850,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					enforcementNotice: {
 						isReceived: true,
 						isListedBuilding: true,
@@ -947,7 +951,7 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/2/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					enforcementNotice: {
 						isReceived: null,
 						isListedBuilding: null,
@@ -1094,7 +1098,7 @@ describe('appellant-case-main', () => {
 				});
 				nock('http://test/')
 					.get('/appeals/1/appellant-cases/0')
-					.reply(200, appellantCaseDataNotValidated);
+					.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 				nock('http://test/')
 					.get('/appeals/document-redaction-statuses')
 					.reply(200, documentRedactionStatuses);
@@ -1752,7 +1756,7 @@ describe('appellant-case-main', () => {
 						.persist();
 					nock('http://test/')
 						.get(`/appeals/${appealId}/appellant-cases/0`)
-						.reply(200, appellantCaseDataNotValidated);
+						.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 					nock('http://test/')
 						.get('/appeals/document-redaction-statuses')
 						.reply(200, documentRedactionStatuses)
@@ -1856,7 +1860,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/1/appellant-cases/3')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							siteAccessRequired: {
 								isRequired: true,
 								details: text300Characters
@@ -1885,7 +1889,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/1/appellant-cases/3')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							siteAccessRequired: {
 								isRequired: true,
 								details: text301Characters
@@ -1916,7 +1920,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/1/appellant-cases/3')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							healthAndSafety: {
 								hasIssues: true,
 								details: text300Characters
@@ -1945,7 +1949,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/1/appellant-cases/3')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							healthAndSafety: {
 								hasIssues: true,
 								details: text301Characters
@@ -1976,7 +1980,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/1/appellant-cases/3')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							developmentDescription: {
 								details: text300Characters
 							}
@@ -2004,7 +2008,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/1/appellant-cases/3')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							developmentDescription: {
 								details: text301Characters
 							}
@@ -2035,7 +2039,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/2/appellant-cases/0')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							appellantProcedurePreferenceDetails: text300Characters
 						});
 
@@ -2062,7 +2066,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/2/appellant-cases/0')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							appellantProcedurePreferenceDetails: text301Characters
 						});
 
@@ -2091,7 +2095,7 @@ describe('appellant-case-main', () => {
 					nock('http://test/')
 						.get('/appeals/2/appellant-cases/0')
 						.reply(200, {
-							...appellantCaseDataNotValidated,
+							...appellantCaseDataNotValidatedNoEnforcementNotice,
 							enforcementNotice: {
 								isReceived: true
 							},
@@ -2131,13 +2135,15 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					documents: {
-						...appellantCaseDataNotValidated.documents,
+						...appellantCaseDataNotValidatedNoEnforcementNotice.documents,
 						appellantCaseCorrespondence: {
-							...appellantCaseDataNotValidated.documents.appellantCaseCorrespondence,
+							...appellantCaseDataNotValidatedNoEnforcementNotice.documents
+								.appellantCaseCorrespondence,
 							documents: [
-								...appellantCaseDataNotValidated.documents.appellantCaseCorrespondence.documents,
+								...appellantCaseDataNotValidatedNoEnforcementNotice.documents
+									.appellantCaseCorrespondence.documents,
 								{
 									id: 'a78446aa-167a-4bef-89b7-18bcb0da11c2',
 									name: 'test-doc.jpeg',
@@ -2145,8 +2151,8 @@ describe('appellant-case-main', () => {
 									caseId: 111,
 									isLateEntry: false,
 									latestDocumentVersion: {
-										...appellantCaseDataNotValidated.documents.appellantCaseCorrespondence
-											.documents[0].latestDocumentVersion,
+										...appellantCaseDataNotValidatedNoEnforcementNotice.documents
+											.appellantCaseCorrespondence.documents[0].latestDocumentVersion,
 										virusCheckStatus: 'not_scanned'
 									}
 								}
@@ -2170,13 +2176,15 @@ describe('appellant-case-main', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, {
-					...appellantCaseDataNotValidated,
+					...appellantCaseDataNotValidatedNoEnforcementNotice,
 					documents: {
-						...appellantCaseDataNotValidated.documents,
+						...appellantCaseDataNotValidatedNoEnforcementNotice.documents,
 						appellantCaseCorrespondence: {
-							...appellantCaseDataNotValidated.documents.appellantCaseCorrespondence,
+							...appellantCaseDataNotValidatedNoEnforcementNotice.documents
+								.appellantCaseCorrespondence,
 							documents: [
-								...appellantCaseDataNotValidated.documents.appellantCaseCorrespondence.documents,
+								...appellantCaseDataNotValidatedNoEnforcementNotice.documents
+									.appellantCaseCorrespondence.documents,
 								{
 									id: 'a78446aa-167a-4bef-89b7-18bcb0da11c2',
 									name: 'test-doc.jpeg',
@@ -2184,8 +2192,8 @@ describe('appellant-case-main', () => {
 									caseId: 111,
 									isLateEntry: false,
 									latestDocumentVersion: {
-										...appellantCaseDataNotValidated.documents.appellantCaseCorrespondence
-											.documents[0].latestDocumentVersion,
+										...appellantCaseDataNotValidatedNoEnforcementNotice.documents
+											.appellantCaseCorrespondence.documents[0].latestDocumentVersion,
 										virusCheckStatus: 'affected'
 									}
 								}
@@ -2216,7 +2224,7 @@ describe('appellant-case-main', () => {
 		beforeEach(() => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataNotValidated);
+				.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
 		});
 
 		afterEach(() => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-notice.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-notice.mapper.js
@@ -1,3 +1,4 @@
+import config from '#environment/config.js';
 import { generateS20Components } from './s20.mapper.js';
 
 /**
@@ -36,9 +37,13 @@ export function generateEnforcementNoticeComponents(
 	const beforeYouStartComponents = getComponentParameters('before-you-start', pageComponents);
 	if (beforeYouStartComponents) {
 		beforeYouStartComponents.parameters.rows = [
-			mappedAppellantCaseData.enforcementNotice.display.summaryListItem,
+			!config.featureFlags.featureFlagNewBeforeYouStart &&
+				mappedAppellantCaseData.enforcementNotice.display.summaryListItem,
 			mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem,
-			mappedAppellantCaseData.enforcementNoticeListedBuilding.display.summaryListItem,
+			config.featureFlags.featureFlagNewBeforeYouStart &&
+				mappedAppellantCaseData.applicationType.display.summaryListItem,
+			!config.featureFlags.featureFlagNewBeforeYouStart &&
+				mappedAppellantCaseData.enforcementNoticeListedBuilding.display.summaryListItem,
 			mappedAppellantCaseData.enforcementIssueDate.display.summaryListItem,
 			mappedAppellantCaseData.enforcementEffectiveDate.display.summaryListItem,
 			mappedAppellantCaseData.contactPlanningInspectorateDate.display.summaryListItem,

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-type.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-type.js
@@ -1,13 +1,26 @@
 import config from '#environment/config.js';
 import { textSummaryListItem } from '#lib/mappers/components/index.js';
+import { APPEAL_TYPE_CHANGE_APPEALS } from '@pins/appeals/constants/common.js';
 import { capitalizeFirstLetter } from '@pins/appeals/utils/string-case.js';
 import { APPEAL_TYPE_OF_PLANNING_APPLICATION } from '@planning-inspectorate/data-model';
 
 /**
  * @param {string | null | undefined } typeOfPlanningApplication
+ * @param {boolean | null | undefined } isEnforcementNotice
+ * @param {boolean | null | undefined } isEnforcementListedBuilding
  * @returns {string}
  */
-const applicationTypeText = (typeOfPlanningApplication) => {
+const applicationTypeText = (
+	typeOfPlanningApplication,
+	isEnforcementNotice,
+	isEnforcementListedBuilding
+) => {
+	if (isEnforcementNotice && config.featureFlags.featureFlagNewBeforeYouStart) {
+		return isEnforcementListedBuilding
+			? APPEAL_TYPE_CHANGE_APPEALS.ENFORCEMENT_LISTED_BUILDING
+			: APPEAL_TYPE_CHANGE_APPEALS.ENFORCEMENT_NOTICE;
+	}
+
 	if (!typeOfPlanningApplication) {
 		return '';
 	}
@@ -30,7 +43,11 @@ export const mapApplicationType = ({ appellantCaseData, currentRoute }) =>
 		text: config.featureFlags.featureFlagNewBeforeYouStart
 			? 'What is your appeal about?'
 			: 'What type of application is your appeal about?',
-		value: applicationTypeText(appellantCaseData.typeOfPlanningApplication),
+		value: applicationTypeText(
+			appellantCaseData.typeOfPlanningApplication,
+			appellantCaseData.enforcementNotice?.isReceived,
+			appellantCaseData.enforcementNotice?.isListedBuilding
+		),
 		link: `${currentRoute}/#`,
 		editable: false
 	});


### PR DESCRIPTION
…A2-8062)

## Describe your changes

- Adding logic to remove '' and '' from enforcement and elb based on the status of the new BYS feature flag
- Adding 'What is your appeal about?' to enforcement and elb based on the status of the new BYS feature flag
- Adding logic to the displaying of 'What is your appeal about?' to display the correct text for enforcement/elb
- Updating tests to not have those parameters true for the tests which are not setting them specifically
- Updating snaps to cover this change

Locally tested running the following e2e test suites (none failing):
- appellantCase
- endToEndEnforcement
- endToEndLinkedEnforcement

Locally checked that the correct text was showing for all appeal types:
- Enforcement and ELB show updated version
<img width="1744" height="712" alt="image" src="https://github.com/user-attachments/assets/4b3ed753-2121-4aff-9404-392faf451153" />
<img width="1781" height="801" alt="image" src="https://github.com/user-attachments/assets/10ac0c56-30be-40fc-90bf-8e4c08792bbd" />

- Other appeal types show no change

Locally checked that changing the feature flag to false returns to the previous behaviour for all appeal types

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8062)
