### PR TITLE
fix/a2-8459-remove-statement-of-common-ground-from-expedited-appellant-case

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s20.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s20.mapper.js
@@ -164,7 +164,7 @@ export function generateS20Components(
 					mappedAppellantCaseData.appealStatement.display.summaryListItem,
 					mappedAppellantCaseData.statusPlanningObligation?.display.summaryListItem,
 					mappedAppellantCaseData.planningObligation?.display.summaryListItem,
-					mappedAppellantCaseData.statementCommonGround.display.summaryListItem,
+					mappedAppellantCaseData.statementCommonGround?.display.summaryListItem,
 					mappedAppellantCaseData.ownershipCertificate.display.summaryListItem,
 					mappedAppellantCaseData.costsDocument.display.summaryListItem,
 					mappedAppellantCaseData.designAccessStatement?.display.summaryListItem,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78-expedited.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78-expedited.mapper.js
@@ -146,7 +146,9 @@ export function generateS78ExpeditedComponents(
 					mappedAppellantCaseData.decisionLetter.display.summaryListItem,
 					mappedAppellantCaseData.appealStatement.display.summaryListItem,
 					mappedAppellantCaseData.planningObligation.display.summaryListItem,
-					mappedAppellantCaseData.statementCommonGround.display.summaryListItem,
+					...(mappedAppellantCaseData.statementCommonGround
+						? [mappedAppellantCaseData.statementCommonGround.display.summaryListItem]
+						: []),
 					mappedAppellantCaseData.ownershipCertificate.display.summaryListItem,
 					...(isExpeditedAppealsActive
 						? [mappedAppellantCaseData.ownershipCertificateExpedited.display.summaryListItem]

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/mapper.js
@@ -2,6 +2,7 @@ import { isFeatureActive } from '#common/feature-flags.js';
 import { permissionNames } from '#environment/permissions.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 import { userHasPermission } from '../../utils/permissions.mapper.js';
 import { submaps as advertSubmaps } from './advert.js';
 import { submaps as casAdvertSubmaps } from './cas-advert.js';
@@ -99,10 +100,18 @@ export function initialiseAndMapData(
 	}
 
 	/** @type {Record<string, SubMapper | SubMapperList>} */
-	const submappers = submaps[appealType];
+	let submappers = { ...submaps[appealType] };
 
 	if (!submappers) {
 		throw new Error(`No submappers found for appeal type ${appealType}`);
+	}
+
+	if (
+		appealType === APPEAL_TYPE.S78_EXPEDITED &&
+		(appellantCaseData.appellantProcedurePreference === APPEAL_CASE_PROCEDURE.INQUIRY ||
+			appellantCaseData.appellantProcedurePreference === APPEAL_CASE_PROCEDURE.HEARING)
+	) {
+		delete submappers.statementCommonGround;
 	}
 
 	/** @type {MappedInstructions} */


### PR DESCRIPTION
- Added conditions which remove statement of common ground question from an appellant case if the appeal type is expedited and preferred procedure type is inquiry or hearing
- Edited display mappers so they are able to handle instances of statement of common ground being undefined

Ticket: https://pins-ds.atlassian.net/browse/A2-8459
