### PR TITLE
fix(web): added condition to hide upload option (a2-8458)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-main.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-main.test.js
@@ -203,6 +203,7 @@ describe('appellant-case-main', () => {
 				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
 				expect(unprettifiedElement.innerHTML).not.toContain('Plans, drawings and list of plans');
+				expect(unprettifiedElement.innerHTML).not.toContain('Design and access statement');
 			}
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
@@ -60,9 +60,11 @@ export function generateCASComponents(
 						? [mappedAppellantCaseData.appealStatement.display.summaryListItem]
 						: []),
 					mappedAppellantCaseData.costsDocument.display.summaryListItem,
-					mappedAppellantCaseData.designAndAccessStatement.display.summaryListItem,
 					...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
-						? [mappedAppellantCaseData.supportingDocuments.display.summaryListItem]
+						? [
+								mappedAppellantCaseData.designAndAccessStatement.display.summaryListItem,
+								mappedAppellantCaseData.supportingDocuments.display.summaryListItem
+							]
 						: [])
 				]
 			}


### PR DESCRIPTION
- Added condition in CAS appellant case mapper which hides upload option for cases after application cut off date  
- Added test

Ticket: https://pins-ds.atlassian.net/browse/A2-8458


