### PR TITLE
fix(web): changed procedure type display name determination from appeal type to expedited condition

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/__snapshots__/start-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/__snapshots__/start-case.test.js.snap
@@ -208,7 +208,7 @@ exports[`start-case POST /start-case/select-procedure should re-render the selec
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure" name="appealProcedure"
                                         type="radio" value="written">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Written representations (Part 2)</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Written representations</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure-2" name="appealProcedure"

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
@@ -155,7 +155,7 @@ export function selectProcedurePage(
 		) {
 			radioItems.push({
 				value: item.case,
-				text: appealProcedureKeyToLabelText(item.case, appealType),
+				text: appealProcedureKeyToLabelText(item.case, appealType, showPart1),
 				checked:
 					storedSessionData?.appealProcedure && storedSessionData?.appealProcedure === item.case
 			});
@@ -215,6 +215,8 @@ export function confirmProcedurePage(
 		APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
 	].includes(appealType);
 
+	const showPart1 = procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1;
+
 	/** @type {PageContent} */
 	const pageContent = {
 		title: 'Check details and start case',
@@ -229,7 +231,8 @@ export function confirmProcedurePage(
 						textSummaryListItem({
 							id: 'appeal-procedure',
 							text: 'Appeal procedure',
-							value: appealProcedureKeyToLabelText(procedureType, appealType) || 'No data',
+							value:
+								appealProcedureKeyToLabelText(procedureType, appealType, showPart1) || 'No data',
 							link: editLink(
 								`/appeals-service/appeal-details/${appealId}/start-case/select-procedure`
 							),

--- a/appeals/web/src/server/lib/__tests__/procedure-type-display-name-formatter.test.js
+++ b/appeals/web/src/server/lib/__tests__/procedure-type-display-name-formatter.test.js
@@ -3,35 +3,51 @@ import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 describe('appealProcedureKeyToLabelText', () => {
-	test.each([
-		[APPEAL_TYPE.S78, 'Written representations (Part 2)'],
-		[APPEAL_TYPE.S78_EXPEDITED, 'Written representations (Part 2)'],
-		[APPEAL_TYPE.HOUSEHOLDER, 'Written representations'],
-		[APPEAL_TYPE.ENFORCEMENT, 'Written representations'],
-		[undefined, 'Written representations']
-	])(
-		'returns the correct label for written procedure when appeal type is %s',
-		(appealType, expected) => {
-			expect(appealProcedureKeyToLabelText(APPEAL_CASE_PROCEDURE.WRITTEN, appealType)).toBe(
-				expected
+	describe('when showPart1 is true', () => {
+		const showPart1 = true;
+
+		test('returns Part 2 label for written procedure radio button', () => {
+			expect(
+				appealProcedureKeyToLabelText(APPEAL_CASE_PROCEDURE.WRITTEN, APPEAL_TYPE.S78, showPart1)
+			).toBe('Written representations (Part 2)');
+		});
+
+		test('returns Part 1 label for written expedited procedure radio button', () => {
+			expect(
+				appealProcedureKeyToLabelText(
+					APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+					APPEAL_TYPE.S78,
+					showPart1
+				)
+			).toBe('Written representations (Part 1)');
+		});
+
+		test.each([
+			[APPEAL_CASE_PROCEDURE.HEARING, 'Hearing'],
+			[APPEAL_CASE_PROCEDURE.INQUIRY, 'Inquiry']
+		])(
+			'returns a capitalized procedure type label for %s radio button',
+			(procedureTypeKey, expected) => {
+				expect(appealProcedureKeyToLabelText(procedureTypeKey, APPEAL_TYPE.S78, showPart1)).toBe(
+					expected
+				);
+			}
+		);
+
+		test('returns empty string for unknown procedure type', () => {
+			expect(appealProcedureKeyToLabelText('unknown-procedure', APPEAL_TYPE.S78, showPart1)).toBe(
+				''
 			);
-		}
-	);
-
-	test('returns Part 1 label for written part 1 procedure', () => {
-		expect(
-			appealProcedureKeyToLabelText(APPEAL_CASE_PROCEDURE.WRITTEN_PART_1, APPEAL_TYPE.S78)
-		).toBe('Written representations (Part 1)');
+		});
 	});
 
-	test.each([
-		[APPEAL_CASE_PROCEDURE.HEARING, 'Hearing'],
-		[APPEAL_CASE_PROCEDURE.INQUIRY, 'Inquiry']
-	])('returns a capitalized procedure type label for %s', (procedureTypeKey, expected) => {
-		expect(appealProcedureKeyToLabelText(procedureTypeKey, APPEAL_TYPE.S78)).toBe(expected);
-	});
+	describe('when showPart1 is false', () => {
+		const showPart1 = false;
 
-	test('returns empty string for unknown procedure type', () => {
-		expect(appealProcedureKeyToLabelText('unknown-procedure', APPEAL_TYPE.S78)).toBe('');
+		test('returns written representations without part 2 label for written procedure radio button', () => {
+			expect(
+				appealProcedureKeyToLabelText(APPEAL_CASE_PROCEDURE.WRITTEN, APPEAL_TYPE.S78, showPart1)
+			).toBe('Written representations');
+		});
 	});
 });

--- a/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
+++ b/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
@@ -1,4 +1,4 @@
-import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
+import { PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
 import { capitalizeFirstLetter } from '@pins/appeals/utils/string-case.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
@@ -23,14 +23,13 @@ export function appealProcedureNameToLabelText(procedureTypeName) {
 /**
  * @param {string} procedureTypeKey
  * @param {string} appealType
+ * @param {Boolean} showPart1
  * @returns string
  */
-export function appealProcedureKeyToLabelText(procedureTypeKey, appealType) {
+export function appealProcedureKeyToLabelText(procedureTypeKey, appealType, showPart1) {
 	switch (procedureTypeKey) {
 		case APPEAL_CASE_PROCEDURE.WRITTEN:
-			return appealType !== APPEAL_TYPE.S78 && appealType !== APPEAL_TYPE.S78_EXPEDITED
-				? 'Written representations'
-				: 'Written representations (Part 2)';
+			return showPart1 ? 'Written representations (Part 2)' : 'Written representations';
 		case APPEAL_CASE_PROCEDURE.WRITTEN_PART_1:
 			return 'Written representations (Part 1)';
 		case APPEAL_CASE_PROCEDURE.HEARING:


### PR DESCRIPTION
- Removed the appealType determination from diplay name formatter as this was resulting in an incorrect display name for Planning appeal cases that did not meet expedited conditions
- Replaced condition with isExpedited Boolean value in order to only change display name if expedited option is present
- Updated snap
- Amended tests  

Ticket: https://pins-ds.atlassian.net/browse/A2-8392
