### PR TITLE
fix(web): prepopulate enforcement valid date from received date (A2-8…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/__snapshots__/outcome-valid.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/__snapshots__/outcome-valid.test.js.snap
@@ -71,27 +71,27 @@ exports[`Appellant Case Valid Flow Enforcement Appeals GET /enforcement/date sho
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-day">Day</label>
                                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
-                                        id="valid-date-day" name="valid-date-day" type="text" inputmode="numeric">
+                                        id="valid-date-day" name="valid-date-day" type="text" value="21" inputmode="numeric">
                                     </div>
                                 </div>
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-month">Month</label>
                                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
-                                        id="valid-date-month" name="valid-date-month" type="text" inputmode="numeric">
+                                        id="valid-date-month" name="valid-date-month" type="text" value="5" inputmode="numeric">
                                     </div>
                                 </div>
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-year">Year</label>
                                         <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
-                                        id="valid-date-year" name="valid-date-year" type="text" inputmode="numeric">
+                                        id="valid-date-year" name="valid-date-year" type="text" value="2023" inputmode="numeric">
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
-                        data-module="govuk-button">Confirm</button>
+                        data-module="govuk-button">Continue</button>
                     </form>
                 </div>
             </div>
@@ -185,6 +185,77 @@ exports[`Appellant Case Valid Flow Enforcement Appeals GET /enforcement/other-in
 </main>"
 `;
 
+exports[`Appellant Case Valid Flow Enforcement Appeals POST /enforcement/date should re-render the 'Valid date' screen if the date is before the date case was received 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#valid-date-day">The valid date must be on or after the date the case was received.</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Valid date</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                            valid.</p>
+                        <label class="govuk-label govuk-label--m">Enter valid date for case</label>
+                        <div class="govuk-form-group govuk-form-group--error">
+                            <div id="valid-date-hint" class="govuk-hint">
+                                <div class="govuk-hint">For example, 31 3 2025</div>
+                            </div>
+                            <p id="valid-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> The valid date must be
+                                on or after the date the case was received.</p>
+                            <div class="govuk-date-input"
+                            id="valid-date">
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="valid-date-day">Day</label>
+                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
+                                        id="valid-date-day" name="valid-date-day" type="text" value="1" inputmode="numeric">
+                                    </div>
+                                </div>
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="valid-date-month">Month</label>
+                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
+                                        id="valid-date-month" name="valid-date-month" type="text" value="1" inputmode="numeric">
+                                    </div>
+                                </div>
+                                <div class="govuk-date-input__item">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label govuk-date-input__label" for="valid-date-year">Year</label>
+                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
+                                        id="valid-date-year" name="valid-date-year" type="text" value="2023" inputmode="numeric">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Appellant Case Valid Flow Enforcement Appeals POST /enforcement/date should re-render the 'Valid date' screen if the date is in the future 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -246,7 +317,7 @@ exports[`Appellant Case Valid Flow Enforcement Appeals POST /enforcement/date sh
                             </div>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
-                        data-module="govuk-button">Confirm</button>
+                        data-module="govuk-button">Continue</button>
                     </form>
                 </div>
             </div>
@@ -295,27 +366,27 @@ exports[`Appellant Case Valid Flow Enforcement Appeals POST /enforcement/date sh
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-day">Day</label>
                                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
-                                        id="valid-date-day" name="valid-date-day" type="text" inputmode="numeric">
+                                        id="valid-date-day" name="valid-date-day" type="text" value="21" inputmode="numeric">
                                     </div>
                                 </div>
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-month">Month</label>
                                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
-                                        id="valid-date-month" name="valid-date-month" type="text" inputmode="numeric">
+                                        id="valid-date-month" name="valid-date-month" type="text" value="5" inputmode="numeric">
                                     </div>
                                 </div>
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-year">Year</label>
                                         <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
-                                        id="valid-date-year" name="valid-date-year" type="text" inputmode="numeric">
+                                        id="valid-date-year" name="valid-date-year" type="text" value="2023" inputmode="numeric">
                                     </div>
                                 </div>
                         </div>
                 </div>
                 <button type="submit" data-prevent-double-click="true" class="govuk-button"
-                data-module="govuk-button">Confirm</button>
+                data-module="govuk-button">Continue</button>
                 </form>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/outcome-valid.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/outcome-valid.test.js
@@ -159,15 +159,15 @@ describe('Appellant Case Valid Flow', () => {
 					'This is the date all case documentation was received and the appeal was valid.</p>'
 				);
 				expect(unprettifiedElement.innerHTML).toContain(
-					'name="valid-date-day" type="text" inputmode="numeric">'
+					'name="valid-date-day" type="text" value="21" inputmode="numeric">'
 				);
 				expect(unprettifiedElement.innerHTML).toContain(
-					'name="valid-date-month" type="text" inputmode="numeric">'
+					'name="valid-date-month" type="text" value="5" inputmode="numeric">'
 				);
 				expect(unprettifiedElement.innerHTML).toContain(
-					'name="valid-date-year" type="text" inputmode="numeric">'
+					'name="valid-date-year" type="text" value="2023" inputmode="numeric">'
 				);
-				expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
+				expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
 			});
 		});
 
@@ -195,6 +195,35 @@ describe('Appellant Case Valid Flow', () => {
 
 				expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 				expect(unprettifiedErrorSummaryHtml).toContain('Enter the valid date');
+			});
+
+			it(`should re-render the 'Valid date' screen if the date is before the date case was received`, async () => {
+				const response = await request
+					.post(`${baseUrl}/${appealId}/appellant-case/valid/enforcement/date`)
+					.send({
+						'valid-date-day': '1',
+						'valid-date-month': '1',
+						'valid-date-year': '2023'
+					});
+
+				expect(response.statusCode).toBe(200);
+
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain(
+					'The valid date must be on or after the date the case was received.</a>'
+				);
+
+				const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+					rootElement: '.govuk-error-summary',
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+				expect(unprettifiedErrorSummaryHtml).toContain(
+					'The valid date must be on or after the date the case was received.'
+				);
 			});
 
 			it(`should re-render the 'Valid date' screen if the date is in the future`, async () => {
@@ -612,6 +641,7 @@ describe('Appellant Case Valid Flow', () => {
 					`Found. Redirecting to /appeals-service/appeal-details/${appealId}/appellant-case/valid/environmental-services-review`
 				);
 			});
+
 			it('should handle posting environmental services review details', async () => {
 				nock('http://test/')
 					.patch(`/appeals/${appealId}/appellant-cases/0`, {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.controller.js
@@ -362,6 +362,38 @@ export const postEnforcementValidDate = async (request, response) => {
 			return renderEnforcementValidDate(request, response, errorMessage);
 		}
 
+		const { createdAt } = currentAppeal;
+		const validDateISOString = dayMonthYearHourMinuteToISOString({
+			year: updatedValidDateYear,
+			month: updatedValidDateMonth,
+			day: updatedValidDateDay
+		});
+
+		const {
+			day: createdAtDay,
+			month: createdAtMonth,
+			year: createdAtYear
+		} = dateISOStringToDayMonthYearHourMinute(createdAt);
+		const createdAtDateAtMidnight = dayMonthYearHourMinuteToISOString({
+			day: createdAtDay,
+			month: createdAtMonth,
+			year: createdAtYear
+		});
+
+		if (isBefore(new Date(validDateISOString), new Date(createdAtDateAtMidnight))) {
+			const /** @type {import('@pins/express').ValidationErrors} */ errorMessage = {
+					'valid-date-day': {
+						location: 'body',
+						path: 'all-fields',
+						value: '',
+						type: 'field',
+						msg: 'The valid date must be on or after the date the case was received.'
+					}
+				};
+
+			return renderEnforcementValidDate(request, response, errorMessage);
+		}
+
 		session.webAppellantCaseReviewOutcome = {
 			...session.webAppellantCaseReviewOutcome,
 			updatedValidDateDay,
@@ -393,16 +425,23 @@ export const postEnforcementValidDate = async (request, response) => {
  */
 const renderEnforcementValidDate = async (request, response, apiErrors) => {
 	const {
-		currentAppeal: { appealId, appealReference },
+		currentAppeal: { appealId, appealReference, createdAt },
 		session: { webAppellantCaseReviewOutcome }
 	} = request;
+	const createdDayMonthYear = dateISOStringToDayMonthYearHourMinute(createdAt);
 
 	const dateValidDay =
-		request.body['valid-date-day'] || webAppellantCaseReviewOutcome?.updatedValidDateDay;
+		request.body['valid-date-day'] ||
+		webAppellantCaseReviewOutcome?.updatedValidDateDay ||
+		createdDayMonthYear.day;
 	const dateValidMonth =
-		request.body['valid-date-month'] || webAppellantCaseReviewOutcome?.updatedValidDateMonth;
+		request.body['valid-date-month'] ||
+		webAppellantCaseReviewOutcome?.updatedValidDateMonth ||
+		createdDayMonthYear.month;
 	const dateValidYear =
-		request.body['valid-date-year'] || webAppellantCaseReviewOutcome?.updatedValidDateYear;
+		request.body['valid-date-year'] ||
+		webAppellantCaseReviewOutcome?.updatedValidDateYear ||
+		createdDayMonthYear.year;
 
 	let errors = request.errors || apiErrors;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.mapper.js
@@ -219,7 +219,7 @@ export function updateEnforcementValidDatePage(
 		backLinkUrl: `/appeals-service/appeal-details/${appealId}/appellant-case/valid/enforcement/other-information`,
 		preHeading: `Appeal ${appealShortReference(appealReference)}`,
 		backLinkText: 'Back',
-		submitButtonText: 'Confirm',
+		submitButtonText: 'Continue',
 		pageComponents: [descriptiveHtml, selectDateComponent]
 	};
 


### PR DESCRIPTION
…339)

## Describe your changes

- Adding in the same error and autofill logic to the valid date for enforcement and ELB that already exists for other appeal types
- Changing the button to say 'Continue' rather than 'Confirm'
- Tests to check this

Tested locally, including testing that for a HAS appeal it still says 'Confirm'

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8339)
