### PR TITLE
fix(web): use default deadline values when change procedure timetable…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/__tests__/change-procedure-check-and-confirm.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/__tests__/change-procedure-check-and-confirm.test.js
@@ -720,12 +720,12 @@ describe('GET /change-appeal-procedure-type/check-and-confirm', () => {
 				existingAppealProcedure: 'hearing',
 				appealProcedure: 'inquiry',
 				eventDate: '3025-02-01T12:00:00.000Z',
-				lpaQuestionnaireDueDate: '2023-10-11T01:00:00.000Z',
-				ipCommentsDueDate: '2023-10-13T01:00:00.000Z',
-				lpaStatementDueDate: '2023-10-14T01:00:00.000Z',
-				finalCommentsDueDate: '2023-10-12T01:00:00.000Z',
-				statementOfCommonGroundDueDate: '2023-10-15T01:00:00.000Z',
-				planningObligationDueDate: '2023-10-16T01:00:00.000Z',
+				lpaQuestionnaireDueDate: '2023-10-11T22:59:00.000Z',
+				ipCommentsDueDate: '2023-10-13T22:59:00.000Z',
+				lpaStatementDueDate: '2023-10-14T22:59:00.000Z',
+				finalCommentsDueDate: '2023-10-12T22:59:00.000Z',
+				statementOfCommonGroundDueDate: '2023-10-15T22:59:00.000Z',
+				planningObligationDueDate: '2023-10-16T22:59:00.000Z',
 				proofOfEvidenceAndWitnessesDueDate: '',
 				caseManagementConferenceDueDate: ''
 			});

--- a/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/change-procedure-check-and-confirm.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/change-procedure-check-and-confirm.controller.js
@@ -4,7 +4,6 @@ import { addressToString } from '#lib/address-formatter.js';
 import {
 	dateISOStringToDisplayDate,
 	dateISOStringToDisplayTime12hr,
-	dateStringToISOString,
 	dayMonthYearHourMinuteToISOString
 } from '#lib/dates.js';
 import { clearEditsForAppeal, editLink, getSessionValuesForAppeal } from '#lib/edit-utilities.js';
@@ -13,6 +12,8 @@ import { renderCheckYourAnswersComponent } from '#lib/mappers/components/page-co
 import { simpleHtmlComponent, textSummaryListItem } from '#lib/mappers/index.js';
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { DEADLINE_HOUR, DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js';
+import { setTimeInTimeZone } from '@pins/appeals/utils/business-days.js';
 import { capitalizeFirstLetter } from '@pins/appeals/utils/string-case.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 import { capitalize, kebabCase, pick } from 'lodash-es';
@@ -376,6 +377,17 @@ const mapSessionValuesForRequest = (values) => {
 	};
 	const includeAddress = address && Object.keys(address.address).length > 0 ? address : {};
 
+	const {
+		lpaQuestionnaireDueDate,
+		ipCommentsDueDate,
+		lpaStatementDueDate,
+		finalCommentsDueDate,
+		statementOfCommonGroundDueDate,
+		planningObligationDueDate,
+		proofOfEvidenceAndWitnessesDueDate,
+		caseManagementConferenceDueDate
+	} = values.appealTimetable;
+
 	/**@type {ChangeProcedureTypeRequest} */
 	return {
 		existingAppealProcedure: values.existingAppealProcedure,
@@ -383,25 +395,35 @@ const mapSessionValuesForRequest = (values) => {
 		eventDate,
 		...includeAddress,
 		estimationDays: values.estimationDays,
-		lpaQuestionnaireDueDate: dateStringToISOString(values.appealTimetable.lpaQuestionnaireDueDate),
-		ipCommentsDueDate: dateStringToISOString(values.appealTimetable.ipCommentsDueDate),
-		lpaStatementDueDate: dateStringToISOString(values.appealTimetable.lpaStatementDueDate),
-		finalCommentsDueDate: dateStringToISOString(values.appealTimetable.finalCommentsDueDate),
-		statementOfCommonGroundDueDate: dateStringToISOString(
-			values.appealTimetable.statementOfCommonGroundDueDate
-		),
-		...(values.appealTimetable.planningObligationDueDate
+		lpaQuestionnaireDueDate: lpaQuestionnaireDueDate
+			? setTimeInTimeZone(lpaQuestionnaireDueDate, DEADLINE_HOUR, DEADLINE_MINUTE)
+			: '',
+		ipCommentsDueDate: ipCommentsDueDate
+			? setTimeInTimeZone(ipCommentsDueDate, DEADLINE_HOUR, DEADLINE_MINUTE)
+			: '',
+		lpaStatementDueDate: lpaStatementDueDate
+			? setTimeInTimeZone(lpaStatementDueDate, DEADLINE_HOUR, DEADLINE_MINUTE)
+			: '',
+		finalCommentsDueDate: finalCommentsDueDate
+			? setTimeInTimeZone(finalCommentsDueDate, DEADLINE_HOUR, DEADLINE_MINUTE)
+			: '',
+		statementOfCommonGroundDueDate: statementOfCommonGroundDueDate
+			? setTimeInTimeZone(statementOfCommonGroundDueDate, DEADLINE_HOUR, DEADLINE_MINUTE)
+			: '',
+		...(planningObligationDueDate
 			? {
-					planningObligationDueDate: dateStringToISOString(
-						values.appealTimetable.planningObligationDueDate
+					planningObligationDueDate: setTimeInTimeZone(
+						planningObligationDueDate,
+						DEADLINE_HOUR,
+						DEADLINE_MINUTE
 					)
 				}
 			: {}),
-		proofOfEvidenceAndWitnessesDueDate: dateStringToISOString(
-			values.appealTimetable.proofOfEvidenceAndWitnessesDueDate
-		),
-		caseManagementConferenceDueDate: dateStringToISOString(
-			values.appealTimetable.caseManagementConferenceDueDate
-		)
+		proofOfEvidenceAndWitnessesDueDate: proofOfEvidenceAndWitnessesDueDate
+			? setTimeInTimeZone(proofOfEvidenceAndWitnessesDueDate, DEADLINE_HOUR, DEADLINE_MINUTE)
+			: '',
+		caseManagementConferenceDueDate: caseManagementConferenceDueDate
+			? setTimeInTimeZone(caseManagementConferenceDueDate, DEADLINE_HOUR, DEADLINE_MINUTE)
+			: ''
 	};
 };

--- a/appeals/web/src/server/lib/dates.js
+++ b/appeals/web/src/server/lib/dates.js
@@ -342,20 +342,6 @@ export const formatDays = (days) => {
 	return `${numberOfDays} ${suffix}`;
 };
 
-/**
- *
- * @param {string | Date} date
- * @param {Number} hours
- * @param {Number} minutes
- * @returns {Date}
- */
-export const setTimeInTimeZone = (date, hours, minutes) => {
-	const ymd = formatInTimeZone(date, DEFAULT_TIMEZONE, 'yyyy-MM-dd');
-	const paddedHours = hours.toString().padStart(2, '0');
-	const paddedMinutes = minutes.toString().padStart(2, '0');
-	return zonedTimeToUtc(`${ymd} ${paddedHours}:${paddedMinutes}`, DEFAULT_TIMEZONE);
-};
-
 export const getExampleDateHint = (daysFromToday = 45, inFuture = true) => {
 	const date = new Date(Date.now());
 	date.setDate(date.getDate() + (inFuture ? daysFromToday : -daysFromToday));


### PR DESCRIPTION
… (A2-8223)

When the appeal procedure is changed, the recalculated timetable defaults to 00:00 for hours/minutes.  This can cause the final day to be cut short.  This change ensures that the recalculated timetable on change procedure uses the default deadline hours/minutes (ie 23:59, timezone adjusted to UTC)

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8223)
