### PR TITLE
feat(appeals): expedited state and broadcast fixes (A2-8468) (A2-8101)

### DIFF
--- a/appeals/api/src/server/state/__tests__/state-machine.test.js
+++ b/appeals/api/src/server/state/__tests__/state-machine.test.js
@@ -571,15 +571,31 @@ describe('State Machine Transitions', () => {
 	});
 
 	describe('Awaiting event transitions', () => {
+		test('should transition to AWAITING_EVENT if site visit has NOT elapsed', () => {
+			const initialState = APPEAL_CASE_STATUS.AWAITING_EVENT;
+			const event = VALIDATION_OUTCOME_COMPLETE;
+			const procedure = APPEAL_CASE_PROCEDURE.WRITTEN;
+			const siteVisitElapsed = false;
+
+			const expectedState = APPEAL_CASE_STATUS.AWAITING_EVENT;
+
+			expect(nextStateFPA(initialState, event, procedure, siteVisitElapsed)).toBe(expectedState);
+			expect(nextStateHAS(initialState, event, siteVisitElapsed)).toBe(expectedState);
+		});
+
+		test('should transition to ISSUE_DETERMINATION if site visit HAS elapsed', () => {
+			const initialState = APPEAL_CASE_STATUS.AWAITING_EVENT;
+			const event = VALIDATION_OUTCOME_COMPLETE;
+			const procedure = APPEAL_CASE_PROCEDURE.WRITTEN;
+			const siteVisitElapsed = true;
+
+			const expectedState = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
+
+			expect(nextStateFPA(initialState, event, procedure, siteVisitElapsed)).toBe(expectedState);
+			expect(nextStateHAS(initialState, event, siteVisitElapsed)).toBe(expectedState);
+		});
+
 		test.each([
-			[
-				APPEAL_CASE_STATUS.AWAITING_EVENT,
-				VALIDATION_OUTCOME_COMPLETE,
-				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
-				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
-				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
-				APPEAL_CASE_STATUS.ISSUE_DETERMINATION
-			],
 			[
 				APPEAL_CASE_STATUS.AWAITING_EVENT,
 				VALIDATION_OUTCOME_INCOMPLETE,
@@ -792,6 +808,18 @@ describe('State Machine Transitions', () => {
 			expect(
 				nextStateExpedited(APPEAL_CASE_STATUS.AWAITING_EVENT, APPEAL_CASE_STATUS.WITHDRAWN)
 			).toBe(APPEAL_CASE_STATUS.WITHDRAWN);
+		});
+
+		test('transitions from AWAITING_EVENT to AWAITING_EVENT on VALIDATION_OUTCOME_COMPLETE if site visit has NOT elapsed', () => {
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.AWAITING_EVENT, VALIDATION_OUTCOME_COMPLETE, false)
+			).toBe(APPEAL_CASE_STATUS.AWAITING_EVENT);
+		});
+
+		test('transitions from AWAITING_EVENT to ISSUE_DETERMINATION on VALIDATION_OUTCOME_COMPLETE if site visit HAS elapsed', () => {
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.AWAITING_EVENT, VALIDATION_OUTCOME_COMPLETE, true)
+			).toBe(APPEAL_CASE_STATUS.ISSUE_DETERMINATION);
 		});
 
 		test('validates and maps procedure types using isAppealTypeAndProcedureTypeValid guard', () => {

--- a/appeals/api/src/server/state/__tests__/transition-state.test.js
+++ b/appeals/api/src/server/state/__tests__/transition-state.test.js
@@ -190,6 +190,43 @@ describe('transitionState', () => {
 					'awaiting_event'
 				);
 			});
+
+			test('transitions a S78 expedited (W + WRITTEN_PART_1) appeal with arranged site visit from event to awaiting_event', async () => {
+				const expeditedAppeal = {
+					...appealFixture,
+					appealStatus: [{ status: 'lpa_questionnaire', valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 },
+					siteVisit: {
+						visitDate: new Date(Date.now() + 86400000).toISOString()
+					}
+				};
+
+				let callCount = 0;
+				databaseConnector.appeal.findUnique.mockImplementation(() => {
+					callCount++;
+					if (callCount === 1) {
+						return Promise.resolve(expeditedAppeal);
+					}
+					return Promise.resolve({
+						...expeditedAppeal,
+						appealStatus: [{ status: 'event', valid: true }]
+					});
+				});
+
+				await transitionState(11, 'user-123', VALIDATION_OUTCOME_COMPLETE);
+
+				expect(appealStatusRepository.updateAppealStatusByAppealId).toHaveBeenNthCalledWith(
+					1,
+					11,
+					'event'
+				);
+				expect(appealStatusRepository.updateAppealStatusByAppealId).toHaveBeenNthCalledWith(
+					2,
+					11,
+					'awaiting_event'
+				);
+			});
 		});
 
 		describe('Error Handling', () => {

--- a/appeals/api/src/server/state/create-state-machine.js
+++ b/appeals/api/src/server/state/create-state-machine.js
@@ -247,7 +247,10 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 			[APPEAL_CASE_STATUS.AWAITING_EVENT]: {
 				on: {
 					//@ts-ignore
-					[VALIDATION_OUTCOME_COMPLETE]: { target: APPEAL_CASE_STATUS.ISSUE_DETERMINATION },
+					[VALIDATION_OUTCOME_COMPLETE]: {
+						target: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+						cond: isEventElapsedAndValid
+					},
 					[VALIDATION_OUTCOME_INCOMPLETE]: { target: APPEAL_CASE_STATUS.EVENT },
 					//@ts-ignore
 					[VALIDATION_OUTCOME_CANCEL]: { target: targetStateOnEventCancelled[procedureType] },

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/outcome-valid.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/outcome-valid.test.js
@@ -613,21 +613,32 @@ describe('Appellant Case Valid Flow', () => {
 				);
 			});
 			it('should handle posting environmental services review details', async () => {
-				nock('http://test/').patch(`/appeals/${appealId}/appellant-cases/0`).reply(200);
-				nock('http://test/').get(`/appeals/${appealId}/appellant-cases/0`).reply(200, {
-					screeningOpinionIndicatesEiaRequired: true,
-					applicationDate: '2026-05-01',
-					applicationDecision: 'refused',
-					typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/0`, {
+						validationOutcome: 'valid',
+						validAt: '2025-01-01T00:00:00.000Z'
+					})
+					.reply(200);
+				nock('http://test/')
+					.get(`/appeals/${appealId}/appellant-cases/0`)
+					.reply(200, {
+						screeningOpinionIndicatesEiaRequired: true,
+						applicationDate: '2026-05-01',
+						applicationDecision: 'refused',
+						typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL
+					})
+					.persist();
+
+				// Post valid date first to store it in session
+				await request.post(`${baseUrl}/${appealId}/appellant-case/valid/date`).send({
+					'valid-date-day': '1',
+					'valid-date-month': 'Jan',
+					'valid-date-year': '2025'
 				});
 
-				const response = await request
-					.post(`${baseUrl}/${appealId}/appellant-case/valid/environmental-services-review`)
-					.send({
-						day: '1',
-						month: 'Jan',
-						year: '2025'
-					});
+				const response = await request.post(
+					`${baseUrl}/${appealId}/appellant-case/valid/environmental-services-review`
+				);
 
 				expect(response.statusCode).toBe(302);
 				expect(response.text).toBe(

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.controller.js
@@ -566,16 +566,21 @@ export const postEnvironmentalServicesReview = async (request, response) => {
 		currentAppeal: { appealId, appellantCaseId },
 		session
 	} = request;
+
+	const { day, month, year } = session.updatedValidDate || {};
+
 	await setReviewOutcomeValidForAppellantCase(
 		request.apiClient,
 		appealId,
 		appellantCaseId,
 		dayMonthYearHourMinuteToISOString({
-			day: session.day,
-			month: session.month,
-			year: session.year
+			day,
+			month,
+			year
 		})
 	);
+
+	delete session.updatedValidDate;
 
 	addNotificationBannerToSession({
 		session,

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
@@ -151,6 +151,34 @@ describe('required actions', () => {
 			).toEqual(['arrangeSiteVisit']);
 		});
 
+		it('should return "arrangeSiteVisit" if appeal procedure is "writtenPart1", appeal status is "EVENT" and no siteVisit exists', () => {
+			expect(
+				getRequiredActionsForAppeal(
+					{
+						...appealData,
+						procedureType: 'writtenPart1',
+						siteVisit: undefined,
+						appealStatus: APPEAL_CASE_STATUS.EVENT
+					},
+					'detail'
+				)
+			).toEqual(['arrangeSiteVisit']);
+		});
+
+		it('should return "arrangeSiteVisit" if appeal procedure is "writtenPart2", appeal status is "EVENT" and no siteVisit exists', () => {
+			expect(
+				getRequiredActionsForAppeal(
+					{
+						...appealData,
+						procedureType: 'writtenPart2',
+						siteVisit: undefined,
+						appealStatus: APPEAL_CASE_STATUS.EVENT
+					},
+					'detail'
+				)
+			).toEqual(['arrangeSiteVisit']);
+		});
+
 		it('should return "issueDecision" if appeal status is "ISSUE_DETERMINATION"', () => {
 			expect(
 				getRequiredActionsForAppeal(

--- a/appeals/web/src/server/lib/mappers/utils/required-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/required-actions.js
@@ -15,7 +15,10 @@ import {
 	DOCUMENT_STATUS_RECEIVED,
 	VALIDATION_OUTCOME_INCOMPLETE
 } from '@pins/appeals/constants/support.js';
-import { isAnyEnforcementAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
+import {
+	isAnyEnforcementAppealType,
+	normalizeProcedureType
+} from '@pins/appeals/utils/appeal-type-checks.js';
 import isAppellantStatementAppealType from '@pins/appeals/utils/is-appellant-statement-appeal-type.js';
 import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
@@ -57,6 +60,8 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 	/** @type {AppealRequiredAction[]} */
 	const actions = [];
 
+	const procedureType = normalizeProcedureType(appealDetails.procedureType);
+
 	switch (appealDetails.appealStatus) {
 		case APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER:
 			actions.push('assignCaseOfficer');
@@ -85,16 +90,14 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 			// appeal types that can't have hearings/inquiries have no procedure type set
 			// i.e. HAS is null, S20 before feature flag is turned on is null etc.
 			if (
-				!appealDetails.procedureType ||
-				appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN.toLowerCase()
+				!procedureType ||
+				procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN.toLowerCase()
 			) {
 				actions.push('arrangeSiteVisit');
 				break;
 			}
 
-			if (
-				appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING.toLowerCase()
-			) {
+			if (procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING.toLowerCase()) {
 				if (
 					// @ts-ignore
 					(view === 'detail' && !appealDetails.hearing) ||
@@ -121,9 +124,7 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 				}
 			}
 
-			if (
-				appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.INQUIRY.toLowerCase()
-			) {
+			if (procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.INQUIRY.toLowerCase()) {
 				if (
 					// @ts-ignore
 					(view === 'detail' && !appealDetails.inquiry) ||
@@ -307,16 +308,16 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 					actions.push('shareIpCommentsAndLpaStatement');
 				} else if (
 					// @ts-ignore
-					appealDetails.procedureType === 'Hearing' &&
+					procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING &&
 					// @ts-ignore
 					appealDetails.hearing?.hearingStartTime &&
 					// @ts-ignore
 					appealDetails.hearing?.addressId
 				) {
 					actions.push('progressHearingCaseWithNoRepsAndHearingSetUpFromStatements');
-				} else if (appealDetails.procedureType === 'Hearing') {
+				} else if (procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING) {
 					actions.push('progressHearingCaseWithNoRepsFromStatements');
-				} else if (appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.INQUIRY) {
+				} else if (procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.INQUIRY) {
 					actions.push('progressToProofOfEvidenceAndWitnesses');
 				} else {
 					actions.push('progressFromStatements');

--- a/packages/appeals/utils/__tests__/is-expedited-appeal-type.test.js
+++ b/packages/appeals/utils/__tests__/is-expedited-appeal-type.test.js
@@ -3,7 +3,7 @@ import {
 	APPEAL_CASE_TYPE,
 	APPEAL_TYPE_OF_PLANNING_APPLICATION
 } from '@planning-inspectorate/data-model';
-import { APPEAL_TYPE } from '../../constants/common';
+import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '../../constants/common';
 import {
 	isExpeditedAppealType,
 	isS78ExpeditedAppealType,
@@ -175,6 +175,18 @@ describe('normalizeProcedureType', () => {
 
 	it('normalizes WRITTEN_PART_2 to WRITTEN', () => {
 		expect(normalizeProcedureType(APPEAL_CASE_PROCEDURE.WRITTEN_PART_2)).toBe(
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		);
+	});
+
+	it('normalizes PROCEDURE_TYPE_NAME.WRITTEN_PART_1 display name to WRITTEN key', () => {
+		expect(normalizeProcedureType(PROCEDURE_TYPE_NAME.WRITTEN_PART_1)).toBe(
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		);
+	});
+
+	it('normalizes PROCEDURE_TYPE_NAME.WRITTEN_PART_2 display name to WRITTEN key', () => {
+		expect(normalizeProcedureType(PROCEDURE_TYPE_NAME.WRITTEN_PART_2)).toBe(
 			APPEAL_CASE_PROCEDURE.WRITTEN
 		);
 	});

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -4,7 +4,7 @@ import {
 	APPEAL_CASE_TYPE,
 	APPEAL_TYPE_OF_PLANNING_APPLICATION
 } from '@planning-inspectorate/data-model';
-import { APPEAL_TYPE } from '../constants/common.js';
+import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '../constants/common.js';
 import { EXPEDITED_ORIGINAL_APPLICATION_CUTOFF } from '../constants/dates.js';
 
 /**
@@ -119,13 +119,18 @@ export const isLdcOrDiscontinuanceOrEnforcementCaseType = (caseType) =>
 	isEnforcementCaseType(caseType);
 
 /**
+ * Normalizes a procedure type value to the canonical data-model key.
+ * Handles both data-model keys (e.g. 'writtenPart1') and display names
+ * (e.g. 'Part 1') that the API formatter sends to the web layer.
  * @param {string | null | undefined} procedureType
  * @returns {string | null | undefined}
  */
 export const normalizeProcedureType = (procedureType) => {
 	if (
 		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
-		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_2
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_2 ||
+		procedureType === PROCEDURE_TYPE_NAME.WRITTEN_PART_1 ||
+		procedureType === PROCEDURE_TYPE_NAME.WRITTEN_PART_2
 	) {
 		return APPEAL_CASE_PROCEDURE.WRITTEN;
 	}


### PR DESCRIPTION
## Describe your changes

This change covers multiple tickets including:

Fixing the display of appeal details on the FO LPA dashboard - valid date was not being set when environmental statement was set to yes.

State machine transitioning to issue decision without site visit elapsing - adding a check to prevent moving to issue decision

The incorrect page displaying when setting up site visit while appeal is in event status - fixed by normalising the procedure type to written

Added unit tests to cover changes and manually tested in browser

## Issue ticket number and link

[Appeal Form not displaying for LPA](https://pins-ds.atlassian.net/browse/A2-8468)
[State machine transitioning to issue decision early](https://pins-ds.atlassian.net/browse/A2-8101)

