### PR TITLE
feat(appeals): add expedited has fields to the PDF generator (A2-8462)

### DIFF
--- a/appeals/pdf-service-api/src/lib/utils/format-significant-changes.js
+++ b/appeals/pdf-service-api/src/lib/utils/format-significant-changes.js
@@ -1,0 +1,33 @@
+import { formatYesNoDetails } from '../nunjucks-filters/format-yes-no-details.js';
+
+/**
+ * @param {any} anySignificantChanges
+ * @param {any} anySignificantChanges_otherSignificantChanges
+ * @param {any} anySignificantChanges_localPlanSignificantChanges
+ * @param {any} anySignificantChanges_nationalPolicySignificantChanges
+ * @param {any} anySignificantChanges_courtJudgementSignificantChanges
+ * @returns {any}
+ */
+export default function formatAnySignificantChanges(
+	anySignificantChanges,
+	anySignificantChanges_otherSignificantChanges,
+	anySignificantChanges_localPlanSignificantChanges,
+	anySignificantChanges_nationalPolicySignificantChanges,
+	anySignificantChanges_courtJudgementSignificantChanges
+) {
+	const details = [];
+
+	if (anySignificantChanges_localPlanSignificantChanges) {
+		details.push(`Local plan: ${anySignificantChanges_localPlanSignificantChanges}`);
+	}
+	if (anySignificantChanges_nationalPolicySignificantChanges) {
+		details.push(`National policy: ${anySignificantChanges_nationalPolicySignificantChanges}`);
+	}
+	if (anySignificantChanges_courtJudgementSignificantChanges) {
+		details.push(`Court judgment: ${anySignificantChanges_courtJudgementSignificantChanges}`);
+	}
+	if (anySignificantChanges_otherSignificantChanges) {
+		details.push(`Other: ${anySignificantChanges_otherSignificantChanges}`);
+	}
+	return anySignificantChanges ? formatYesNoDetails(details) : 'No';
+}

--- a/appeals/pdf-service-api/src/mappers/appellant-case/__tests__/__snapshots__/appellant-case.mapper.test.js.snap
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/__tests__/__snapshots__/appellant-case.mapper.test.js.snap
@@ -478,6 +478,155 @@ exports[`mapAppellantCaseData appellantCase should map appellant case data for a
 }
 `;
 
+exports[`mapAppellantCaseData appellantCase should map appellant case data for a householder submitted after cutoff appeal 1`] = `
+{
+  "details": {
+    "appealReference": "6000073",
+    "appealSite": {
+      "addressId": 72,
+      "addressLine1": "Copthalls",
+      "addressLine2": "Clevedon Road",
+      "postCode": "BS48 1PN",
+      "town": "West Hill",
+    },
+    "localPlanningDepartment": "Maidstone Borough Council",
+  },
+  "sections": [
+    {
+      "heading": "Before you start",
+      "items": [
+        {
+          "html": "Maidstone Borough Council",
+          "key": "Local planning authority",
+        },
+        {
+          "key": "What type of application is your appeal about?",
+          "text": "Householder appeal",
+        },
+        {
+          "key": "Was your application granted or refused?",
+          "text": "Refused",
+        },
+        {
+          "key": "What’s the date on the decision letter from the local planning authority?",
+          "text": "3 June 2025",
+        },
+        {
+          "key": "Are you claiming costs as part of your appeal?",
+          "text": "Not answered",
+        },
+        {
+          "key": "What is the application reference number?",
+          "text": "44377/APP/3/218453",
+        },
+      ],
+    },
+    {
+      "heading": "Appellant details",
+      "items": [
+        {
+          "html": "Sophie Skinner<br />test4@example.com",
+          "key": "Appellant details",
+        },
+        {
+          "html": "Lee Thornton<br />Lee Thornton Ltd<br />test1@example.com",
+          "key": "Agent details",
+        },
+      ],
+    },
+    {
+      "heading": "Site details",
+      "items": [
+        {
+          "html": "Copthalls, Clevedon Road, West Hill, BS48 1PN",
+          "key": "What is the address of the appeal site?",
+        },
+        {
+          "key": "What is the area of the appeal site?",
+          "text": "30.9 m²",
+        },
+        {
+          "key": "Is the appeal site in a green belt?",
+          "text": "No",
+        },
+        {
+          "key": "Does the appellant own all of the land involved in the appeal?",
+          "text": "Fully owned",
+        },
+        {
+          "key": "Does the appellant know who owns the land involved in the appeal?",
+          "text": "No data",
+        },
+        {
+          "html": "No",
+          "key": "Will an inspector need to access your land or property?",
+        },
+        {
+          "html": "No",
+          "key": "Are there any health and safety issues on the appeal site?",
+        },
+        {
+          "html": "Yes<br>Other: Other changes",
+          "key": "Have there been any significant changes that would affect the application?",
+        },
+      ],
+    },
+    {
+      "heading": "Application details",
+      "items": [
+        {
+          "key": "What date did you submit your application?",
+          "text": "1 April 2026",
+        },
+        {
+          "key": "Enter the description of development that you submitted in your application",
+          "text": "Lorem ipsum",
+        },
+        {
+          "html": "No",
+          "key": "Are there other appeals linked to your development?",
+        },
+        {
+          "html": "No documents",
+          "key": "Decision letter from the local planning authority",
+        },
+        {
+          "key": "Why are you appealing?",
+          "text": "My reason for appeal",
+        },
+      ],
+    },
+    undefined,
+    {
+      "heading": "Upload documents",
+      "items": [
+        {
+          "html": "No documents",
+          "key": "Application form",
+        },
+        {
+          "html": "No documents",
+          "key": "Agreement to change the description of development",
+        },
+        {
+          "html": "No documents",
+          "key": "Application for an award of appeal costs",
+        },
+      ],
+    },
+    {
+      "heading": "Additional documents",
+      "items": [
+        {
+          "html": "No documents",
+          "key": "",
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`mapAppellantCaseData appellantCase should map appellant case data for a ldc appeal 1`] = `
 {
   "details": {
@@ -1213,10 +1362,6 @@ exports[`mapAppellantCaseData appellantCase should map appellant case data for a
         {
           "html": "No documents",
           "key": "Agreement to change the description of development",
-        },
-        {
-          "key": "Why are you appealing?",
-          "text": "Not provided",
         },
         {
           "html": "No documents",

--- a/appeals/pdf-service-api/src/mappers/appellant-case/__tests__/appellant-case.mapper.test.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/__tests__/appellant-case.mapper.test.js
@@ -5,6 +5,16 @@ describe('mapAppellantCaseData', () => {
 	describe('appellantCase', () => {
 		it.each([
 			['householder', mockAppellantCaseData.appellantCaseDataHouseholder],
+			[
+				'householder submitted after cutoff',
+				{
+					...mockAppellantCaseData.appellantCaseDataHouseholder,
+					applicationDate: '2026-04-01T00:00:00.000Z',
+					reasonForAppealAppellant: 'My reason for appeal',
+					anySignificantChanges: true,
+					anySignificantChanges_otherSignificantChanges: 'Other changes'
+				}
+			],
 			['s78', mockAppellantCaseData.appellantCaseDataS78],
 			['s78 expedited', mockAppellantCaseData.appellantCaseDataS78Expedited],
 			['s20', mockAppellantCaseData.appellantCaseDataS20],

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/application-details/row-keys.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/application-details/row-keys.js
@@ -1,10 +1,16 @@
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
+
 export const rowKeys = {
 	[APPEAL_TYPE.HOUSEHOLDER]: [
 		'applicationDate',
 		'developmentDescription',
 		'otherAppealsList',
-		'applicationDecisionLetter'
+		'applicationDecisionLetter',
+		{
+			key: 'reasonForAppealAppellant',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data.applicationDate)
+		}
 	],
 	[APPEAL_TYPE.CAS_PLANNING]: [
 		'applicationDate',

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/application-details/rows.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/application-details/rows.js
@@ -5,7 +5,6 @@ import {
 	formatDocumentData,
 	formatSentenceCase
 } from '../../../../lib/nunjucks-filters/index.js';
-
 export const rowBuilders = {
 	applicationDate: (data) => ({
 		key: 'What date did you submit your application?',
@@ -40,5 +39,9 @@ export const rowBuilders = {
 	applicationDecisionLetter: (data) => ({
 		key: 'Decision letter from the local planning authority',
 		html: formatDocumentData(data.documents.applicationDecisionLetter)
+	}),
+	reasonForAppealAppellant: (data) => ({
+		key: 'Why are you appealing?',
+		text: formatSentenceCase(data.reasonForAppealAppellant, 'Not provided')
 	})
 };

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/site-details/row-keys.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/site-details/row-keys.js
@@ -1,4 +1,5 @@
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 export const rowKeys = {
 	[APPEAL_TYPE.HOUSEHOLDER]: [
 		'appealSite',
@@ -7,7 +8,12 @@ export const rowKeys = {
 		'ownsAllLand',
 		'knowsOtherLandowners',
 		'siteAccessRequired',
-		'healthAndSafety'
+		'healthAndSafety',
+		{
+			key: 'anySignificantChanges',
+			condition: (/** @type {any} */ data) =>
+				!beforeExpeditedOriginalApplicationCutOff(data.applicationDate)
+		}
 	],
 	[APPEAL_TYPE.CAS_PLANNING]: [
 		'appealSite',

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/site-details/rows.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/site-details/rows.js
@@ -4,6 +4,7 @@ import {
 	formatYesNo,
 	formatYesNoDetails
 } from '../../../../lib/nunjucks-filters/index.js';
+import formatAnySignificantChanges from '../../../../lib/utils/format-significant-changes.js';
 
 /**
  * @param {any} area
@@ -63,38 +64,6 @@ function formatOwnsAllLand(siteOwnership) {
 	if (siteOwnership.ownsSomeLand) return 'Partially owned';
 
 	return 'Not owned';
-}
-
-/**
- * @param {any} anySignificantChanges
- * @param {any} anySignificantChanges_otherSignificantChanges
- * @param {any} anySignificantChanges_localPlanSignificantChanges
- * @param {any} anySignificantChanges_nationalPolicySignificantChanges
- * @param {any} anySignificantChanges_courtJudgementSignificantChanges
- * @returns {any}
- */
-function formatAnySignificantChanges(
-	anySignificantChanges,
-	anySignificantChanges_otherSignificantChanges,
-	anySignificantChanges_localPlanSignificantChanges,
-	anySignificantChanges_nationalPolicySignificantChanges,
-	anySignificantChanges_courtJudgementSignificantChanges
-) {
-	const details = [];
-
-	if (anySignificantChanges_localPlanSignificantChanges) {
-		details.push(`Local plan: ${anySignificantChanges_localPlanSignificantChanges}`);
-	}
-	if (anySignificantChanges_nationalPolicySignificantChanges) {
-		details.push(`National policy: ${anySignificantChanges_nationalPolicySignificantChanges}`);
-	}
-	if (anySignificantChanges_courtJudgementSignificantChanges) {
-		details.push(`Court judgment: ${anySignificantChanges_courtJudgementSignificantChanges}`);
-	}
-	if (anySignificantChanges_otherSignificantChanges) {
-		details.push(`Other: ${anySignificantChanges_otherSignificantChanges}`);
-	}
-	return anySignificantChanges ? formatYesNoDetails(details) : 'No';
 }
 
 /** @type {Record<string, (data: any) => any>} */

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents/row-keys.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents/row-keys.js
@@ -1,9 +1,13 @@
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 export const rowKeys = {
 	[APPEAL_TYPE.HOUSEHOLDER]: [
 		'originalApplicationForm',
 		'changedDescription',
-		'appellantStatement',
+		{
+			key: 'appellantStatement',
+			condition: (data) => beforeExpeditedOriginalApplicationCutOff(data.applicationDate)
+		},
 		'appellantApplicationFolder'
 	],
 	[APPEAL_TYPE.CAS_PLANNING]: [
@@ -62,7 +66,6 @@ export const rowKeys = {
 		'environmentalStatement',
 		'changedDevelopmentDescription',
 		'changedDescription',
-		'reasonForAppealAppellant',
 		'applicationDecisionLetter',
 		'planningObligation',
 		'statementCommonGround',

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents/rows.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents/rows.js
@@ -32,10 +32,6 @@ export const rowBuilders = {
 		key: 'Agreement to change the description of development',
 		html: formatDocumentData(data.documents.changedDescription)
 	}),
-	reasonForAppealAppellant: (data) => ({
-		key: 'Why are you appealing?',
-		text: formatSentenceCase(data.reasonForAppealAppellant, 'Not provided')
-	}),
 	applicationDecisionLetter: (data) => ({
 		key: 'Decision letter from the local planning authority',
 		html: formatDocumentData(data.documents.applicationDecisionLetter)


### PR DESCRIPTION
## Describe your changes

This PR adds the required fields with conditional display to the HAS PDF generator.
It also reorganises the categories of the PDF fields to match how the appeal details screen is displayed.

Updated unit tests.
Manually tested in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8462)
