### PR TITLE
fix(web): display details for appeal notification letter (A2-7829)

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/reviewLpaq.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/reviewLpaq.spec.js
@@ -119,7 +119,10 @@ describe('Review LPAQ', () => {
 			lpaqPage.assertFieldLabelAndValue('Site notice', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Letter or email notification', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Press advertisement', 'No documents');
-			lpaqPage.assertFieldLabelAndValue('Appeal notification letter', 'No documents');
+			lpaqPage.assertFieldLabelAndValue(
+				'Appeal notification letter and the list of people that you notified',
+				'No documents'
+			);
 
 			// Section 3 – Representations
 			lpaqPage.assertFieldLabelAndValue(
@@ -212,7 +215,10 @@ describe('Review LPAQ', () => {
 			lpaqPage.assertFieldLabelAndValue('Site notice', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Letter or email notification', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Press advertisement', 'No documents');
-			lpaqPage.assertFieldLabelAndValue('Appeal notification letter', 'No documents');
+			lpaqPage.assertFieldLabelAndValue(
+				'Appeal notification letter and the list of people that you notified',
+				'No documents'
+			);
 
 			// Section 4 – Representations
 			lpaqPage.assertFieldLabelAndValue(
@@ -322,7 +328,10 @@ describe('Review LPAQ', () => {
 			lpaqPage.assertFieldLabelAndValue('Site notice', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Letter or email notification', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Press advertisement', 'No documents');
-			lpaqPage.assertFieldLabelAndValue('Appeal notification letter', 'No documents');
+			lpaqPage.assertFieldLabelAndValue(
+				'Appeal notification letter and the list of people that you notified',
+				'No documents'
+			);
 
 			// Section 4 – Representations
 			lpaqPage.assertFieldLabelAndValue(
@@ -428,7 +437,10 @@ describe('Review LPAQ', () => {
 			lpaqPage.assertFieldLabelAndValue('Site notice', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Letter or email notification', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Press advertisement', 'No documents');
-			lpaqPage.assertFieldLabelAndValue('Appeal notification letter', 'No documents');
+			lpaqPage.assertFieldLabelAndValue(
+				'Appeal notification letter and the list of people that you notified',
+				'No documents'
+			);
 
 			// Section 3 – Representations
 			lpaqPage.assertFieldLabelAndValue(
@@ -524,7 +536,10 @@ describe('Review LPAQ', () => {
 			lpaqPage.assertFieldLabelAndValue('Site notice', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Letter or email notification', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Press advertisement', 'No documents');
-			lpaqPage.assertFieldLabelAndValue('Appeal notification letter', 'No documents');
+			lpaqPage.assertFieldLabelAndValue(
+				'Appeal notification letter and the list of people that you notified',
+				'No documents'
+			);
 
 			// Section 3 – Representations
 			lpaqPage.assertFieldLabelAndValue(
@@ -617,7 +632,10 @@ describe('Review LPAQ', () => {
 			lpaqPage.assertFieldLabelAndValue('Site notice', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Letter or email notification', 'No documents');
 			lpaqPage.assertFieldLabelAndValue('Press advertisement', 'No documents');
-			lpaqPage.assertFieldLabelAndValue('Appeal notification letter', 'No documents');
+			lpaqPage.assertFieldLabelAndValue(
+				'Appeal notification letter and the list of people that you notified',
+				'No documents'
+			);
 
 			// Section 3 – Representations
 			lpaqPage.assertFieldLabelAndValue(

--- a/appeals/pdf-service-api/src/mappers/lpa-questionnaire/__tests__/__snapshots__/lpa-questionaire.mapper.test.js.snap
+++ b/appeals/pdf-service-api/src/mappers/lpa-questionnaire/__tests__/__snapshots__/lpa-questionaire.mapper.test.js.snap
@@ -527,7 +527,7 @@ exports[`mapLpaQuestionnaireData should map advert LPA questionnaire data correc
         },
         {
           "html": "No documents",
-          "key": "Appeal notification letter",
+          "key": "Appeal notification letter and the list of people that you notified",
         },
       ],
     },
@@ -1158,7 +1158,7 @@ exports[`mapLpaQuestionnaireData should map cas advert LPA questionnaire data co
         },
         {
           "html": "No documents",
-          "key": "Appeal notification letter",
+          "key": "Appeal notification letter and the list of people that you notified",
         },
       ],
     },
@@ -1744,7 +1744,7 @@ exports[`mapLpaQuestionnaireData should map householder LPA questionnaire data c
         },
         {
           "html": "No documents",
-          "key": "Appeal notification letter",
+          "key": "Appeal notification letter and the list of people that you notified",
         },
       ],
     },
@@ -2445,7 +2445,7 @@ exports[`mapLpaQuestionnaireData should map s20 LPA questionnaire data correctly
         },
         {
           "html": "No documents",
-          "key": "Appeal notification letter",
+          "key": "Appeal notification letter and the list of people that you notified",
         },
       ],
     },
@@ -3214,7 +3214,7 @@ exports[`mapLpaQuestionnaireData should map s78 LPA questionnaire data correctly
         },
         {
           "html": "No documents",
-          "key": "Appeal notification letter",
+          "key": "Appeal notification letter and the list of people that you notified",
         },
       ],
     },

--- a/appeals/pdf-service-api/src/mappers/lpa-questionnaire/sections/notifying-relevant-parties/index.js
+++ b/appeals/pdf-service-api/src/mappers/lpa-questionnaire/sections/notifying-relevant-parties/index.js
@@ -41,7 +41,7 @@ export function notifyingRelevantPartiesSection(templateData) {
 				html: formatDocumentData(whoNotifiedPressAdvert)
 			},
 			{
-				key: 'Appeal notification letter',
+				key: 'Appeal notification letter and the list of people that you notified',
 				html: formatDocumentData(appealNotification)
 			}
 		]

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -3,7 +3,11 @@ import { addressToString } from '#lib/address-formatter.js';
 import { generateNotifyPreview } from '#lib/api/notify-preview.api.js';
 import { getFeedbackLinkFromAppealTypeName } from '#lib/feedback-form-link.js';
 import logger from '#lib/logger.js';
-import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
+import {
+	getPageHeadingTextOverrideForAddDocuments,
+	getPageHeadingTextOverrideForFolder,
+	mapFolderNameToDisplayLabel
+} from '#lib/mappers/utils/documents-and-folders.js';
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { getBackLinkUrlFromQuery, stripQueryString } from '#lib/url-utilities.js';
@@ -36,8 +40,6 @@ import {
 	appellantCasePage,
 	checkAndConfirmPage,
 	getDocumentNameFromFolder,
-	getPageHeadingTextOverrideForAddDocuments,
-	getPageHeadingTextOverrideForFolder,
 	getValidationOutcomeFromAppellantCase,
 	mapWebReviewOutcomeToApiReviewOutcome
 } from './appellant-case.mapper.js';

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -951,126 +951,6 @@ function generateCaseTypeSpecificComponents(
 }
 
 /**
- * @param {import('@pins/appeals.api').Appeals.FolderInfo} folder
- * @returns {string | undefined}
- */
-export function getPageHeadingTextOverrideForFolder(folder) {
-	switch (folder.path.split('/')[1]) {
-		case APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS:
-			return 'Plans, drawings and list of plans';
-		case APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS:
-			return 'new plans or drawings';
-		case APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT:
-			return 'design and access statement';
-		case APPEAL_DOCUMENT_TYPE.OWNERSHIP_CERTIFICATE:
-			return 'Separate ownership certificate and agricultural land declaration';
-		case APPEAL_DOCUMENT_TYPE.APPLICATION_DECISION_LETTER:
-			return 'Decision letter from the local planning authority';
-		case APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS:
-			return 'Other new supporting documents';
-		case APPEAL_DOCUMENT_TYPE.PRIOR_CORRESPONDENCE_WITH_PINS:
-			return 'communication with the Planning Inspectorate';
-		case APPEAL_DOCUMENT_TYPE.GROUND_A_SUPPORTING:
-			return 'Ground (a) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_B_SUPPORTING:
-			return 'Ground (b) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_C_SUPPORTING:
-			return 'Ground (c) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_D_SUPPORTING:
-			return 'Ground (d) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_E_SUPPORTING:
-			return 'Ground (e) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_F_SUPPORTING:
-			return 'Ground (f) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_G_SUPPORTING:
-			return 'Ground (g) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_H_SUPPORTING:
-			return 'Ground (h) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_I_SUPPORTING:
-			return 'Ground (i) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_J_SUPPORTING:
-			return 'Ground (j) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_K_SUPPORTING:
-			return 'Ground (k) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_A_FEE_RECEIPT:
-			return 'Ground (a) fee receipt';
-		case APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT_APPELLANT:
-			return 'Environmental statement';
-		default:
-			return;
-	}
-}
-
-/**
- * @param {import('@pins/appeals.api').Appeals.FolderInfo} folder
- * @param {string} appealType
- * @returns {string | undefined}
- */
-export function getPageHeadingTextOverrideForAddDocuments(folder, appealType) {
-	switch (folder.path.split('/')[1]) {
-		case APPEAL_DOCUMENT_TYPE.APPLICATION_DECISION_LETTER:
-			return 'Upload the decision letter from the local planning authority';
-		case APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS:
-			return 'Upload plans, drawings and list of plans';
-		case APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM:
-			return 'Upload your application form';
-		case APPEAL_DOCUMENT_TYPE.CHANGED_DESCRIPTION:
-			return appealType === APPEAL_TYPE.CAS_ADVERTISEMENT ||
-				appealType === APPEAL_TYPE.ADVERTISEMENT
-				? 'Upload evidence of your agreement to change the description of the advertisement'
-				: 'Upload evidence of your agreement to change the description of development';
-		case APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT:
-			return 'Upload your appeal statement';
-		case APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION:
-			return 'Upload your planning obligation';
-		case APPEAL_DOCUMENT_TYPE.OWNERSHIP_CERTIFICATE:
-			return 'Upload your separate ownership certificate and agricultural land declaration';
-		case APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION:
-			return 'Upload your application for an award of appeal costs';
-		case APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT:
-			return 'Upload your design and access statement';
-		case APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS:
-			return 'Upload your new plans or drawings';
-		case APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS:
-			return 'Upload your other new supporting documents';
-		case APPEAL_DOCUMENT_TYPE.PRIOR_CORRESPONDENCE_WITH_PINS:
-			return 'Upload your communication with the Planning Inspectorate';
-		case APPEAL_DOCUMENT_TYPE.ENFORCEMENT_NOTICE:
-			return 'Upload your enforcement notice';
-		case APPEAL_DOCUMENT_TYPE.ENFORCEMENT_NOTICE_PLAN:
-			return 'Upload your enforcement notice plan';
-		case APPEAL_DOCUMENT_TYPE.GROUND_A_SUPPORTING:
-			return 'Upload your ground (a) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_B_SUPPORTING:
-			return 'Upload your ground (b) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_C_SUPPORTING:
-			return 'Upload your ground (c) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_D_SUPPORTING:
-			return 'Upload your ground (d) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_E_SUPPORTING:
-			return 'Upload your ground (e) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_F_SUPPORTING:
-			return 'Upload your ground (f) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_G_SUPPORTING:
-			return 'Upload your ground (g) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_H_SUPPORTING:
-			return 'Upload your ground (h) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_I_SUPPORTING:
-			return 'Upload your ground (i) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_J_SUPPORTING:
-			return 'Upload your ground (j) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_K_SUPPORTING:
-			return 'Upload your ground (k) supporting documents';
-		case APPEAL_DOCUMENT_TYPE.GROUND_A_FEE_RECEIPT:
-			return 'Upload your ground (a) fee receipt';
-		case 'eiaEnvironmentalStatementAppellant':
-			return 'Upload your environmental statement';
-		default:
-			break;
-	}
-}
-
-/**
  * @param {string} folderPath
  * @returns {string | undefined}
  */
@@ -1124,7 +1004,7 @@ export function getDocumentNameFromFolder(folderPath) {
 			return 'ground (k) supporting documents';
 		case APPEAL_DOCUMENT_TYPE.GROUND_A_FEE_RECEIPT:
 			return 'ground (a) fee receipt';
-		case 'eiaEnvironmentalStatementAppellant':
+		case APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT_APPELLANT:
 			return 'environmental statement';
 	}
 }

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -147,9 +147,9 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -521,9 +521,9 @@ exports[`LPA Questionnaire review GET / should render the CAS planning LPA Quest
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -887,9 +887,9 @@ exports[`LPA Questionnaire review GET / should render the Cas Advert LPA Questio
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -1274,9 +1274,9 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -1960,9 +1960,9 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (3. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (3. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (3. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -2438,9 +2438,9 @@ exports[`LPA Questionnaire review GET / should render the advert LPA Questionnai
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -2878,9 +2878,9 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -3234,9 +3234,9 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -3742,7 +3742,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-row pins-file-upload" data-next-page-url="/appeals-service/appeal-details/1/lpa-questionnaire/1/undefined/add-document-details/2864"
             data-form-id="1" data-case-id="1" data-case-reference="APP/Q9999/D/21/351062"
-            data-folder-id="2864" data-document-type="changedDescription" data-document-stage="appellant-case"
+            data-folder-id="2864" data-document-type="testDocument" data-document-stage="testFolder"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-outlook,image/jpeg,image/jpeg,video/mpeg,audio/mpeg,video/mp4,video/quicktime,image/png,image/tiff,image/tiff"
             data-formatted-allowed-types="PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF or TIFF">
@@ -6402,9 +6402,9 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
                             <dd                             class="govuk-summary-list__value">No documents</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
                                 </dd>
                         </div>
                     </dl>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -758,7 +758,7 @@ describe('LPA Questionnaire review', () => {
 				},
 				{
 					folderPath: `${APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE}/${APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION}`,
-					label: 'Appeal notification letter'
+					label: 'Appeal notification letter and the list of people that you notified'
 				}
 			];
 
@@ -1056,7 +1056,9 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toContain('Site notice</dt>');
 			expect(element.innerHTML).toContain('Letter or email notification</dt>');
 			expect(element.innerHTML).toContain('Press advertisement</dt>');
-			expect(element.innerHTML).toContain('Appeal notification letter</dt>');
+			expect(element.innerHTML).toContain(
+				'Appeal notification letter and the list of people that you notified</dt>'
+			);
 
 			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
 			expect(element.innerHTML).toContain(
@@ -1157,7 +1159,9 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toContain('Site notice</dt>');
 			expect(element.innerHTML).toContain('Letter or email notification</dt>');
 			expect(element.innerHTML).toContain('Press advertisement</dt>');
-			expect(element.innerHTML).toContain('Appeal notification letter</dt>');
+			expect(element.innerHTML).toContain(
+				'Appeal notification letter and the list of people that you notified</dt>'
+			);
 
 			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
 			expect(element.innerHTML).toContain(
@@ -1238,7 +1242,9 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toContain('Site notice</dt>');
 			expect(element.innerHTML).toContain('Letter or email notification</dt>');
 			expect(element.innerHTML).toContain('Press advertisement</dt>');
-			expect(element.innerHTML).toContain('Appeal notification letter</dt>');
+			expect(element.innerHTML).toContain(
+				'Appeal notification letter and the list of people that you notified</dt>'
+			);
 
 			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
 			expect(element.innerHTML).toContain(
@@ -1415,7 +1421,9 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toContain('Site notice</dt>');
 			expect(element.innerHTML).toContain('Letter or email notification</dt>');
 			expect(element.innerHTML).toContain('Press advertisement</dt>');
-			expect(element.innerHTML).toContain('Appeal notification letter</dt>');
+			expect(element.innerHTML).toContain(
+				'Appeal notification letter and the list of people that you notified</dt>'
+			);
 
 			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
 			expect(element.innerHTML).toContain(
@@ -2812,10 +2820,13 @@ describe('LPA Questionnaire review', () => {
 		});
 
 		it('should render document upload page with a file upload component, and no late entry status tag and associated details component, and no additional documents warning text, if the folder is not additional documents', async () => {
+			const mockFolderInfo = structuredClone(documentFolderInfo);
+			mockFolderInfo.path = 'testFolder/testDocument';
+
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, mockFolderInfo);
 
 			const response = await request.get(
 				`/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1`

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -1,7 +1,11 @@
 import * as appealDetailsService from '#appeals/appeal-details/appeal-details.service.js';
 import { getDocumentFileType } from '#appeals/appeal-documents/appeal.documents.service.js';
 import logger from '#lib/logger.js';
-import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
+import {
+	getPageHeadingTextOverrideForAddDocuments,
+	getPageHeadingTextOverrideForFolder,
+	mapFolderNameToDisplayLabel
+} from '#lib/mappers/utils/documents-and-folders.js';
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { getBackLinkUrlFromQuery, stripQueryString } from '#lib/url-utilities.js';
@@ -322,55 +326,8 @@ export const getAddDocuments = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
-	const documentType = currentFolder.path.split('/')[1];
-
 	// @ts-ignore
-	const pageHeadingTextOverride = {
-		[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED]:
-			"Upload the list of neighbours' addresses that you notified about the application",
-		[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE]: 'Upload the site notice',
-		[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS]: 'Upload letter or email notification',
-		[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT]: 'Upload press advertisement',
-		[APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES]: 'Upload any other relevant policies',
-		[APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN]: 'Upload a plan showing the extent of the order',
-		[APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT]:
-			'Upload the definitive map and statement extract',
-		[APPEAL_DOCUMENT_TYPE.EIA_SCREENING_DIRECTION]: 'Upload the screening direction',
-		[APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION]:
-			'Upload your screening opinion and any correspondence',
-		[APPEAL_DOCUMENT_TYPE.EIA_SCOPING_OPINION]:
-			'Upload your scoping opinion and any correspondence',
-		[APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT]:
-			'Environmental statement and supporting information',
-		[APPEAL_DOCUMENT_TYPE.CONSULTATION_RESPONSES]:
-			'Upload the consultation responses and standing advice',
-		[APPEAL_DOCUMENT_TYPE.OTHER_PARTY_REPRESENTATIONS]:
-			'Upload the representations from members of the public or other parties',
-		[APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS]: 'Upload the plans, drawings and list of plans',
-		[APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT]:
-			'Upload the planning officer’s report or what your decision notice would have said',
-		[APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES]:
-			'Upload relevant policies from your statutory development plan',
-		[APPEAL_DOCUMENT_TYPE.EMERGING_PLAN]: 'Upload the emerging plan and supporting information',
-		[APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING]: 'Upload supplementary planning documents',
-		[APPEAL_DOCUMENT_TYPE.STOP_NOTICE]: 'Upload the stop notice',
-		[APPEAL_DOCUMENT_TYPE.ARTICLE_4_DIRECTION]: 'Upload the article 4 direction',
-		[APPEAL_DOCUMENT_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY]:
-			'Upload the community infrastructure levy',
-		[APPEAL_DOCUMENT_TYPE.LOCAL_DEVELOPMENT_ORDER]: 'Upload the local development order',
-		[APPEAL_DOCUMENT_TYPE.PLANNING_PERMISSION]:
-			'Upload the planning permission and any other relevant documents',
-		[APPEAL_DOCUMENT_TYPE.LPA_ENFORCEMENT_NOTICE]: 'Upload the enforcement notice',
-		[APPEAL_DOCUMENT_TYPE.LPA_ENFORCEMENT_NOTICE_PLAN]: 'Upload the enforcement notice plan',
-		[APPEAL_DOCUMENT_TYPE.PLANNING_CONTRAVENTION_NOTICE]:
-			'Upload the planning contravention notice',
-		[APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT_LPA]:
-			'Upload the design and access statement submitted for the application',
-		[APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS_LPA]:
-			'Upload the plans and drawings submitted for the application',
-		[APPEAL_DOCUMENT_TYPE.ADDITIONAL_DOCUMENTS_LPA]:
-			'Upload any other documents submitted with the application'
-	}[documentType];
+	const pageHeadingTextOverride = getPageHeadingTextOverrideForAddDocuments(currentFolder);
 
 	await renderDocumentUpload({
 		request,
@@ -535,38 +492,7 @@ export const postAddDocumentVersionCheckAndConfirm = async (request, response) =
 export const getManageFolder = async (request, response) => {
 	const { currentFolder } = request;
 
-	const documentType = currentFolder.path.split('/')[1];
-	let managePageHeadingText = '';
-
-	switch (documentType) {
-		case `${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED}`:
-			managePageHeadingText = `Notification documents`;
-			break;
-		case `${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE}`:
-			managePageHeadingText = `Site notice documents`;
-			break;
-		case `${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS}`:
-			managePageHeadingText = `Letter or email notification documents`;
-			break;
-		case `${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT}`:
-			managePageHeadingText = `Press advert notification documents`;
-			break;
-		case `${APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT}`:
-			managePageHeadingText = `Environmental statement documents`;
-			break;
-		case `${APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION}`:
-			managePageHeadingText = `Screening opinion documents`;
-			break;
-		case `${APPEAL_DOCUMENT_TYPE.EIA_SCREENING_DIRECTION}`:
-			managePageHeadingText = `Screening direction documents`;
-			break;
-		case `${APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES}`:
-			managePageHeadingText = `Other relevant policies`;
-			break;
-		default:
-			managePageHeadingText = '';
-			break;
-	}
+	const managePageHeadingText = getPageHeadingTextOverrideForFolder(currentFolder);
 
 	await renderManageFolder({
 		request,

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-appeal-notification.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-appeal-notification.js
@@ -4,7 +4,7 @@ import { documentInstruction } from '../common.js';
 export const mapAppealNotification = ({ lpaQuestionnaireData, session }) =>
 	documentInstruction({
 		id: 'appeal-notification',
-		text: 'Appeal notification letter',
+		text: 'Appeal notification letter and the list of people that you notified',
 		folderInfo: lpaQuestionnaireData.documents.appealNotification,
 		cypressDataName: 'appeal-notification-letter',
 		lpaQuestionnaireData,

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/documents-and-folders.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/documents-and-folders.test.js
@@ -139,7 +139,7 @@ describe('documents and folders', () => {
 			},
 			{
 				documentType: APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION,
-				label: 'Appeal notification letter'
+				label: 'Appeal notification letter and the list of people that you notified'
 			},
 			{
 				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,

--- a/appeals/web/src/server/lib/mappers/utils/documents-and-folders.js
+++ b/appeals/web/src/server/lib/mappers/utils/documents-and-folders.js
@@ -1,4 +1,6 @@
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { DOCUMENT_FOLDER_DISPLAY_LABELS } from '@pins/appeals/constants/documents.js';
+import { APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 
 /**
  * @param {string|undefined} folderPath
@@ -13,5 +15,199 @@ export function mapFolderNameToDisplayLabel(folderPath) {
 
 	if (documentType in DOCUMENT_FOLDER_DISPLAY_LABELS) {
 		return DOCUMENT_FOLDER_DISPLAY_LABELS[documentType];
+	}
+}
+
+/**
+ * @param {import('@pins/appeals.api').Appeals.FolderInfo} folder
+ * @param {string} [appealType]
+ * @returns {string | undefined}
+ */
+export function getPageHeadingTextOverrideForAddDocuments(folder, appealType = '') {
+	switch (folder.path.split('/')[1]) {
+		case APPEAL_DOCUMENT_TYPE.ADDITIONAL_DOCUMENTS_LPA:
+			return 'Upload any other documents submitted with the application';
+		case APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION:
+			return 'Upload the appeal notification letter and the list of people that you notified';
+		case APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION:
+			return 'Upload your application for an award of appeal costs';
+		case APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT:
+			return 'Upload your appeal statement';
+		case APPEAL_DOCUMENT_TYPE.APPLICATION_DECISION_LETTER:
+			return 'Upload the decision letter from the local planning authority';
+		case APPEAL_DOCUMENT_TYPE.ARTICLE_4_DIRECTION:
+			return 'Upload the article 4 direction';
+		case APPEAL_DOCUMENT_TYPE.CHANGED_DESCRIPTION:
+			return appealType === APPEAL_TYPE.CAS_ADVERTISEMENT ||
+				appealType === APPEAL_TYPE.ADVERTISEMENT
+				? 'Upload evidence of your agreement to change the description of the advertisement'
+				: 'Upload evidence of your agreement to change the description of development';
+		case APPEAL_DOCUMENT_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY:
+			return 'Upload the community infrastructure levy';
+		case APPEAL_DOCUMENT_TYPE.CONSULTATION_RESPONSES:
+			return 'Upload the consultation responses and standing advice';
+		case APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT:
+			return 'Upload the definitive map and statement extract';
+		case APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT:
+			return 'Upload your design and access statement';
+		case APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT_LPA:
+			return 'Upload the design and access statement submitted for the application';
+		case APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES:
+			return 'Upload relevant policies from your statutory development plan';
+		case APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT:
+			return 'Environmental statement and supporting information';
+		case APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT_APPELLANT:
+			return 'Upload your environmental statement';
+		case APPEAL_DOCUMENT_TYPE.EIA_SCREENING_DIRECTION:
+			return 'Upload the screening direction';
+		case APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION:
+			return 'Upload your screening opinion and any correspondence';
+		case APPEAL_DOCUMENT_TYPE.EIA_SCOPING_OPINION:
+			return 'Upload your scoping opinion and any correspondence';
+		case APPEAL_DOCUMENT_TYPE.EMERGING_PLAN:
+			return 'Upload the emerging plan and supporting information';
+		case APPEAL_DOCUMENT_TYPE.ENFORCEMENT_NOTICE:
+			return 'Upload your enforcement notice';
+		case APPEAL_DOCUMENT_TYPE.ENFORCEMENT_NOTICE_PLAN:
+			return 'Upload your enforcement notice plan';
+		case APPEAL_DOCUMENT_TYPE.GROUND_A_FEE_RECEIPT:
+			return 'Upload your ground (a) fee receipt';
+		case APPEAL_DOCUMENT_TYPE.GROUND_A_SUPPORTING:
+			return 'Upload your ground (a) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_B_SUPPORTING:
+			return 'Upload your ground (b) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_C_SUPPORTING:
+			return 'Upload your ground (c) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_D_SUPPORTING:
+			return 'Upload your ground (d) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_E_SUPPORTING:
+			return 'Upload your ground (e) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_F_SUPPORTING:
+			return 'Upload your ground (f) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_G_SUPPORTING:
+			return 'Upload your ground (g) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_H_SUPPORTING:
+			return 'Upload your ground (h) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_I_SUPPORTING:
+			return 'Upload your ground (i) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_J_SUPPORTING:
+			return 'Upload your ground (j) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_K_SUPPORTING:
+			return 'Upload your ground (k) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.LOCAL_DEVELOPMENT_ORDER:
+			return 'Upload the local development order';
+		case APPEAL_DOCUMENT_TYPE.LPA_ENFORCEMENT_NOTICE:
+			return 'Upload the enforcement notice';
+		case APPEAL_DOCUMENT_TYPE.LPA_ENFORCEMENT_NOTICE_PLAN:
+			return 'Upload the enforcement notice plan';
+		case APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS:
+			return 'Upload your new plans or drawings';
+		case APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM:
+			return 'Upload your application form';
+		case APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS:
+			return 'Upload your other new supporting documents';
+		case APPEAL_DOCUMENT_TYPE.OTHER_PARTY_REPRESENTATIONS:
+			return 'Upload the representations from members of the public or other parties';
+		case APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES:
+			return 'Upload any other relevant policies';
+		case APPEAL_DOCUMENT_TYPE.OWNERSHIP_CERTIFICATE:
+			return 'Upload your separate ownership certificate and agricultural land declaration';
+		case APPEAL_DOCUMENT_TYPE.PLANNING_CONTRAVENTION_NOTICE:
+			return 'Upload the planning contravention notice';
+		case APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION:
+			return 'Upload your planning obligation';
+		case APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT:
+			return 'Upload the planning officer’s report or what your decision notice would have said';
+		case APPEAL_DOCUMENT_TYPE.PLANNING_PERMISSION:
+			return 'Upload the planning permission and any other relevant documents';
+		case APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS:
+			return 'Upload the plans, drawings and list of plans';
+		case APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS_LPA:
+			return 'Upload the plans and drawings submitted for the application';
+		case APPEAL_DOCUMENT_TYPE.PRIOR_CORRESPONDENCE_WITH_PINS:
+			return 'Upload your communication with the Planning Inspectorate';
+		case APPEAL_DOCUMENT_TYPE.STOP_NOTICE:
+			return 'Upload the stop notice';
+		case APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING:
+			return 'Upload supplementary planning documents';
+		case APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN:
+			return 'Upload a plan showing the extent of the order';
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED:
+			return "Upload the list of neighbours' addresses that you notified about the application";
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS:
+			return 'Upload letter or email notification';
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT:
+			return 'Upload press advertisement';
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE:
+			return 'Upload the site notice';
+		default:
+			return '';
+	}
+}
+
+/**
+ * @param {import('@pins/appeals.api').Appeals.FolderInfo} folder
+ * @returns {string | undefined}
+ */
+export function getPageHeadingTextOverrideForFolder(folder) {
+	switch (folder.path.split('/')[1]) {
+		case APPEAL_DOCUMENT_TYPE.APPLICATION_DECISION_LETTER:
+			return 'Decision letter from the local planning authority';
+		case APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT:
+			return 'design and access statement';
+		case APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT:
+			return `Environmental statement documents`;
+		case APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT_APPELLANT:
+			return 'Environmental statement';
+		case APPEAL_DOCUMENT_TYPE.EIA_SCREENING_DIRECTION:
+			return `Screening direction documents`;
+		case APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION:
+			return `Screening opinion documents`;
+		case APPEAL_DOCUMENT_TYPE.GROUND_A_FEE_RECEIPT:
+			return 'Ground (a) fee receipt';
+		case APPEAL_DOCUMENT_TYPE.GROUND_A_SUPPORTING:
+			return 'Ground (a) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_B_SUPPORTING:
+			return 'Ground (b) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_C_SUPPORTING:
+			return 'Ground (c) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_D_SUPPORTING:
+			return 'Ground (d) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_E_SUPPORTING:
+			return 'Ground (e) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_F_SUPPORTING:
+			return 'Ground (f) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_G_SUPPORTING:
+			return 'Ground (g) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_H_SUPPORTING:
+			return 'Ground (h) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_I_SUPPORTING:
+			return 'Ground (i) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_J_SUPPORTING:
+			return 'Ground (j) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.GROUND_K_SUPPORTING:
+			return 'Ground (k) supporting documents';
+		case APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS:
+			return 'new plans or drawings';
+		case APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS:
+			return 'Other new supporting documents';
+		case APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES:
+			return `Other relevant policies`;
+		case APPEAL_DOCUMENT_TYPE.OWNERSHIP_CERTIFICATE:
+			return 'Separate ownership certificate and agricultural land declaration';
+		case APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS:
+			return 'Plans, drawings and list of plans';
+		case APPEAL_DOCUMENT_TYPE.PRIOR_CORRESPONDENCE_WITH_PINS:
+			return 'communication with the Planning Inspectorate';
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED:
+			return `Notification documents`;
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS:
+			return `Letter or email notification documents`;
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT:
+			return `Press advert notification documents`;
+		case APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE:
+			return `Site notice documents`;
+		default:
+			return '';
 	}
 }

--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -155,7 +155,8 @@ export const DOCUMENT_FOLDER_DISPLAY_LABELS = Object.freeze({
 	[APPEAL_DOCUMENT_TYPE.EIA_SCOPING_OPINION]: 'Scoping opinion documents',
 	[APPEAL_DOCUMENT_TYPE.LPA_CASE_CORRESPONDENCE]: 'Additional documents',
 	[APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES]: 'Other relevant policies',
-	[APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION]: 'Appeal notification letter',
+	[APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION]:
+		'Appeal notification letter and the list of people that you notified',
 	[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION]: 'Appellant costs application',
 	[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_WITHDRAWAL]: 'Appellant costs withdrawal',
 	[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE]: 'Appellant costs correspondence',


### PR DESCRIPTION
## Describe your changes

Update display for appeal notification letter to bring in line with FO and to make clear that upload should include list of people that were notified.

Refactor some getPageHeadingOverride functions into shared functions.

Includes update to pdf.

## Issue ticket number and link

[A2-7829](https://pins-ds.atlassian.net/browse/A2-7829)
[A2-8435](https://pins-ds.atlassian.net/browse/A2-8435)


[A2-7829]: https://pins-ds.atlassian.net/browse/A2-7829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[A2-8435]: https://pins-ds.atlassian.net/browse/A2-8435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ