### PR TITLE
fix(appeals): remove appellant statement row from expedited S78 appeals (A2-8600)

### DIFF
--- a/appeals/pdf-service-api/src/mappers/__tests__/build-rows.test.js
+++ b/appeals/pdf-service-api/src/mappers/__tests__/build-rows.test.js
@@ -1,0 +1,87 @@
+// @ts-nocheck
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { buildRows } from '../build-rows.js';
+
+describe('buildRows', () => {
+	const mockRowBuilders = {
+		originalApplicationForm: (data) => ({
+			key: 'Application form',
+			value: data.applicationFormValue
+		}),
+		appellantStatement: (data) => ({ key: 'Appeal statement', value: data.appealStatementValue }),
+		changedDescription: (data) => ({
+			key: 'Changed description',
+			value: data.changedDescriptionValue
+		})
+	};
+
+	const mockRowKeys = {
+		[APPEAL_TYPE.HOUSEHOLDER]: [
+			'originalApplicationForm',
+			{ key: 'appellantStatement', condition: (data) => data.showStatement },
+			{ key: 'changedDescription', condition: (data) => data.showChangedDescription }
+		],
+		[APPEAL_TYPE.S78_EXPEDITED]: ['originalApplicationForm', 'appellantStatement']
+	};
+
+	it('should return an empty array if template data is missing or lacks appealType', () => {
+		expect(buildRows(null, mockRowBuilders, mockRowKeys)).toEqual([]);
+		expect(buildRows({}, mockRowBuilders, mockRowKeys)).toEqual([]);
+	});
+
+	it('should build rows correctly based on simple string keys', () => {
+		const templateData = {
+			appealType: APPEAL_TYPE.HOUSEHOLDER,
+			applicationFormValue: 'form.pdf',
+			showStatement: false,
+			showChangedDescription: false
+		};
+		const result = buildRows(templateData, mockRowBuilders, mockRowKeys);
+
+		expect(result).toEqual([{ key: 'Application form', value: 'form.pdf' }]);
+	});
+
+	it('should include conditional rows when condition is met (returns true)', () => {
+		const templateData = {
+			appealType: APPEAL_TYPE.HOUSEHOLDER,
+			applicationFormValue: 'form.pdf',
+			appealStatementValue: 'statement.pdf',
+			showStatement: true,
+			showChangedDescription: false
+		};
+		const result = buildRows(templateData, mockRowBuilders, mockRowKeys);
+
+		expect(result).toEqual([
+			{ key: 'Application form', value: 'form.pdf' },
+			{ key: 'Appeal statement', value: 'statement.pdf' }
+		]);
+	});
+
+	it('should use S78_EXPEDITED keys if templateData.isS78Expedited is true', () => {
+		const templateData = {
+			appealType: APPEAL_TYPE.S78,
+			isS78Expedited: true,
+			applicationFormValue: 'form.pdf',
+			appealStatementValue: 'statement.pdf'
+		};
+		const result = buildRows(templateData, mockRowBuilders, mockRowKeys);
+
+		expect(result).toEqual([
+			{ key: 'Application form', value: 'form.pdf' },
+			{ key: 'Appeal statement', value: 'statement.pdf' }
+		]);
+	});
+
+	it('should skip row if builder is not a function', () => {
+		const badRowKeys = {
+			[APPEAL_TYPE.HOUSEHOLDER]: ['originalApplicationForm', 'rowDoesNotExist']
+		};
+		const templateData = {
+			appealType: APPEAL_TYPE.HOUSEHOLDER,
+			applicationFormValue: 'form.pdf'
+		};
+		const result = buildRows(templateData, mockRowBuilders, badRowKeys);
+
+		expect(result).toEqual([{ key: 'Application form', value: 'form.pdf' }]);
+	});
+});

--- a/appeals/pdf-service-api/src/mappers/appellant-case/__tests__/__snapshots__/appellant-case.mapper.test.js.snap
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/__tests__/__snapshots__/appellant-case.mapper.test.js.snap
@@ -1224,10 +1224,6 @@ exports[`mapAppellantCaseData appellantCase should map appellant case data for a
         },
         {
           "html": "No documents",
-          "key": "Appeal statement",
-        },
-        {
-          "html": "No documents",
           "key": "Planning obligation",
         },
         {

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents/row-keys.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents/row-keys.js
@@ -64,7 +64,6 @@ export const rowKeys = {
 		'changedDescription',
 		'reasonForAppealAppellant',
 		'applicationDecisionLetter',
-		'appellantStatement',
 		'planningObligation',
 		'statementCommonGround',
 		'ownershipCertificate',

--- a/appeals/pdf-service-api/src/mappers/build-rows.js
+++ b/appeals/pdf-service-api/src/mappers/build-rows.js
@@ -1,5 +1,16 @@
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
+/**
+ * Supports conditional row key definitions in the `rowKeys` configuration.
+ * A row key item can either be a simple string (e.g. `'appellantStatement'`) or a conditional
+ * object like this: `{ key: string, condition: (data: any) => boolean }`.
+ * If the condition function returns `false` for the given template data, the row is excluded.
+ *
+ * @param {any} templateData The raw data passed to the template rendering context.
+ * @param {Record<string, (data: any) => any>} rowBuilders Map of row key identifiers to builder functions.
+ * @param {Record<string, Array<string | { key: string, condition: (data: any) => boolean }>>} rowKeys Map of appeal types to lists of active row configurations.
+ * @returns {any[]} Array of built row objects for the PDF layout.
+ */
 export const buildRows = (templateData, rowBuilders, rowKeys) => {
 	if (!templateData || !templateData.appealType) {
 		console.warn('Template data or appeal type is missing. Cannot build constraints rows.');
@@ -15,7 +26,17 @@ export const buildRows = (templateData, rowBuilders, rowKeys) => {
 	}
 
 	return constraintRowKeys
-		.map((key) => {
+		.map((/** @type {any} */ item) => {
+			let key;
+			if (typeof item === 'object' && item !== null) {
+				if (typeof item.condition === 'function' && !item.condition(templateData)) {
+					return null;
+				}
+				key = item.key;
+			} else {
+				key = item;
+			}
+
 			const rowBuilder = rowBuilders[key];
 			if (typeof rowBuilder !== 'function') {
 				console.warn(`No row builder function found for key: ${key}`);

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78-expedited.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78-expedited.mapper.js
@@ -144,7 +144,6 @@ export function generateS78ExpeditedComponents(
 					mappedAppellantCaseData.applicationForm.display.summaryListItem,
 					mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
 					mappedAppellantCaseData.decisionLetter.display.summaryListItem,
-					mappedAppellantCaseData.appealStatement.display.summaryListItem,
 					mappedAppellantCaseData.planningObligation.display.summaryListItem,
 					...(mappedAppellantCaseData.statementCommonGround
 						? [mappedAppellantCaseData.statementCommonGround.display.summaryListItem]


### PR DESCRIPTION
## Describe your changes

S78 Expedited Updates: 
Removed the "Appeal statement" row from the S78 expedited appeal details page and generated PDF.
Row-Filtering Mechanism:
 Refactored buildRows to support conditional row keys with { key, condition } for future scaling (HAS/CAS).

Testing: Added new unit tests for buildRows and verified all existing PDF/web test suites pass.
Manually tested in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8600)
