### PR TITLE
fix(appeals): add has and cas planning to expedited appeal flow for granted appeals (A2-8541)

### DIFF
--- a/packages/appeals/utils/__tests__/is-expedited-appeal-type.test.js
+++ b/packages/appeals/utils/__tests__/is-expedited-appeal-type.test.js
@@ -164,6 +164,50 @@ describe('isS78ExpeditedAppealType', () => {
 			)
 		).toBe(false);
 	});
+
+	it('returns true if appealType is S78, planning application is MINOR_COMMERCIAL_DEVELOPMENT, and decision is granted', () => {
+		expect(
+			isS78ExpeditedAppealType(
+				APPEAL_TYPE.S78,
+				'2026-04-02',
+				'granted',
+				APPEAL_TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
+			)
+		).toBe(true);
+	});
+
+	it('returns false if appealType is S78, planning application is MINOR_COMMERCIAL_DEVELOPMENT, and decision is refused', () => {
+		expect(
+			isS78ExpeditedAppealType(
+				APPEAL_TYPE.S78,
+				'2026-04-02',
+				'refused',
+				APPEAL_TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
+			)
+		).toBe(false);
+	});
+
+	it('returns true if appealType is S78, planning application is HOUSEHOLDER_PLANNING, and decision is granted', () => {
+		expect(
+			isS78ExpeditedAppealType(
+				APPEAL_TYPE.S78,
+				'2026-04-02',
+				'granted',
+				APPEAL_TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING
+			)
+		).toBe(true);
+	});
+
+	it('returns false if appealType is S78, planning application is HOUSEHOLDER_PLANNING, and decision is refused', () => {
+		expect(
+			isS78ExpeditedAppealType(
+				APPEAL_TYPE.S78,
+				'2026-04-02',
+				'refused',
+				APPEAL_TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING
+			)
+		).toBe(false);
+	});
 });
 
 describe('normalizeProcedureType', () => {

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -76,19 +76,37 @@ export const isS78ExpeditedAppealType = (
 	applicationDecision,
 	typeOfPlanningApplication
 ) => {
-	if (!appealType) return false;
-	if (
-		(appealType === APPEAL_CASE_TYPE.W || appealType === APPEAL_TYPE.S78) &&
-		dateIsAfterDate(new Date(caseSubmissionDate), new Date(2026, 3, 1)) &&
-		(applicationDecision === APPEAL_APPLICATION_DECISION.REFUSED ||
-			applicationDecision === APPEAL_APPLICATION_DECISION.GRANTED) &&
-		(typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL ||
-			typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING ||
-			typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS)
-	) {
-		return true;
+	if (!appealType || !caseSubmissionDate) return false;
+
+	const isS78 = appealType === APPEAL_CASE_TYPE.W || appealType === APPEAL_TYPE.S78;
+	const isAfterCutoff = dateIsAfterDate(
+		new Date(caseSubmissionDate),
+		EXPEDITED_ORIGINAL_APPLICATION_CUTOFF
+	);
+
+	if (!isS78 || !isAfterCutoff) {
+		return false;
 	}
-	return false;
+
+	const isHasOrCas =
+		typeOfPlanningApplication ===
+			APPEAL_TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT ||
+		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING;
+
+	if (isHasOrCas) {
+		return applicationDecision === APPEAL_APPLICATION_DECISION.GRANTED;
+	}
+
+	const isEligibleDecision =
+		applicationDecision === APPEAL_APPLICATION_DECISION.REFUSED ||
+		applicationDecision === APPEAL_APPLICATION_DECISION.GRANTED;
+
+	const isEligiblePlanningApplication =
+		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL ||
+		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING ||
+		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS;
+
+	return isEligibleDecision && isEligiblePlanningApplication;
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

### Updates
Refactors expedited S78 appeal check
Add MINOR_COMMERCIAL_DEVELOPMENT and HOOUSEHOLDER_PLANNING to the allowed appeal types. where decision is granted.

### Testing
Updated unit tests
Tested manually in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8541)
