### PR TITLE
fix(web): create S78 expedited spcific LPAQ, removed shared mapper from S20 lpaq (A2-8493)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -2189,6 +2189,505 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
         <div class="govuk-grid-column-full">
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> Additional documents</h2>
+                    <ul class="govuk-summary-card__actions">
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/21/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        </li>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/21">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                    </li>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                    </li>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                    </li>
+                                </ol>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`LPA Questionnaire review GET / should render the S78 expedited LPA Questionnaire page with the expected content 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">LPA questionnaire</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F2%2Flpa-questionnaire%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 1. Constraints, designations and other issues</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="constraints-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is planning appeal the correct type of appeal?</dt>
+                            <dd                             class="govuk-summary-list__value">Yes</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/is-correct-appeal-type/change"
+                                    data-cy="change-is-correct-appeal-type">Change<span class="govuk-visually-hidden"> Is planning appeal the correct type of appeal? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Does the development change a listed building?</dt>
+                            <dd                             class="govuk-summary-list__value">No</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/changed-listed-buildings/add"
+                                    lpaQuestionnaireData-cy="add-changed-listed-building">Add<span class="govuk-visually-hidden"> changed listed building (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Does the development affect the setting of listed buildings?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list">
+                                    <li><a href='https://historicengland.org.uk/listing/the-list/list-entry/123456'
+                                        class="govuk-link" aria-label="Listed building number 1 2 3 4 5 6">123456</a>
+                                    </li>
+                                    <li><a href='https://historicengland.org.uk/listing/the-list/list-entry/123457'
+                                        class="govuk-link" aria-label="Listed building number 1 2 3 4 5 7">123457</a>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/affected-listed-buildings/manage"
+                                            lpaQuestionnaireData-cy="manage-affected-listed-building">Change<span class="govuk-visually-hidden"> affected listed building (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/affected-listed-buildings/add"
+                                            lpaQuestionnaireData-cy="add-affected-listed-building">Add<span class="govuk-visually-hidden"> affected listed building (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Would the development affect a scheduled monument?</dt>
+                            <dd                             class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/affects-scheduled-monument/change"
+                                    data-cy="change-affects-scheduled-monument">Change<span class="govuk-visually-hidden"> Would the development affect a scheduled monument? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
+                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
+                                            data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Would the development affect a protected species?</dt>
+                            <dd                             class="govuk-summary-list__value">Yes</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/has-protected-species/change"
+                                    data-cy="change-has-protected-species">Change<span class="govuk-visually-hidden"> Would the development affect a protected species? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Green belt</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/green-belt/change/lpa"
+                                data-cy="change-site-within-green-belt">Change<span class="govuk-visually-hidden"> Green belt (1. Constraints, designations and other issues)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the site in a national landscape?</dt>
+                            <dd                             class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/is-aonb-national-landscape/change"
+                                    data-cy="change-is-aonb-national-landscape">Change<span class="govuk-visually-hidden"> Is the site in a national landscape? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the development in, near or likely to affect any designated sites?</dt>
+                            <dd                             class="govuk-summary-list__value">No
+                                <ul class="pins-summary-list-sublist"></ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/in-near-or-likely-to-affect-designated-sites/change"
+                                    data-cy="change-in-near-or-likely-to-affect-designated-sites">Change<span class="govuk-visually-hidden"> Is the development in, near or likely to affect any designated sites? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Tree Preservation Order</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-tree-preservation-plan">Add<span class="govuk-visually-hidden"> Tree Preservation Order (1. Constraints, designations and other issues)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Does the development relate to anyone claiming to be a Gypsy or Traveller?</dt>
+                            <dd                             class="govuk-summary-list__value">Yes</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/is-gypsy-or-traveller-site/change"
+                                    data-cy="change-is-gypsy-or-traveller-site">Change<span class="govuk-visually-hidden"> Does the development relate to anyone claiming to be a Gypsy or Traveller? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Definitive map and statement extract</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-definitive-map-statement">Add<span class="govuk-visually-hidden"> Definitive map and statement extract (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 2. Environmental impact assessment</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the development category?</dt>
+                            <dd                             class="govuk-summary-list__value">Other</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/eia-environmental-impact-schedule/change"
+                                    data-cy="change-eia-environmental-impact-schedule">Change<span class="govuk-visually-hidden"> What is the development category? (2. Environmental impact assessment)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-eia-requires-environmental-statement"><dt class="govuk-summary-list__key"> Did your screening opinion say the development needed an environmental statement?</dt>
+                            <dd                             class="govuk-summary-list__value">Not answered</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/environmental-impact-assessment/requires-environmental-statement/change"
+                                    data-cy="change-eia-requires-environmental-statement">Change<span class="govuk-visually-hidden"> Did your screening opinion say the development needed an environmental statement? (2. Environmental impact assessment)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Environmental statement and supporting information</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-eia-environmental-statement">Add<span class="govuk-visually-hidden"> Environmental statement and supporting information (2. Environmental impact assessment)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Screening opinion documents</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-eia-screening-opinion">Add<span class="govuk-visually-hidden"> Screening opinion documents (2. Environmental impact assessment)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Screening direction documents</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-eia-screening-direction">Add<span class="govuk-visually-hidden"> Screening direction documents (2. Environmental impact assessment)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Scoping opinion documents</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-eia-scoping-opinion">Add<span class="govuk-visually-hidden"> Scoping opinion documents (2. Environmental impact assessment)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 3. Notifying relevant parties</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
+                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
+                                            data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about this application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list__value">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/notification-methods/change"
+                                    data-cy="change-notification-methods">Change<span class="govuk-visually-hidden"> How did you notify relevant parties about this application? (3. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-site-notice">Add<span class="govuk-visually-hidden"> Site notice (3. Notifying relevant parties)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Letter or email notification</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-letter-or-email-notification">Add<span class="govuk-visually-hidden"> Letter or email notification (3. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Press advertisement</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (3. Notifying relevant parties)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (3. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 4. Consultation responses and representations</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
+                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
+                                            data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Consultation responses and standing advice</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-consultation-responses">Add<span class="govuk-visually-hidden"> Consultation responses and standing advice (4. Consultation responses and representations)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-eia-consulted-bodies-details"><dt class="govuk-summary-list__key"> Did you consult all the relevant statutory consultees about the development?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>Yes</span>
+                                <br><span>Some other people need to be consulted</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/environmental-impact-assessment/consulted-bodies-details/change"
+                                    data-cy="change-eia-consulted-bodies-details">Change<span class="govuk-visually-hidden"> Did you consult all the relevant statutory consultees about the development? (4. Consultation responses and representations)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 5. Planning officer’s report and supplementary documents</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Relevant policies from statutory development plan</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-development-plan-policies">Add<span class="govuk-visually-hidden"> Relevant policies from statutory development plan (5. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supplementary planning documents</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-supplementary-planning">Add<span class="govuk-visually-hidden"> Supplementary planning documents (5. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Emerging plan relevant to appeal</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-emerging-plan">Add<span class="govuk-visually-hidden"> Emerging plan relevant to appeal (5. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Other relevant policies</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-other-relevant-policies">Add<span class="govuk-visually-hidden"> Other relevant policies (5. Planning officer’s report and supplementary documents)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Community infrastructure levy</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-community-infrastructure-levy">Add<span class="govuk-visually-hidden"> Community infrastructure levy (5. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-is-infrastructure-levy-formally-adopted"><dt class="govuk-summary-list__key"> Is the community infrastructure levy formally adopted?</dt>
+                            <dd                             class="govuk-summary-list__value">Not answered</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/is-infrastructure-levy-formally-adopted/change"
+                                    data-cy="change-is-infrastructure-levy-formally-adopted">Change<span class="govuk-visually-hidden"> Is the community infrastructure levy formally adopted? (5. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> When was the community infrastructure levy formally adopted?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/infrastructure-levy-adopted-date/change"
+                                    data-cy="change-infrastructure-levy-adopted-date">Change<span class="govuk-visually-hidden"> When was the community infrastructure levy formally adopted? (5. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> When do you expect to formally adopt the community infrastructure levy?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/infrastructure-levy-expected-date/change"
+                                    data-cy="change-infrastructure-levy-expected-date">Change<span class="govuk-visually-hidden"> When do you expect to formally adopt the community infrastructure levy? (5. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 6. Site access</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Will the inspector need access to the appellant’s land or property?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/inspector-access/change/lpa"
+                                    data-cy="change-does-site-require-inspector-access">Change<span class="govuk-visually-hidden"> Will the inspector need access to the appellant’s land or property? (6. Site access)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-neighbouring-site-access"><dt class="govuk-summary-list__key"> Will the inspector need to enter a neighbour’s land or property?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/neighbouring-site-access/change"
+                                    data-cy="change-neighbouring-site-access">Change<span class="govuk-visually-hidden"> Will the inspector need to enter a neighbour’s land or property? (6. Site access)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                            <dd                             class="govuk-summary-list__value">1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/neighbouring-sites/manage">Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A) (6. Site access)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa">Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA) (6. Site access)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-health-and-safety"><dt class="govuk-summary-list__key"> Are there any potential safety risks?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/safety-risks/change/lpa"
+                                    data-cy="change-health-and-safety">Change<span class="govuk-visually-hidden"> Are there any potential safety risks? (6. Site access)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 7. Appeal process</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Which procedure do you think is most appropriate for this appeal?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/procedure-preference/change"
+                                    data-cy="change-procedure-preference">Change<span class="govuk-visually-hidden"> Which procedure do you think is most appropriate for this appeal? (7. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Why would you prefer this procedure?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/procedure-preference/details/change"
+                                    data-cy="change-procedure-preference-details">Change<span class="govuk-visually-hidden"> Why would you prefer this procedure? (7. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How many days would you expect the inquiry to last?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/procedure-preference/duration/change"
+                                    data-cy="change-procedure-preference-duration">Change<span class="govuk-visually-hidden"> How many days would you expect the inquiry to last? (7. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have there been any significant changes that would affect the application?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/any-significant-changes-lpa/change">Change<span class="govuk-visually-hidden"> Have there been any significant changes that would affect the application? (7. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there any other ongoing appeals next to, or close to the site?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals (7. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there any new conditions?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>Yes</span>
+                                <br><span>Some extra conditions</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/1/extra-conditions/change">Change<span class="govuk-visually-hidden"> Are there any new conditions? (7. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> 8. Original Evidence</h2>
                 </div>
                 <div class="govuk-summary-card__content">

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -1121,6 +1121,42 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toContain('Additional documents</h2>');
 		}, 10000);
 
+		it('should render the S78 expedited LPA Questionnaire page with the expected content', async () => {
+			nock('http://test/')
+				.get('/appeals/2?include=all')
+				.reply(200, {
+					...appealDataFullPlanning,
+					appealId: 2,
+					isS78Expedited: true
+				});
+			nock('http://test/')
+				.get('/appeals/2/lpa-questionnaires/1')
+				.reply(200, {
+					...lpaQuestionnaireDataNotValidated,
+					lpaQuestionnaireId: 1
+				});
+
+			const response = await request.get('/appeals-service/appeal-details/2/lpa-questionnaire/1');
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('LPA questionnaire</h1>');
+			expect(element.innerHTML).toContain('1. Constraints, designations and other issues</h2>');
+			expect(element.innerHTML).toContain('2. Environmental impact assessment</h2>');
+			expect(element.innerHTML).toContain('3. Notifying relevant parties</h2>');
+			expect(element.innerHTML).toContain('4. Consultation responses and representations</h2>');
+			expect(element.innerHTML).toContain(
+				'5. Planning officer’s report and supplementary documents</h2>'
+			);
+			expect(element.innerHTML).toContain('6. Site access</h2>');
+			expect(element.innerHTML).toContain('7. Appeal process</h2>');
+			expect(element.innerHTML).toContain('Original Evidence</h2>');
+			expect(element.innerHTML).toContain(
+				'What documents and plans did you use to make your decision?</dt>'
+			);
+			expect(element.innerHTML).toContain('Additional documents</h2>');
+		}, 10000);
+
 		it('should render the CAS planning LPA Questionnaire page with the expected content', async () => {
 			nock('http://test/')
 				.get('/appeals/3?include=all')

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/index.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/index.js
@@ -8,6 +8,7 @@ import { generateEnforcementLpaQuestionnaireComponents } from './enforcement.js'
 import { generateHASLpaQuestionnaireComponents } from './has.js';
 import { generateLdcLpaQuestionnaireComponents } from './ldc.js';
 import { generateS20LpaQuestionnaireComponents } from './s20.js';
+import { generateS78ExpeditedLpaQuestionnaireComponents } from './s78-expedited.js';
 import { generateS78LpaQuestionnaireComponents } from './s78.js';
 
 /**
@@ -48,7 +49,10 @@ export function generateCaseTypeSpecificComponents(appealDetails, mappedLPAQData
 			throw new Error('Enforcement feature flag is disabled');
 		case APPEAL_TYPE.S78:
 			if (isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78)) {
-				return generateS78LpaQuestionnaireComponents(mappedLPAQData);
+				if (appealDetails.isS78Expedited) {
+					return generateS78ExpeditedLpaQuestionnaireComponents(appealDetails, mappedLPAQData);
+				}
+				return generateS78LpaQuestionnaireComponents(appealDetails, mappedLPAQData);
 			} else {
 				throw new Error('Feature flag inactive for S78');
 			}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/s78-expedited.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/s78-expedited.js
@@ -11,7 +11,7 @@ import { generateSharedS78S20LpaQuestionnaireComponents } from './shared-s78-s20
  * @param {{lpaq: MappedInstructions}} mappedLPAQData
  * @returns {PageComponent[]}
  */
-export const generateS78LpaQuestionnaireComponents = (appealDetails, mappedLPAQData) => {
+export const generateS78ExpeditedLpaQuestionnaireComponents = (appealDetails, mappedLPAQData) => {
 	/** @type {PageComponent[]} */
 	const pageComponents = [];
 
@@ -49,5 +49,28 @@ export const generateS78LpaQuestionnaireComponents = (appealDetails, mappedLPAQD
 	});
 
 	pageComponents.push(...generateSharedS78S20LpaQuestionnaireComponents(mappedLPAQData));
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			card: {
+				title: {
+					text: '8. Original Evidence'
+				}
+			},
+			rows: [
+				mappedLPAQData.lpaq?.designAccessStatementLpa?.display.summaryListItem,
+				mappedLPAQData.lpaq?.plansDrawingsLpa?.display.summaryListItem,
+				mappedLPAQData.lpaq?.additionalDocumentsLpa?.display.summaryListItem,
+				mappedLPAQData.lpaq?.listOfDocumentsBeforeDecision?.display.summaryListItem
+			].filter(isDefined)
+		}
+	});
+
 	return pageComponents;
 };

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/shared-s78-s20.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/shared-s78-s20.js
@@ -167,27 +167,5 @@ export const generateSharedS78S20LpaQuestionnaireComponents = (mappedLPAQData) =
 		}
 	});
 
-	pageComponents.push({
-		/** @type {'summary-list'} */
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			card: {
-				title: {
-					text: '8. Original Evidence'
-				}
-			},
-			rows: [
-				mappedLPAQData.lpaq?.designAccessStatementLpa?.display.summaryListItem,
-				mappedLPAQData.lpaq?.plansDrawingsLpa?.display.summaryListItem,
-				mappedLPAQData.lpaq?.additionalDocumentsLpa?.display.summaryListItem,
-				mappedLPAQData.lpaq?.listOfDocumentsBeforeDecision?.display.summaryListItem
-			].filter(isDefined)
-		}
-	});
-
 	return pageComponents;
 };

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/mapper.js
@@ -9,6 +9,7 @@ import { submaps as enforcementSubmaps } from './enforcement.js';
 import { submaps as hasSubmaps } from './has.js';
 import { submaps as ldcSubmaps } from './ldc.js';
 import { submaps as s20Submaps } from './s20.js';
+import { submaps as s78ExpeditedSubmaps } from './s78-expedited.js';
 import { submaps as s78Submaps } from './s78.js';
 /**
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal
@@ -70,7 +71,10 @@ export function initialiseAndMapLPAQData(
 	/** @type {{lpaq: MappedInstructions}} */
 	const mappedData = { lpaq: {} };
 
-	const submappers = submaps[appealDetails.appealType];
+	let submappers = submaps[appealDetails.appealType];
+	if (appealDetails.appealType === APPEAL_TYPE.S78 && appealDetails.isS78Expedited) {
+		submappers = s78ExpeditedSubmaps;
+	}
 
 	if (!submappers) {
 		console.error(`[LPAQ Mapper] No submapper found for appeal type: ${appealDetails.appealType}`);

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s20.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s20.js
@@ -2,8 +2,13 @@ import { submaps as s78Submaps } from './s78.js';
 import { mapGrantLoanToPreserve } from './submappers/map-grant-loan-preserve-listed-building.js';
 import { mapHistoricEnglandConsultation } from './submappers/map-historic-england-consultation.js';
 
+// listOfDocumentsBeforeDecision is only relevant for S78 expedited cases — exclude it from S20
+const s78SubmapsForS20 = Object.fromEntries(
+	Object.entries(s78Submaps).filter(([key]) => key !== 'listOfDocumentsBeforeDecision')
+);
+
 export const submaps = {
-	...s78Submaps,
+	...s78SubmapsForS20,
 	grantLoanToPreserve: mapGrantLoanToPreserve,
 	historicEnglandConsultation: mapHistoricEnglandConsultation
 };

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s78-expedited.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s78-expedited.js
@@ -1,0 +1,7 @@
+import { submaps as s78Submaps } from './s78.js';
+import { mapListOfDocumentsBeforeDecision } from './submappers/map-list-of-documents-before-decision.js';
+
+export const submaps = {
+	...s78Submaps,
+	listOfDocumentsBeforeDecision: mapListOfDocumentsBeforeDecision
+};

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s78.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s78.js
@@ -25,7 +25,6 @@ import { mapInfrastructureLevyExpectedDate } from './submappers/map-infrastructu
 import { mapIsAonbNationalLandscape } from './submappers/map-is-aonb-national-landscape.js';
 import { mapIsGypsyOrTravellerSite } from './submappers/map-is-gypsy-or-traveller-site.js';
 import { mapIsInfrastructureLevyFormallyAdopted } from './submappers/map-is-infrastructure-levy-formally-adopted.js';
-import { mapListOfDocumentsBeforeDecision } from './submappers/map-list-of-documents-before-decision.js';
 import { mapOtherRelevantPolicies } from './submappers/map-other-relevant-policies.js';
 import { mapPlansDrawingsLpa } from './submappers/map-plans-drawings-lpa.js';
 import { mapProcedurePreferenceDetails } from './submappers/map-procedure-preference-details.js';
@@ -68,6 +67,5 @@ export const submaps = {
 	designAccessStatementLpa: mapDesignAccessStatementLpa,
 	plansDrawingsLpa: mapPlansDrawingsLpa,
 	additionalDocumentsLpa: mapAdditionalDocumentsLpa,
-	listOfDocumentsBeforeDecision: mapListOfDocumentsBeforeDecision,
 	anySignificantChangesLpa: mapAnySignificantChangesLpa
 };


### PR DESCRIPTION
## Describe your changes

This PR creates a S78 expedited specific LPAQ mapper. This ensures that only the correct fields are displayed and only in the expected areas.
The Original Evidence section has been removed from the shared mapper.
Update selected to ensure only s78expedited cases are selected - note this is for any case where the expedited LPAQ would be used



Updated unit tests
Manually tested in browser


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8493)
