### PR TITLE
fix(api): handle publishing for appellantCase cost doc (A2-8547)

### DIFF
--- a/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
+++ b/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
@@ -377,6 +377,16 @@ describe('map-document-entity', () => {
 			expectedDocumentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
 			expectedCaseStage: APPEAL_CASE_STAGE.COSTS,
 			expectedPublishedDocumentUri: null
+		},
+		{
+			desc: 'appellant case cost unpublished - still broadcast as published',
+			documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+			representationType: null,
+			caseStage: APPEAL_CASE_STAGE.APPELLANT_CASE,
+			isPublished: false,
+			expectedDocumentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+			expectedCaseStage: APPEAL_CASE_STAGE.APPELLANT_CASE,
+			expectedPublishedDocumentUri: testUri
 		}
 	])(
 		'handles document type: $desc',

--- a/appeals/api/src/server/mappers/integration/map-document-entity.js
+++ b/appeals/api/src/server/mappers/integration/map-document-entity.js
@@ -126,9 +126,11 @@ const mapPublishedFields = (documentVersion) => {
 	}
 
 	// only costs docs currently use internally managed published statuses
+	// the costs application from the appellant case works as a standard appellant case doc
 	if (
 		documentVersion.documentType &&
-		documentTypesWithManagedPublishedStatuses.has(documentVersion.documentType)
+		documentTypesWithManagedPublishedStatuses.has(documentVersion.documentType) &&
+		documentVersion.stage !== APPEAL_CASE_STAGE.APPELLANT_CASE
 	) {
 		const isPublished = documentVersion.published;
 		return {


### PR DESCRIPTION
## Describe your changes

Defaults appellant costs applications from the appellant case to be published
So it works with the same logic as from before costs changes moved to manual sharing model

- those uploaded manually have to be shared before showing to users
- comes in via appellant case it will follow the same rules as the case itself being visible

## Issue ticket number and link

Ticket: https://pins-ds.atlassian.net/browse/A2-8637
