### PR TITLE
fix(web): validate API parameters that come from request parameters (no-ticket)

### DIFF
--- a/appeals/web/src/server/app/components/file-uploader.component.js
+++ b/appeals/web/src/server/app/components/file-uploader.component.js
@@ -1,4 +1,5 @@
 import logger from '#lib/logger.js';
+import { assertValidIds, assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /** @typedef {import('@pins/appeals/index.js').AddDocumentsRequest} AddDocumentsRequest */
 /** @typedef {import('@pins/appeals/index.js').AddDocumentVersionRequest} AddDocumentVersionRequest */
@@ -12,7 +13,10 @@ import logger from '#lib/logger.js';
  */
 export const createNewDocument = async (apiClient, caseId, payload) => {
 	try {
-		const result = await apiClient.post(`appeals/${caseId}/documents`, { json: payload }).json();
+		const ids = assertValidNumericIds({ caseId });
+		const result = await apiClient
+			.post(`appeals/${ids.caseId}/documents`, { json: payload })
+			.json();
 		return result;
 	} catch (error) {
 		logger.error(
@@ -33,8 +37,10 @@ export const createNewDocument = async (apiClient, caseId, payload) => {
  * @returns {Promise<AddDocumentsResponse>}
  */
 export const createNewDocumentVersion = async (apiClient, caseId, documentId, payload) => {
+	const ids = assertValidNumericIds({ caseId });
+	const guids = assertValidIds({ documentId });
 	const result = apiClient
-		.post(`appeals/${caseId}/documents/${documentId}`, { json: payload })
+		.post(`appeals/${ids.caseId}/documents/${guids.documentId}`, { json: payload })
 		.json();
 	return result;
 };

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
@@ -1,3 +1,5 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
+
 /**
  *
  * @param {import('got').Got} apiClient
@@ -10,7 +12,8 @@ export function getAppealDetailsFromId(apiClient, appealId, include) {
 		throw new Error('include=all is not allowed, select only the keys needed');
 	}
 
-	const encodedAppealId = encodeURIComponent(appealId);
+	const ids = assertValidNumericIds({ appealId });
+	const encodedAppealId = encodeURIComponent(ids.appealId);
 	const url = include
 		? `appeals/${encodedAppealId}?include=${include}`
 		: `appeals/${encodedAppealId}`;
@@ -37,7 +40,8 @@ export function getAppealDetailsPageFromId(apiClient, appealId) {
  * @returns {Promise<import('./appeal-details.types.js').WebAppeal>}
  */
 export function deprecatedGetAppealDetailsFromId(apiClient, appealId) {
-	const encodedAppealId = encodeURIComponent(appealId);
+	const ids = assertValidNumericIds({ appealId });
+	const encodedAppealId = encodeURIComponent(ids.appealId);
 	const url = `appeals/${encodedAppealId}?include=all`;
 
 	return apiClient.get(url).json();
@@ -50,7 +54,8 @@ export function deprecatedGetAppealDetailsFromId(apiClient, appealId) {
  * @returns {Promise<{id: number}>}
  */
 export function checkAppealExists(apiClient, appealId) {
-	const encodedAppealId = encodeURIComponent(appealId);
+	const ids = assertValidNumericIds({ appealId });
+	const encodedAppealId = encodeURIComponent(ids.appealId);
 	const url = `appeals/${encodedAppealId}/exists`;
 
 	return apiClient.get(url).json();
@@ -67,7 +72,8 @@ export function setEnvironmentalImpactAssessmentScreening(
 	appealId,
 	eiaScreeningRequired
 ) {
-	const encodedAppealId = encodeURIComponent(appealId);
+	const ids = assertValidNumericIds({ appealId });
+	const encodedAppealId = encodeURIComponent(ids.appealId);
 	return apiClient
 		.patch(`appeals/${encodedAppealId}/eia-screening-required`, {
 			json: { eiaScreeningRequired }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/address/address.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/address/address.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -15,7 +16,8 @@ export function changeSiteAddress(apiClient, appealId, siteAddress, addressId) {
 		town: siteAddress.town
 	};
 
-	return apiClient.patch(`appeals/${appealId}/addresses/${addressId}`, {
+	const ids = assertValidNumericIds({ appealId, addressId });
+	return apiClient.patch(`appeals/${ids.appealId}/addresses/${ids.addressId}`, {
 		json: {
 			...formattedSiteAddress
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/advertisement-description/advertisement-description.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/advertisement-description/advertisement-description.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeAdvertisementDescription(apiClient, appealId, appellantCaseId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			// uses developmentDescription in db
 			developmentDescription: {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/advertisement-in-position/advertisement-in-position.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/advertisement-in-position/advertisement-in-position.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeAdvertisementInPosition(apiClient, appealId, appellantCaseId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			advertInPosition: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changePartOfAgriculturalHolding(
 	appellantCaseId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			agriculturalHolding: updatedValue
 		}
@@ -31,7 +33,8 @@ export function changeTenantOfAgriculturalHolding(
 	appellantCaseId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			tenantAgriculturalHolding: updatedValue
 		}
@@ -51,7 +54,8 @@ export function changeOtherTenantsOfAgriculturalHolding(
 	appellantCaseId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			otherTenantsAgriculturalHolding: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/alleged-breach-description/alleged-breach-description.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/alleged-breach-description/alleged-breach-description.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -12,7 +13,8 @@ export function changeAllegedBreachDescription(
 	appellantCaseId,
 	descriptionOfAllegedBreach
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			descriptionOfAllegedBreach
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/any-significant-changes/any-significant-changes.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/any-significant-changes/any-significant-changes.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeSignificantChanges(apiClient, appealId, appellantCaseId, updatedValues) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			anySignificantChanges: updatedValues.anySignificantChanges,
 			anySignificantChanges_localPlanSignificantChanges:

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appeal-decision-date/appeal-decision-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appeal-decision-date/appeal-decision-date.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function ChangeAppealDecisionDate(apiClient, appealId, appellantCaseId, appealDecisionDate) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			appealDecisionDate
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @typedef {import('@pins/appeals.api').Appeals.ReasonOption} ReasonOption
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -10,7 +11,8 @@
  * @param {number|string} appellantCaseId
  */
 export function getAppellantCaseFromAppealId(apiClient, appealId, appellantCaseId) {
-	return apiClient.get(`appeals/${appealId}/appellant-cases/${appellantCaseId}`).json();
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.get(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`).json();
 }
 
 /**
@@ -26,8 +28,9 @@ export async function setReviewOutcomeForAppellantCase(
 	appellantCaseId,
 	reviewOutcome
 ) {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
 	return apiClient
-		.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+		.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 			json: reviewOutcome
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeApplicationDecisionDate(apiClient, appealId, appellantCaseId, updatedDate) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			applicationDecisionDate: updatedDate
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-development-all-or-part/application-development-all-or-part.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-development-all-or-part/application-development-all-or-part.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeApplicationDevelopmentAllOrPart(
 	appellantCaseId,
 	applicationDevelopmentAllOrPart
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			applicationDevelopmentAllOrPart
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-development-type/application-development-type.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-development-type/application-development-type.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeDevelopmentType(apiClient, appealId, appellantCaseId, developmentType) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			developmentType
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeApplicationOutcome(apiClient, appealId, appellantCaseId, applicationOutcome) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			applicationDecision: applicationOutcome
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeApplicationSubmissionDate(apiClient, appealId, appellantCaseId, updatedDate) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			applicationDate: updatedDate
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/contact-address/contact-address.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/contact-address/contact-address.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 import { manageContactAddressPage } from './contact-address.mapper.js';
 
 /**
@@ -28,15 +29,19 @@ export const renderManageContactAddress = async (request, response) => {
  * @param {*} contactAddress
  */
 export const addContactAddress = async (apiClient, appealId, appellantCaseId, contactAddress) => {
-	return apiClient.post(`appeals/${appealId}/appellant-cases/${appellantCaseId}/contact-address`, {
-		json: {
-			addressLine1: contactAddress.addressLine1,
-			addressLine2: contactAddress.addressLine2,
-			addressTown: contactAddress.town,
-			addressCounty: contactAddress.county,
-			postcode: contactAddress.postCode
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.post(
+		`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}/contact-address`,
+		{
+			json: {
+				addressLine1: contactAddress.addressLine1,
+				addressLine2: contactAddress.addressLine2,
+				addressTown: contactAddress.town,
+				addressCounty: contactAddress.county,
+				postcode: contactAddress.postCode
+			}
 		}
-	});
+	);
 };
 
 /**
@@ -53,8 +58,9 @@ export const updateContactAddress = async (
 	contactAddressId,
 	contactAddress
 ) => {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId, contactAddressId });
 	return apiClient.patch(
-		`appeals/${appealId}/appellant-cases/${appellantCaseId}/contact-address/${contactAddressId}`,
+		`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}/contact-address/${contactAddressId}`,
 		{
 			json: {
 				addressLine1: contactAddress.addressLine1,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/contact-planning-inspectorate-date/contact-planning-inspectorate-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/contact-planning-inspectorate-date/contact-planning-inspectorate-date.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeContactPlanningInspectorateDate(
 	appellantCaseId,
 	contactPlanningInspectorateDate
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			contactPlanningInspectorateDate
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeDevelopmentDescription(apiClient, appealId, appellantCaseId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			developmentDescription: {
 				details: updatedData

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/eia-screening/eia-screening.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/eia-screening/eia-screening.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function updateEiaScreening(apiClient, appealId, appellantCaseId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			screeningOpinionIndicatesEiaRequired: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-effective-date/enforcement-effective-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-effective-date/enforcement-effective-date.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeEnforcementEffectiveDate(
 	appellantCaseId,
 	enforcementEffectiveDate
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			enforcementEffectiveDate
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-issue-date/enforcement-issue-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-issue-date/enforcement-issue-date.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeEnforcementIssueDate(
 	appellantCaseId,
 	enforcementIssueDate
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			enforcementIssueDate
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-notice-listed-building/enforcement-notice-listed-building.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-notice-listed-building/enforcement-notice-listed-building.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -12,7 +13,8 @@ export function changeEnforcementNoticeListedBuilding(
 	appellantCaseId,
 	enforcementNoticeListedBuilding
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			enforcementNoticeListedBuilding
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-notice/enforcement-notice.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-notice/enforcement-notice.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -7,7 +8,8 @@
  * @returns {Promise<{}>}
  */
 export function changeEnforcementNotice(apiClient, appealId, appellantCaseId, enforcementNotice) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			enforcementNotice
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-reference/enforcement-reference.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/enforcement-reference/enforcement-reference.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -12,7 +13,8 @@ export function changeEnforcementReference(
 	appellantCaseId,
 	enforcementReference
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			enforcementReference
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/facts-for-ground/facts-for-ground.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/facts-for-ground/facts-for-ground.service.js
@@ -1,3 +1,8 @@
+import {
+	assertValidGroundRef,
+	assertValidNumericIds
+} from '#lib/validators/api-parameters.validator.js';
+
 /**
  *
  * @param {import('got').Got} apiClient
@@ -14,7 +19,9 @@ export function changeFactsForGround(
 	groundRef,
 	factsForGround
 ) {
-	return apiClient.patch(`appeals/${appealId}/grounds-for-appeal/${groundRef}`, {
+	const ids = assertValidNumericIds({ appealId });
+	const refs = assertValidGroundRef({ groundRef });
+	return apiClient.patch(`appeals/${ids.appealId}/grounds-for-appeal/${refs.groundRef}`, {
 		json: {
 			factsForGround
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/grid-reference/grid-reference.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/grid-reference/grid-reference.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -5,7 +6,8 @@
  * @param {{ siteGridReferenceEasting?: number | string, siteGridReferenceNorthing?: number | string }} gridRef
  */
 export function changeSiteGridReference(apiClient, appealId, appellantCaseId, gridRef) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			siteGridReferenceEasting: gridRef.siteGridReferenceEasting,
 			siteGridReferenceNorthing: gridRef.siteGridReferenceNorthing

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/grounds-for-appeal/grounds-for-appeal.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/grounds-for-appeal/grounds-for-appeal.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /** @typedef {import('@pins/appeals.api').Schema.Ground} Ground */
 
 /**
@@ -8,7 +9,8 @@
  * @returns {Promise<{}>}
  */
 export function changeGroundsForAppeal(apiClient, appealId, appellantCaseId, groundsForAppeal) {
-	return apiClient.patch(`appeals/${appealId}/grounds-for-appeal`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.patch(`appeals/${ids.appealId}/grounds-for-appeal`, {
 		json: {
 			groundsForAppeal
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/highway-land/highway-land.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/highway-land/highway-land.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -7,7 +8,8 @@
  * @returns {Promise<{}>}
  */
 export function changeHighwayLand(apiClient, appealId, appellantCaseId, updatedHighwayLand) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			highwayLand: updatedHighwayLand
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/interest-in-land/interest-in-land.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/interest-in-land/interest-in-land.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeInterestInLand(apiClient, appealId, appellantCaseId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			interestInLand: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/landowner-permission/landowner-permission.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/landowner-permission/landowner-permission.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeLandownerPermission(apiClient, appealId, appellantCaseId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			landownerPermission: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/ldc-type/ldc-type.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/ldc-type/ldc-type.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -12,7 +13,8 @@ export function changeApplicationMadeUnderActSection(
 	appellantCaseId,
 	applicationMadeUnderActSection
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			applicationMadeUnderActSection: applicationMadeUnderActSection
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-incomplete/outcome-incomplete.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-incomplete/outcome-incomplete.service.js
@@ -1,4 +1,5 @@
 import { dayMonthYearHourMinuteToISOString } from '#lib/dates.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { DEADLINE_HOUR, DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js';
 import {
@@ -98,8 +99,9 @@ export async function setReviewOutcomeForEnforcementNoticeAppellantCase(
 	appellantCaseId,
 	reviewOutcome
 ) {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
 	return apiClient
-		.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+		.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 			json: {
 				validationOutcome: reviewOutcome.validationOutcome,
 				enforcementNoticeInvalid: reviewOutcome.enforcementNoticeInvalid,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeOwnersKnown(apiClient, appealId, appellantCaseId, updatedOwnersKnown) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			knowsOtherOwners: updatedOwnersKnown.radio
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changePlanningObligationStatus(
 	appellantCaseId,
 	updatedPlanningObligationStatus
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			statusPlanningObligation: updatedPlanningObligationStatus
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/procedure-preference.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/procedure-preference.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeProcedurePreference(apiClient, appealId, appellantCaseId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			appellantProcedurePreference: updatedValue
 		}
@@ -26,7 +28,8 @@ export function changeProcedurePreferenceDetails(
 	appellantCaseId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			appellantProcedurePreferenceDetails: updatedValue
 		}
@@ -46,7 +49,8 @@ export function changeProcedurePreferenceDuration(
 	appellantCaseId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			appellantProcedurePreferenceDuration: updatedValue
 		}
@@ -61,7 +65,8 @@ export function changeProcedurePreferenceDuration(
  * @returns {Promise<{}>}
  */
 export function changeInquiryNumberOfWitnesses(apiClient, appealId, appellantCaseId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			appellantProcedurePreferenceWitnessCount: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/reason-for-appeal/reason-for-appeal.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/reason-for-appeal/reason-for-appeal.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeReasonForAppeal(apiClient, appealId, appellantCaseId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			reasonForAppealAppellant: updatedData
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/retrospective-application/retrospective-application.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/retrospective-application/retrospective-application.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeRetrospectiveApplication(apiClient, appealId, appellantCaseId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			retrospectiveApplication: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-area/site-area.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-area/site-area.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -7,7 +8,8 @@
  * @returns {Promise<{}>}
  */
 export function changeSiteArea(apiClient, appealId, appellantCaseId, updatedSiteArea) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			siteAreaSquareMetres: updatedSiteArea
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -13,7 +14,8 @@ export function changeSiteOwnership(apiClient, appealId, appellantCaseId, update
 				? { ownsAllLand: false, ownsSomeLand: true }
 				: { ownsAllLand: false, ownsSomeLand: false };
 
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			...formattedData
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-use-at-time-of-application/site-use-at-time-of-application.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-use-at-time-of-application/site-use-at-time-of-application.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -12,7 +13,8 @@ export function changeSiteUseAtTimeOfApplication(
 	appellantCaseId,
 	siteUseAtTimeOfApplication
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			siteUseAtTimeOfApplication: siteUseAtTimeOfApplication
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/written-or-verbal-permission/written-or-verbal-permission.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/written-or-verbal-permission/written-or-verbal-permission.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeWrittenOrVerbalPermission(
 	appellantCaseId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			writtenOrVerbalPermission: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /** @typedef {import('../appeal-details.types.js').WebAppeal} Appeal */
 /**
  * @typedef {Object} User
@@ -33,7 +34,8 @@ export async function setAppealAssignee(apiClient, appealId, assigneeUser, isIns
 	} else {
 		userJson = { caseOfficerId: assigneeUserId, caseOfficerName: assigneeUser.name };
 	}
-	return apiClient.patch(`appeals/${appealId}`, { json: userJson }).json();
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.patch(`appeals/${ids.appealId}`, { json: userJson }).json();
 }
 
 /**

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /** @typedef {import('@pins/appeals.api/src/server/endpoints/appeals').GetAuditTrailsResponse} GetAuditTrailsResponse */
 /** @typedef {import('@pins/appeals.api/src/server/openapi-types.js').AuditNotifications} AuditNotifications */
 
@@ -7,8 +8,10 @@
  * @param {string} appealId
  * @returns {Promise<GetAuditTrailsResponse>}
  */
-export const getAppealAudit = (apiClient, appealId) =>
-	apiClient.get(`appeals/${appealId}/audit-trails`).json();
+export const getAppealAudit = (apiClient, appealId) => {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.get(`appeals/${ids.appealId}/audit-trails`).json();
+};
 
 /**
  *
@@ -16,5 +19,7 @@ export const getAppealAudit = (apiClient, appealId) =>
  * @param {string} appealId
  * @returns {Promise<AuditNotifications>}
  */
-export const getAppealAuditNotifications = (apiClient, appealId) =>
-	apiClient.get(`appeals/${appealId}/audit-notifications`).json();
+export const getAppealAuditNotifications = (apiClient, appealId) => {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.get(`appeals/${ids.appealId}/audit-notifications`).json();
+};

--- a/appeals/web/src/server/appeals/appeal-details/case-notes/case-notes.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/case-notes/case-notes.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /** @typedef {import('@pins/appeals.api/src/server/endpoints/appeals').GetCaseNotesResponse} GetCaseNotesResponse */
 /** @typedef {import('@pins/appeals.api/src/server/endpoints/appeals').GetCaseNoteResponse} GetCaseNoteResponse */
 /**
@@ -7,7 +8,8 @@
  * @returns {Promise<GetCaseNotesResponse>}
  */
 export async function getAppealCaseNotes(apiClient, appealId) {
-	return await apiClient.get(`appeals/${appealId}/case-notes`).json();
+	const ids = assertValidNumericIds({ appealId });
+	return await apiClient.get(`appeals/${ids.appealId}/case-notes`).json();
 }
 
 /**
@@ -17,8 +19,9 @@ export async function getAppealCaseNotes(apiClient, appealId) {
  * @param {string} comment
  */
 export async function postAppealCaseNote(apiClient, appealId, comment) {
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.post(`appeals/${appealId}/case-notes`, {
+		.post(`appeals/${ids.appealId}/case-notes`, {
 			json: {
 				comment
 			}

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-details/local-planning-authority/local-planning-authority.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-details/local-planning-authority/local-planning-authority.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @returns {Promise <import('../../appeal-details.types.js').Lpa[]>}
@@ -13,8 +14,9 @@ export function getLpaList(apiClient) {
  * @returns {Promise <import('../../appeal-details.types.js').LpaChangeRequest>}
  */
 export function postChangeLpaRequest(apiClient, appealId, lpaId) {
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.post(`appeals/${appealId}/lpa`, {
+		.post(`appeals/${ids.appealId}/lpa`, {
 			json: { newLpaId: lpaId }
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.service.js
@@ -1,5 +1,6 @@
 import { appealSiteToAddressString } from '#lib/address-formatter.js';
 import { generateNotifyPreview } from '#lib/api/notify-preview.api.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 import { formatAppealTypeForNotify } from '@pins/appeals/utils/change-appeal-type.js';
 import { getTeamFromAppealId } from '../update-case-team/update-case-team.service.js';
 
@@ -25,7 +26,8 @@ export function getAppealTypes(apiClient, filterEnabled = false) {
  * @returns {Promise<import('#appeals/appeals.types.js').AppealType[]>}
  */
 export function getAppealTypesFromId(apiClient, appealId) {
-	return apiClient.get(`appeals/${appealId}/appeal-types`).json();
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.get(`appeals/${ids.appealId}/appeal-types`).json();
 }
 
 /**
@@ -42,8 +44,9 @@ export async function postAppealChangeRequest(
 	appealTypeId,
 	appealTypeFinalDate
 ) {
+	const ids = assertValidNumericIds({ appealId });
 	return await apiClient
-		.post(`appeals/${appealId}/appeal-change-request`, {
+		.post(`appeals/${ids.appealId}/appeal-change-request`, {
 			json: { newAppealTypeId: appealTypeId, newAppealTypeFinalDate: appealTypeFinalDate }
 		})
 		.json();
@@ -65,8 +68,9 @@ export async function postAppealResubmitMarkInvalidRequest(
 	appealTypeId,
 	appealTypeFinalDate
 ) {
+	const ids = assertValidNumericIds({ appealId });
 	return await apiClient
-		.post(`appeals/${appealId}/appeal-resubmit-mark-invalid`, {
+		.post(`appeals/${ids.appealId}/appeal-resubmit-mark-invalid`, {
 			json: {
 				newAppealTypeId: appealTypeId,
 				newAppealTypeFinalDate: appealTypeFinalDate,
@@ -84,8 +88,9 @@ export async function postAppealResubmitMarkInvalidRequest(
  * @returns {Promise<import('./change-appeal-type.types.js').ChangeAppealTypeRequest>}
  */
 export async function postAppealTransferRequest(apiClient, appealId, appealTypeId) {
+	const ids = assertValidNumericIds({ appealId });
 	return await apiClient
-		.post(`appeals/${appealId}/appeal-transfer-request`, {
+		.post(`appeals/${ids.appealId}/appeal-transfer-request`, {
 			json: { newAppealTypeId: appealTypeId }
 		})
 		.json();
@@ -103,8 +108,9 @@ export async function postAppealTransferConfirmation(
 	appealId,
 	transferredAppealHorizonReference
 ) {
+	const ids = assertValidNumericIds({ appealId });
 	return await apiClient
-		.post(`appeals/${appealId}/appeal-transfer-confirmation`, {
+		.post(`appeals/${ids.appealId}/appeal-transfer-confirmation`, {
 			json: { newAppealReference: transferredAppealHorizonReference }
 		})
 		.json();
@@ -201,8 +207,9 @@ export async function getUpdateAppealRequest(apiClient, appeal, changeAppealType
  * @returns {Promise<void>}
  */
 export async function postAppealUpdateRequest(apiClient, appealId, appealTypeId) {
+	const ids = assertValidNumericIds({ appealId });
 	return await apiClient
-		.post(`appeals/${appealId}/appeal-update-request`, {
+		.post(`appeals/${ids.appealId}/appeal-update-request`, {
 			json: { newAppealTypeId: appealTypeId }
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/change-procedure-check-and-confirm.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/change-procedure-check-and-confirm.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @typedef {import('../change-procedure-type.controller.js').ChangeProcedureTypeRequest} ChangeProcedureTypeRequest
  */
@@ -9,7 +10,8 @@
  * @returns {Promise<*>}
  */
 export const postProcedureChangeRequest = async (apiClient, appealId, data) => {
-	return await apiClient.post(`appeals/${appealId}/procedure-type-change-request`, {
+	const ids = assertValidNumericIds({ appealId });
+	return await apiClient.post(`appeals/${ids.appealId}/procedure-type-change-request`, {
 		json: data
 	});
 };

--- a/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -11,7 +12,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
 export function changeGreenBeltAppellant(apiClient, appealId, appellantCaseId, updatedGreenBelt) {
 	const formattedGreenBelt = convertFromYesNoToBoolean(updatedGreenBelt);
 
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			isGreenBelt: formattedGreenBelt
 		}
@@ -29,7 +31,8 @@ export function changeGreenBeltAppellant(apiClient, appealId, appellantCaseId, u
 export function changeGreenBeltLPA(apiClient, appealId, lpaQuestionnaireId, updatedGreenBelt) {
 	const formattedGreenBelt = convertFromYesNoToBoolean(updatedGreenBelt);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			isGreenBelt: formattedGreenBelt
 		}

--- a/appeals/web/src/server/appeals/appeal-details/inspector-access/inspector-access.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/inspector-access/inspector-access.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -22,7 +23,8 @@ export function changeLpaInspectorAccess(
 		siteAccessDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			siteAccessDetails
 		}
@@ -50,7 +52,8 @@ export function changeAppellantInspectorAccess(
 		siteAccessDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			siteAccessDetails
 		}

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.service.js
@@ -1,4 +1,5 @@
 import { dayMonthYearHourMinuteToISOString } from '#lib/dates.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 import { DEADLINE_HOUR, DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js';
 
 /**
@@ -6,7 +7,8 @@ import { DEADLINE_HOUR, DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js
  * @param {number} appealId
  */
 export async function getInvalidStatusCreatedDate(apiClient, appealId) {
-	return apiClient.get(`appeals/${appealId}/appeal-status/invalid/created-date`).json();
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.get(`appeals/${ids.appealId}/appeal-status/invalid/created-date`).json();
 }
 
 const mapIncompleteReviewOutcomeApiResponse = (/** @type {any} */ reviewOutcome) => {
@@ -109,8 +111,9 @@ export async function setReviewOutcomeForEnforcementNoticeAppellantCase(
 	appellantCaseId,
 	reviewOutcome
 ) {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
 	return apiClient
-		.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+		.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 			json: {
 				validationOutcome: reviewOutcome.validationOutcome,
 				enforcementNoticeInvalid: reviewOutcome.enforcementNoticeInvalid,

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.service.js
@@ -1,10 +1,12 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealReference
  * @returns {Promise<import('@pins/appeals.api').Appeals.LinkableAppealSummary>}
  */
 export async function getLinkableAppealByReference(apiClient, appealReference) {
-	return apiClient.get(`appeals/linkable-appeal/${appealReference}/linked`).json();
+	const ids = assertValidNumericIds({ appealReference });
+	return apiClient.get(`appeals/linkable-appeal/${ids.appealReference}/linked`).json();
 }
 
 /**
@@ -20,8 +22,9 @@ export async function linkAppealToBackOfficeAppeal(
 	linkedAppealId,
 	targetAppealIsParent = false
 ) {
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.post(`appeals/${appealId}/link-appeal`, {
+		.post(`appeals/${ids.appealId}/link-appeal`, {
 			json: {
 				linkedAppealId,
 				isCurrentAppealParent: !targetAppealIsParent
@@ -43,8 +46,9 @@ export async function linkAppealToLegacyAppeal(
 	linkedAppealReference,
 	targetAppealIsParent = false
 ) {
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.post(`appeals/${appealId}/link-legacy-appeal`, {
+		.post(`appeals/${ids.appealId}/link-legacy-appeal`, {
 			json: {
 				linkedAppealReference,
 				isCurrentAppealParent: targetAppealIsParent

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -17,7 +18,8 @@ export function addAffectedListedBuilding(
 		listEntry: affectedListedBuilding,
 		affectsListedBuilding: true
 	};
-	return apiClient.post(`appeals/${appealId}/listed-buildings`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.post(`appeals/${ids.appealId}/listed-buildings`, {
 		json: {
 			...formattedData
 		}
@@ -38,7 +40,8 @@ export function changeAffectedListedBuilding(
 	listedBuildingId,
 	affectedListedBuilding
 ) {
-	return apiClient.patch(`appeals/${appealId}/listed-buildings/${listedBuildingId}`, {
+	const ids = assertValidNumericIds({ appealId, listedBuildingId });
+	return apiClient.patch(`appeals/${ids.appealId}/listed-buildings/${ids.listedBuildingId}`, {
 		json: {
 			listEntry: affectedListedBuilding,
 			affectsListedBuilding: true
@@ -54,7 +57,8 @@ export function changeAffectedListedBuilding(
  * @returns {Promise<{}>}
  */
 export function removeAffectedListedBuilding(apiClient, appealId, listedBuildingId) {
-	return apiClient.delete(`appeals/${appealId}/listed-buildings`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.delete(`appeals/${ids.appealId}/listed-buildings`, {
 		json: {
 			listedBuildingId
 		}
@@ -68,5 +72,6 @@ export function removeAffectedListedBuilding(apiClient, appealId, listedBuilding
  * @returns {Promise<{}>}
  */
 export function getAffectedListedBuilding(apiClient, listedBuildingId) {
-	return apiClient.get(`appeals/listed-buildings/${listedBuildingId}`);
+	const ids = assertValidNumericIds({ listedBuildingId });
+	return apiClient.get(`appeals/listed-buildings/${ids.listedBuildingId}`);
 }

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -11,7 +12,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
 export function changeAffectsScheduledMonument(apiClient, appealId, lpaQuestionnaireId, inputData) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			affectsScheduledMonument: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/alleged-breach-creates-floor-space/alleged-breach-creates-floor-space.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/alleged-breach-creates-floor-space/alleged-breach-creates-floor-space.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -21,7 +22,8 @@ export function changeFloorSpaceCreatedByBreachInSquareMetres(
 		changeAreaOfAllegedFloorSpaceDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			floorSpaceCreatedByBreachInSquareMetres: changeAreaOfAllegedFloorSpaceDetails
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/any-significant-changes-lpa/any-significant-changes-lpa.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/any-significant-changes-lpa/any-significant-changes-lpa.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeSignificantChangesLpa(
 	lpaQuestionnaireId,
 	updatedValues
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			anySignificantChangesLpa: updatedValues.anySignificantChangesLpa,
 			anySignificantChangesLpa_localPlanSignificantChanges:

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/appellant-photos-and-plans/appellant-photos-and-plans.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/appellant-photos-and-plans/appellant-photos-and-plans.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -11,7 +12,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
 export function changeAppellantPhotosAndPlans(apiClient, appealId, lpaQuestionnaireId, inputData) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			didAppellantSubmitCompletePhotosAndPlans: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/change-of-use-mineral-extraction/change-of-use-mineral-extraction.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/change-of-use-mineral-extraction/change-of-use-mineral-extraction.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeOfUseMineralExtraction(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			changeOfUseMineralExtraction: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/change-of-use-mineral-storage/change-of-use-mineral-storage.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/change-of-use-mineral-storage/change-of-use-mineral-storage.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeOfUseMineralStorage(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			changeOfUseMineralStorage: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/change-of-use-refuse-or-waste/change-of-use-refuse-or-waste.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/change-of-use-refuse-or-waste/change-of-use-refuse-or-waste.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeOfUseRefuseOrWaste(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			changeOfUseRefuseOrWaste: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -17,7 +18,8 @@ export function addChangedListedBuilding(
 		listEntry: affectedListedBuilding,
 		affectsListedBuilding: false
 	};
-	return apiClient.post(`appeals/${appealId}/listed-buildings`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.post(`appeals/${ids.appealId}/listed-buildings`, {
 		json: {
 			...formattedData
 		}
@@ -38,7 +40,8 @@ export function changeChangedListedBuilding(
 	listedBuildingId,
 	affectedListedBuilding
 ) {
-	return apiClient.patch(`appeals/${appealId}/listed-buildings/${listedBuildingId}`, {
+	const ids = assertValidNumericIds({ appealId, listedBuildingId });
+	return apiClient.patch(`appeals/${ids.appealId}/listed-buildings/${ids.listedBuildingId}`, {
 		json: {
 			listEntry: affectedListedBuilding,
 			affectsListedBuilding: false
@@ -54,7 +57,8 @@ export function changeChangedListedBuilding(
  * @returns {Promise<{}>}
  */
 export function removeChangedListedBuilding(apiClient, appealId, listedBuildingId) {
-	return apiClient.delete(`appeals/${appealId}/listed-buildings`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.delete(`appeals/${ids.appealId}/listed-buildings`, {
 		json: {
 			listedBuildingId
 		}
@@ -68,5 +72,6 @@ export function removeChangedListedBuilding(apiClient, appealId, listedBuildingI
  * @returns {Promise<{}>}
  */
 export function getChangedListedBuilding(apiClient, listedBuildingId) {
-	return apiClient.get(`appeals/listed-buildings/${listedBuildingId}`);
+	const ids = assertValidNumericIds({ listedBuildingId });
+	return apiClient.get(`appeals/listed-buildings/${ids.listedBuildingId}`);
 }

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/has-community-infrastructure-levy/has-community-infrastructure-levy.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/has-community-infrastructure-levy/has-community-infrastructure-levy.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -16,7 +17,8 @@ export function changeHasCommunityInfrastructureLevy(
 ) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			hasInfrastructureLevy: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/infrastructure-levy-adopted-date/infrastructure-levy-adopted-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/infrastructure-levy-adopted-date/infrastructure-levy-adopted-date.service.js
@@ -1,4 +1,5 @@
 import { dayMonthYearHourMinuteToISOString } from '#lib/dates.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -16,7 +17,8 @@ export function changeInfrastructureLevyAdoptedDate(
 ) {
 	const formattedValue = dayMonthYearHourMinuteToISOString(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			infrastructureLevyAdoptedDate: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/infrastructure-levy-expected-date/infrastructure-levy-expected-date.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/infrastructure-levy-expected-date/infrastructure-levy-expected-date.service.js
@@ -1,4 +1,5 @@
 import { dayMonthYearHourMinuteToISOString } from '#lib/dates.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -16,7 +17,8 @@ export function changeInfrastructureLevyExpectedDate(
 ) {
 	const formattedValue = dayMonthYearHourMinuteToISOString(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			infrastructureLevyExpectedDate: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/is-infrastructure-levy-formally-adopted/is-infrastructure-levy-formally-adopted.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/community-infrastructure-levy/is-infrastructure-levy-formally-adopted/is-infrastructure-levy-formally-adopted.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -16,7 +17,8 @@ export function changeIsInfrastructureLevyFormallyAdopted(
 ) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			isInfrastructureLevyFormallyAdopted: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/correct-appeal-type.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/correct-appeal-type.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeCorrectAppealType(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			isCorrectAppealType: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/designated-sites/designated-sites.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/designated-sites/designated-sites.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -21,7 +22,8 @@ export function changeInNearOrLikelyToAffectDesignatedSites(
 	lpaQuestionnaireId,
 	designatedSiteNames
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			designatedSiteNames
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/eia-development-description/eia-development-description.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/eia-development-description/eia-development-description.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeEiaDevelopmentDescription(
 	lpaQuestionnaireId,
 	updatedData
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			eiaDevelopmentDescription: updatedData
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/eia-environmental-impact-schedule/eia-environmental-impact-schedule.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/eia-environmental-impact-schedule/eia-environmental-impact-schedule.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeEiaEnvironmentalImpactSchedule(
 	lpaQuestionnaireId,
 	updatedData
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			eiaEnvironmentalImpactSchedule: updatedData
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeEiaColumnTwoThreshold(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			eiaColumnTwoThreshold: convertFromYesNoToBoolean(updatedData)
 		}
@@ -28,7 +30,8 @@ export function changeEiaRequiresEnvironmentalStatement(
 	lpaQuestionnaireId,
 	updatedData
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			eiaRequiresEnvironmentalStatement: convertFromYesNoToBoolean(updatedData)
 		}
@@ -56,7 +59,8 @@ export function changeEiaSensitiveAreaDetails(
 		eiaSensitiveAreaDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			eiaSensitiveAreaDetails
 		}
@@ -84,7 +88,8 @@ export function changeEiaConsultedBodiesDetails(
 		consultedBodiesDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			consultedBodiesDetails
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/extra-conditions.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/extra-conditions.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -21,7 +22,8 @@ export function changeExtraConditions(
 		extraConditionsDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			extraConditions: extraConditionsDetails
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-alleged-breach-area/has-alleged-breach-area.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-alleged-breach-area/has-alleged-breach-area.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -17,7 +18,8 @@ export function changeAreaOfAllegedBreachInSquareMetres(
 		? null
 		: updatedData?.details;
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			areaOfAllegedBreachInSquareMetres: changeAreaOfAllegedBreachDetails
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -11,7 +12,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
 export function changeHasProtectedSpecies(apiClient, appealId, lpaQuestionnaireId, inputData) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			hasProtectedSpecies: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/highway-traffic-public-safety/highway-traffic-public-safety.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/highway-traffic-public-safety/highway-traffic-public-safety.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -16,7 +17,8 @@ export function changeHighwayTrafficPublicSafety(
 ) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			wasApplicationRefusedDueToHighwayOrTraffic: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -11,7 +12,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
 export function changeIsAonbNationalLandscape(apiClient, appealId, lpaQuestionnaireId, inputData) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			isAonbNationalLandscape: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-appeal-invalid/is-appeal-invalid.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-appeal-invalid/is-appeal-invalid.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -17,7 +18,8 @@ export function changeIsAppealInvalid(apiClient, appealId, lpaQuestionnaireId, u
 		lpaAppealInvalidReasons = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			lpaConsiderAppealInvalid: convertFromYesNoToBoolean(lpaConsiderAppealInvalid),
 			lpaAppealInvalidReasons

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -11,7 +12,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
 export function changeAffectsScheduledMonument(apiClient, appealId, lpaQuestionnaireId, inputData) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			isGypsyOrTravellerSite: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-on-crown-land/is-on-crown-land.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-on-crown-land/is-on-crown-land.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeIsOnCrownLand(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			isSiteOnCrownLand: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/ldc-type/ldc-type.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/ldc-type/ldc-type.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -12,7 +13,8 @@ export function changeAppealUnderActSection(
 	lpaQuestionnaireId,
 	appealUnderActSection
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			appealUnderActSection: appealUnderActSection
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/list-of-documents-before-decision/list-of-documents-before-decision.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/list-of-documents-before-decision/list-of-documents-before-decision.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeListDocumentsBeforeDecision(
 	lpaQuestionnaireId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			listOfDocumentsBeforeDecision: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleLPAQuestionnaireResponse} LpaQuestionnaire
  */
@@ -9,7 +10,10 @@
  * @returns {Promise<LpaQuestionnaire>}
  */
 export function getLpaQuestionnaireFromId(apiClient, appealId, lpaQuestionnaireId) {
-	return apiClient.get(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`).json();
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient
+		.get(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`)
+		.json();
 }
 
 /**
@@ -25,8 +29,9 @@ export function setReviewOutcomeForLpaQuestionnaire(
 	lpaQuestionnaireId,
 	reviewOutcome
 ) {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
 	return apiClient
-		.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+		.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 			json: { ...reviewOutcome }
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -21,7 +22,8 @@ export function changeNeighbouringSiteAccess(
 		reasonForNeighbourVisits = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			reasonForNeighbourVisits
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/notification-methods.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/notification-methods.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @returns {Promise<import('@pins/appeals.api').Api.AllLPANotificationMethodsResponse>}
@@ -20,7 +21,8 @@ export function changeNotificationMethods(
 	lpaQuestionnaireId,
 	updatedNotificationMethods
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			lpaNotificationMethods: updatedNotificationMethods
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/pd-rights-removed/pd-rights-removed.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/pd-rights-removed/pd-rights-removed.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -21,7 +22,8 @@ export function changePdRightsRemoved(
 		article4AffectedDevelopmentRights = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			article4AffectedDevelopmentRights: article4AffectedDevelopmentRights
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/preserve-grant-loan/preserve-grant-loan.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/preserve-grant-loan/preserve-grant-loan.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -11,7 +12,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
 export function changePreserveGrantLoan(apiClient, appealId, lpaQuestionnaireId, inputData) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			preserveGrantLoan: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/procedure-preference.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/procedure-preference.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeProcedurePreference(apiClient, appealId, lpaQuestionnaireId, updatedValue) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			lpaProcedurePreference: updatedValue
 		}
@@ -26,7 +28,8 @@ export function changeProcedurePreferenceDetails(
 	lpaQuestionnaireId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			lpaProcedurePreferenceDetails: updatedValue
 		}
@@ -46,7 +49,8 @@ export function changeProcedurePreferenceDuration(
 	lpaQuestionnaireId,
 	updatedValue
 ) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			lpaProcedurePreferenceDuration: updatedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/relates-to-agricultural-purpose/relates-to-agricultural-purpose.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/relates-to-agricultural-purpose/relates-to-agricultural-purpose.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function relatesToAgriculturalPurpose(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			relatesToBuildingWithAgriculturalPurpose: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/relates-to-erection-buildings/relates-to-erection-buildings.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/relates-to-erection-buildings/relates-to-erection-buildings.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function erectionBuildings(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			relatesToErectionOfBuildingOrBuildings: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/relates-to-operations/relates-to-operations.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/relates-to-operations/relates-to-operations.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeRelatesToOperations(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			noticeRelatesToBuildingEngineeringMiningOther: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/single-dwelling-house/single-dwelling-house.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/single-dwelling-house/single-dwelling-house.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * @param {import('got').Got} apiClient
@@ -8,7 +9,8 @@ import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
  * @returns {Promise<{}>}
  */
 export function changeSingleDwellingHouse(apiClient, appealId, lpaQuestionnaireId, updatedData) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			relatesToBuildingSingleDwellingHouse: convertFromYesNoToBoolean(updatedData)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/site-area/site-area.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/site-area/site-area.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -7,7 +8,8 @@
  * @returns {Promise<{}>}
  */
 export function changeSiteArea(apiClient, appealId, lpaQuestionnaireId, updatedSiteArea) {
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			siteAreaSquareMetres: updatedSiteArea
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/special-control-of-advertisement/special-control-of-advertisement.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/special-control-of-advertisement/special-control-of-advertisement.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -16,7 +17,8 @@ export function changeSpecialControlOfAdvertisement(
 ) {
 	const formattedValue = convertFromYesNoToBoolean(inputData);
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			isSiteInAreaOfSpecialControlAdverts: formattedValue
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/trunk-road/trunk-road.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/trunk-road/trunk-road.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -16,7 +17,8 @@ export function changeTrunkRoad(apiClient, appealId, lpaQuestionnaireId, updated
 		trunkRoadDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			affectedTrunkRoadName: trunkRoadDetails
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -6,7 +7,8 @@
  * @returns {Promise<{}>}
  */
 export function changeLpaReference(apiClient, appealId, updatedLpaReference) {
-	return apiClient.patch(`appeals/${appealId}`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.patch(`appeals/${ids.appealId}`, {
 		json: {
 			planningApplicationReference: updatedLpaReference
 		}

--- a/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -15,7 +16,8 @@ export function addNeighbouringSite(apiClient, appealId, source, neighbouringSit
 		postcode: neighbouringSite.postCode,
 		town: neighbouringSite.town
 	};
-	return apiClient.post(`appeals/${appealId}/neighbouring-sites`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.post(`appeals/${ids.appealId}/neighbouring-sites`, {
 		json: {
 			...formattedNeighbouringSite
 		}
@@ -42,7 +44,8 @@ export function changeNeighbouringSite(apiClient, appealId, neighbouringSite, si
 		}
 	};
 
-	return apiClient.patch(`appeals/${appealId}/neighbouring-sites`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.patch(`appeals/${ids.appealId}/neighbouring-sites`, {
 		json: {
 			...formattedNeighbouringSite
 		}
@@ -61,7 +64,8 @@ export function removeNeighbouringSite(apiClient, appealId, siteId) {
 		siteId: siteId
 	};
 
-	return apiClient.delete(`appeals/${appealId}/neighbouring-sites`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.delete(`appeals/${ids.appealId}/neighbouring-sites`, {
 		json: {
 			...formattedSiteId
 		}

--- a/appeals/web/src/server/appeals/appeal-details/net-residence/net-residence.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/net-residence/net-residence.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -11,7 +12,8 @@ export function changeNumberOfResidencesNetChange(
 	appellantCaseId,
 	numberOfResidencesNetChange
 ) {
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			numberOfResidencesNetChange: numberOfResidencesNetChange
 		}

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  *
  * @param {import('got').Got} apiClient
@@ -5,7 +6,8 @@
  * @returns {Promise<import('@pins/appeals.api').Appeals.LinkableAppealSummary>}
  */
 export function getLinkableAppealSummaryFromReference(apiClient, appealReference) {
-	return apiClient.get(`appeals/linkable-appeal/${appealReference}/related`).json();
+	const ids = assertValidNumericIds({ appealReference });
+	return apiClient.get(`appeals/linkable-appeal/${ids.appealReference}/related`).json();
 }
 
 /**
@@ -16,8 +18,9 @@ export function getLinkableAppealSummaryFromReference(apiClient, appealReference
  * @returns {Promise<import('../appeal-details.types.js').WebAppeal>}
  */
 export function postAssociateAppeal(apiClient, appealId, otherAppealId) {
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.post(`appeals/${appealId}/associate-appeal`, {
+		.post(`appeals/${ids.appealId}/associate-appeal`, {
 			json: {
 				linkedAppealId: otherAppealId
 			}
@@ -33,8 +36,9 @@ export function postAssociateAppeal(apiClient, appealId, otherAppealId) {
  * @returns {Promise<import('../appeal-details.types.js').WebAppeal>}
  */
 export function postAssociateLegacyAppeal(apiClient, appealId, otherAppealReference) {
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.post(`appeals/${appealId}/associate-legacy-appeal`, {
+		.post(`appeals/${ids.appealId}/associate-legacy-appeal`, {
 			json: {
 				linkedAppealReference: otherAppealReference
 			}
@@ -50,9 +54,9 @@ export function postAssociateLegacyAppeal(apiClient, appealId, otherAppealRefere
  * @returns {Promise<{}>}
  */
 export function postUnrelateRequest(apiClient, appealId, relationshipId) {
-	const appealIdNumber = parseInt(appealId, 10);
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.delete(`appeals/${appealIdNumber}/unlink-appeal`, {
+		.delete(`appeals/${ids.appealId}/unlink-appeal`, {
 			json: { relationshipId }
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/attachments-service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/attachments-service.js
@@ -1,4 +1,8 @@
 import logger from '#lib/logger.js';
+import {
+	assertValidNumericIds,
+	assertValidProofOfEvidenceType
+} from '#lib/validators/api-parameters.validator.js';
 
 export const DOCUMENT_STAGE = 'representation';
 export const DOCUMENT_TYPE = 'representationAttachments';
@@ -9,8 +13,9 @@ export const DOCUMENT_TYPE = 'representationAttachments';
  * @returns {Promise<import('@pins/appeals.api').Appeals.FolderInfo>}
  * */
 export const getAttachmentsFolder = async (apiClient, appealId) => {
+	const ids = assertValidNumericIds({ appealId });
 	const folders = await apiClient
-		.get(`appeals/${appealId}/document-folders?path=${DOCUMENT_STAGE}/${DOCUMENT_TYPE}`)
+		.get(`appeals/${ids.appealId}/document-folders?path=${DOCUMENT_STAGE}/${DOCUMENT_TYPE}`)
 		.json();
 	if (!(folders && folders.length > 0)) {
 		throw new Error(`failed to find folder for appeal ID ${appealId}`);
@@ -27,8 +32,9 @@ export const getAttachmentsFolder = async (apiClient, appealId) => {
  * @returns {Promise<import('@pins/appeals.api').Appeals.FolderInfo>}
  * */
 export const patchRepresentationAttachments = async (apiClient, appealId, repId, documentGUIDs) => {
+	const ids = assertValidNumericIds({ appealId, repId });
 	return apiClient
-		.patch(`appeals/${appealId}/reps/${repId}/attachments`, {
+		.patch(`appeals/${ids.appealId}/reps/${repId}/attachments`, {
 			json: {
 				attachments: documentGUIDs
 			}
@@ -50,8 +56,10 @@ export const postRepresentationProofOfEvidence = async (
 	proofOfEvidenceType
 ) => {
 	try {
+		const ids = assertValidNumericIds({ appealId });
+		const types = assertValidProofOfEvidenceType({ proofOfEvidenceType });
 		const response = await apiClient.post(
-			`appeals/${appealId}/reps/${proofOfEvidenceType}/proof-of-evidence`,
+			`appeals/${ids.appealId}/reps/${types.proofOfEvidenceType}/proof-of-evidence`,
 			{
 				json: {
 					attachments: documentGUIDs

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/reject.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/reject.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 
 /**
@@ -17,14 +18,16 @@ export async function getRepresentationRejectionReasonOptions(apiClient, finalCo
  * @param {string} commentId
  * @param {import('#appeals/appeal-details/representations/types.js').RejectionReasonUpdateInput[]} rejectionReasons
  * */
-export const updateRejectionReasons = (apiClient, appealId, commentId, rejectionReasons) =>
-	apiClient
-		.patch(`appeals/${appealId}/reps/${commentId}/rejection-reasons`, {
+export const updateRejectionReasons = (apiClient, appealId, commentId, rejectionReasons) => {
+	const ids = assertValidNumericIds({ appealId, commentId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/reps/${commentId}/rejection-reasons`, {
 			json: {
 				rejectionReasons: rejectionReasons
 			}
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
@@ -32,10 +35,12 @@ export const updateRejectionReasons = (apiClient, appealId, commentId, rejection
  * @param {number} commentId
  * @param {import('#appeals/appeal-details/representations/types.js').RejectionReasonUpdateInput[]} rejectionReasons
  * */
-export const rejectFinalComment = (apiClient, appealId, commentId, rejectionReasons) =>
-	apiClient.patch(`appeals/${appealId}/reps/${commentId}`, {
+export const rejectFinalComment = (apiClient, appealId, commentId, rejectionReasons) => {
+	const ids = assertValidNumericIds({ appealId, commentId });
+	return apiClient.patch(`appeals/${ids.appealId}/reps/${ids.commentId}`, {
 		json: {
 			rejectionReasons,
 			status: COMMENT_STATUS.INVALID
 		}
 	});
+};

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/edit-ip-comment.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/edit-ip-comment.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /** @typedef {{ addressLine1: string, addressLine2?: string, town: string, county?: string, postCode: string }} AddressInput */
 
 /**
@@ -7,9 +8,10 @@
  * @param {AddressInput} address
  * @returns {Promise<import('@pins/appeals.api').Appeals.ServiceUserResponse>}
  * */
-export const updateAddress = (apiClient, appealId, representedId, address) =>
-	apiClient
-		.patch(`appeals/${appealId}/service-user/${representedId}/address`, {
+export const updateAddress = (apiClient, appealId, representedId, address) => {
+	const ids = assertValidNumericIds({ appealId, representedId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/service-user/${representedId}/address`, {
 			json: {
 				addressLine1: address.addressLine1,
 				addressLine2: address.addressLine2,
@@ -19,23 +21,28 @@ export const updateAddress = (apiClient, appealId, representedId, address) =>
 			}
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
  * @param {number} appealId
  * @param {number} commentId
  * */
-export const unsetSiteVisitRequested = (apiClient, appealId, commentId) =>
-	apiClient
-		.patch(`appeals/${appealId}/reps/${commentId}`, {
+export const unsetSiteVisitRequested = (apiClient, appealId, commentId) => {
+	const ids = assertValidNumericIds({ appealId, commentId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/reps/${commentId}`, {
 			json: { siteVisitRequested: false }
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
  * @param {string} commentId
  * */
-export const patchInterestedPartyComment = (apiClient, appealId, commentId) =>
-	apiClient.patch(`appeals/${appealId}/reps/${commentId}`, {}).json();
+export const patchInterestedPartyComment = (apiClient, appealId, commentId) => {
+	const ids = assertValidNumericIds({ appealId, commentId });
+	return apiClient.patch(`appeals/${ids.appealId}/reps/${ids.commentId}`, {}).json();
+};

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.service.js
@@ -1,4 +1,5 @@
 import { paginationDefaultSettings } from '#appeals/appeal.constants.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} IPComments */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').RepresentationList} IPCommentsList */
@@ -20,7 +21,8 @@ export const getInterestedPartyComments = (
 	pageNumber = paginationDefaultSettings.firstPageNumber,
 	pageSize = paginationDefaultSettings.pageSize
 ) => {
-	let url = `appeals/${appealId}/reps?type=comment&pageNumber=${pageNumber}&pageSize=${pageSize}`;
+	const ids = assertValidNumericIds({ appealId });
+	let url = `appeals/${ids.appealId}/reps?type=comment&pageNumber=${pageNumber}&pageSize=${pageSize}`;
 
 	if (statusFilter && statusFilter !== 'all') {
 		url += `&status=${encodeURIComponent(statusFilter)}`;
@@ -34,5 +36,7 @@ export const getInterestedPartyComments = (
  * @param {string} appealId
  * @param {string} commentId
  * */
-export const getInterestedPartyComment = (apiClient, appealId, commentId) =>
-	apiClient.get(`appeals/${appealId}/reps/${commentId}`).json();
+export const getInterestedPartyComment = (apiClient, appealId, commentId) => {
+	const ids = assertValidNumericIds({ appealId, commentId });
+	return apiClient.get(`appeals/${ids.appealId}/reps/${ids.commentId}`).json();
+};

--- a/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/add-representation/add-representation.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/add-representation/add-representation.service.js
@@ -1,4 +1,5 @@
 import logger from '#lib/logger.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * Map an incoming proofOfEvidenceType string to a trusted representation type path segment.
@@ -44,9 +45,13 @@ export async function postRepresentationProofOfEvidence(
 	try {
 		const repType = mapProofOfEvidenceTypeToRepType(proofOfEvidenceType);
 
-		const response = await apiClient.post(`appeals/${appealId}/reps/${repType}/proof-of-evidence`, {
-			json: payload
-		});
+		const ids = assertValidNumericIds({ appealId });
+		const response = await apiClient.post(
+			`appeals/${ids.appealId}/reps/${repType}/proof-of-evidence`,
+			{
+				json: payload
+			}
+		);
 		return response.body;
 	} catch (error) {
 		logger.error('Error posting proof of evidence:', error);
@@ -62,8 +67,9 @@ export async function postRepresentationProofOfEvidence(
  * @returns {Promise<import('@pins/appeals.api').Appeals.FolderInfo>}
  * */
 export const patchRepresentationAttachments = async (apiClient, appealId, repId, documentGUIDs) => {
+	const ids = assertValidNumericIds({ appealId, repId });
 	return apiClient
-		.patch(`appeals/${appealId}/reps/${repId}/attachments`, {
+		.patch(`appeals/${ids.appealId}/reps/${repId}/attachments`, {
 			json: {
 				attachments: documentGUIDs
 			}

--- a/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/proof-of-evidence.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/proof-of-evidence.middleware.js
@@ -3,6 +3,7 @@ import {
 	getSingularRepresentationByType
 } from '#appeals/appeal-details/representations/representations.service.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
 import { formatProofOfEvidenceTypeText } from './view-and-review/view-and-review.mapper.js';
 
@@ -105,7 +106,8 @@ export const withRule6PartyRepresentation = async (req, res, next) => {
 			return res.status(404).render('app/404.njk');
 		}
 
-		const url = `appeals/${appealId}/reps?type=${APPEAL_REPRESENTATION_TYPE.RULE_6_PARTY_PROOFS_EVIDENCE}`;
+		const ids = assertValidNumericIds({ appealId });
+		const url = `appeals/${ids.appealId}/reps?type=${APPEAL_REPRESENTATION_TYPE.RULE_6_PARTY_PROOFS_EVIDENCE}`;
 		const apiResponse = await apiClient.get(url).json();
 		const representation = apiResponse.items?.find(
 			(/** @type {any} */ rep) => rep.representedId === currentRule6Party.serviceUserId

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
@@ -2,6 +2,7 @@
 /** @typedef {import('#appeals/appeal-details/representations/types.js').RepresentationRequest} RepresentationRequest */
 
 import logger from '#lib/logger.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  * Fetch unique representations (eg final comments) based on appeal id and representation type
@@ -12,7 +13,8 @@ import logger from '#lib/logger.js';
  * @returns {Promise<Representation>}
  */
 export const getSingularRepresentationByType = async (apiClient, appealId, type) => {
-	const url = `appeals/${appealId}/reps?type=${type}`;
+	const ids = assertValidNumericIds({ appealId });
+	const url = `appeals/${ids.appealId}/reps?type=${type}`;
 	const apiResponse = await apiClient.get(url).json();
 
 	if (apiResponse.itemCount > 1) {
@@ -34,7 +36,8 @@ export const getSingularRepresentationByType = async (apiClient, appealId, type)
  * @param {string} types
  */
 export const getRepresentationsByTypes = async (apiClient, appealId, types) => {
-	const url = `appeals/${appealId}/reps?type=${types}`;
+	const ids = assertValidNumericIds({ appealId });
+	const url = `appeals/${ids.appealId}/reps?type=${types}`;
 	const apiResponse = await apiClient.get(url).json();
 	if (apiResponse.itemCount === 0) {
 		return {};
@@ -73,7 +76,8 @@ export const getRepresentationsByTypes = async (apiClient, appealId, types) => {
  * @returns {Promise<Representation[]>}
  */
 export const getAllRepresentationsByType = async (apiClient, appealId, type) => {
-	const apiResponse = await apiClient.get(`appeals/${appealId}/reps?type=${type}`).json();
+	const ids = assertValidNumericIds({ appealId });
+	const apiResponse = await apiClient.get(`appeals/${ids.appealId}/reps?type=${type}`).json();
 	return apiResponse.items;
 };
 
@@ -84,8 +88,10 @@ export const getAllRepresentationsByType = async (apiClient, appealId, type) => 
  * @param {string} status
  * @returns {Promise<Representation>}
  * */
-export const setRepresentationStatus = (apiClient, appealId, repId, status) =>
-	apiClient.patch(`appeals/${appealId}/reps/${repId}`, { json: { status } }).json();
+export const setRepresentationStatus = (apiClient, appealId, repId, status) => {
+	const ids = assertValidNumericIds({ appealId, repId });
+	return apiClient.patch(`appeals/${ids.appealId}/reps/${ids.repId}`, { json: { status } }).json();
+};
 
 /**
  * @param {import('got').Got} apiClient
@@ -94,15 +100,17 @@ export const setRepresentationStatus = (apiClient, appealId, repId, status) =>
  * @param {string} redactedRepresentation
  * @returns {Promise<Representation>}
  * */
-export const redactAndAccept = (apiClient, appealId, repId, redactedRepresentation) =>
-	apiClient
-		.patch(`appeals/${appealId}/reps/${repId}`, {
+export const redactAndAccept = (apiClient, appealId, repId, redactedRepresentation) => {
+	const ids = assertValidNumericIds({ appealId, repId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/reps/${ids.repId}`, {
 			json: {
 				status: 'valid',
 				redactedRepresentation
 			}
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
@@ -110,12 +118,14 @@ export const redactAndAccept = (apiClient, appealId, repId, redactedRepresentati
  * @param {number} repId
  * @returns {Promise<Representation>}
  * */
-export const acceptRepresentation = (apiClient, appealId, repId) =>
-	apiClient
-		.patch(`appeals/${appealId}/reps/${repId}`, {
+export const acceptRepresentation = (apiClient, appealId, repId) => {
+	const ids = assertValidNumericIds({ appealId, repId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/reps/${ids.repId}`, {
 			json: { status: 'valid' }
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
@@ -124,12 +134,14 @@ export const acceptRepresentation = (apiClient, appealId, repId) =>
  * @param {{ allowResubmit: boolean }} data
  * @returns {Promise<Representation>}
  * */
-export const representationIncomplete = (apiClient, appealId, repId, { allowResubmit }) =>
-	apiClient
-		.patch(`appeals/${appealId}/reps/${repId}`, {
+export const representationIncomplete = (apiClient, appealId, repId, { allowResubmit }) => {
+	const ids = assertValidNumericIds({ appealId, repId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/reps/${ids.repId}`, {
 			json: { status: 'incomplete', allowResubmit }
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
@@ -148,12 +160,14 @@ export async function getRepresentationRejectionReasonOptions(apiClient, represe
  * @param {string} commentId
  * @param {import('#appeals/appeal-details/representations/types.js').RejectionReasonUpdateInput[]} rejectionReasons
  * */
-export const updateRejectionReasons = (apiClient, appealId, commentId, rejectionReasons) =>
-	apiClient
-		.patch(`appeals/${appealId}/reps/${commentId}/rejection-reasons`, {
+export const updateRejectionReasons = (apiClient, appealId, commentId, rejectionReasons) => {
+	const ids = assertValidNumericIds({ appealId, commentId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/reps/${commentId}/rejection-reasons`, {
 			json: { rejectionReasons }
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
@@ -161,12 +175,14 @@ export const updateRejectionReasons = (apiClient, appealId, commentId, rejection
  * @param {String} inspectorName
  * @returns {Promise<any>}
  * */
-export const publishRepresentations = (apiClient, appealId, inspectorName) =>
-	apiClient
-		.post(`appeals/${appealId}/reps/publish`, {
+export const publishRepresentations = (apiClient, appealId, inspectorName) => {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient
+		.post(`appeals/${ids.appealId}/reps/publish`, {
 			json: { inspectorName }
 		})
 		.json();
+};
 
 /**
  * @param {import('got').Got} apiClient
@@ -177,8 +193,9 @@ export const publishRepresentations = (apiClient, appealId, inspectorName) =>
  */
 export async function postRepresentation(apiClient, appealId, payload, representationType) {
 	try {
+		const ids = assertValidNumericIds({ appealId });
 		const response = await apiClient
-			.post(`appeals/${appealId}/reps/${representationType}`, {
+			.post(`appeals/${ids.appealId}/reps/${representationType}`, {
 				json: payload
 			})
 			.json();

--- a/appeals/web/src/server/appeals/appeal-details/safety-risks/safety-risks.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/safety-risks/safety-risks.service.js
@@ -1,4 +1,5 @@
 import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /**
  *
@@ -21,7 +22,8 @@ export function changeLpaSafetyRisks(
 		siteSafetyDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+	const ids = assertValidNumericIds({ appealId, lpaQuestionnaireId });
+	return apiClient.patch(`appeals/${ids.appealId}/lpa-questionnaires/${ids.lpaQuestionnaireId}`, {
 		json: {
 			siteSafetyDetails
 		}
@@ -49,7 +51,8 @@ export function changeAppellantSafetyRisks(
 		siteSafetyDetails = null;
 	}
 
-	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+	const ids = assertValidNumericIds({ appealId, appellantCaseId });
+	return apiClient.patch(`appeals/${ids.appealId}/appellant-cases/${ids.appellantCaseId}`, {
 		json: {
 			siteSafetyDetails
 		}

--- a/appeals/web/src/server/appeals/appeal-details/service-user/service-user.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/service-user/service-user.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /** @typedef {{firstName: string; lastName: string; organisationName: string | null | undefined; email: string | null | undefined; phoneNumber: string | null | undefined;}} WebServiceUser*/
 /**
  *
@@ -7,8 +8,9 @@
  * @param {WebServiceUser} data
  * @returns {Promise<{}>}
  */
-export const assignServiceUser = (apiClient, appealId, userType, data) =>
-	apiClient.patch(`appeals/${appealId}?include=childAppeals`, {
+export const assignServiceUser = (apiClient, appealId, userType, data) => {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.patch(`appeals/${ids.appealId}?include=childAppeals`, {
 		json: {
 			[userType]: {
 				firstName: data.firstName,
@@ -19,6 +21,7 @@ export const assignServiceUser = (apiClient, appealId, userType, data) =>
 			}
 		}
 	});
+};
 
 /**
  *
@@ -29,8 +32,9 @@ export const assignServiceUser = (apiClient, appealId, userType, data) =>
  * @param {WebServiceUser} data
  * @returns {Promise<{}>}
  */
-export const updateServiceUser = (apiClient, appealId, serviceUserId, userType, data) =>
-	apiClient.patch(`appeals/${appealId}/service-user`, {
+export const updateServiceUser = (apiClient, appealId, serviceUserId, userType, data) => {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.patch(`appeals/${ids.appealId}/service-user`, {
 		json: {
 			serviceUser: {
 				serviceUserId,
@@ -43,6 +47,7 @@ export const updateServiceUser = (apiClient, appealId, serviceUserId, userType, 
 			}
 		}
 	});
+};
 
 /**
  *
@@ -52,10 +57,12 @@ export const updateServiceUser = (apiClient, appealId, serviceUserId, userType, 
  * @param {string} userType
  * @returns {Promise<{}>}
  */
-export const removeServiceUser = (apiClient, appealId, serviceUserId, userType) =>
-	apiClient.delete(`appeals/${appealId}/service-user`, {
+export const removeServiceUser = (apiClient, appealId, serviceUserId, userType) => {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.delete(`appeals/${ids.appealId}/service-user`, {
 		json: {
 			serviceUserId,
 			userType
 		}
 	});
+};

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @typedef {Object} UpdateOrCreateSiteVisitParameters
  * @property {number} appealIdNumber
@@ -29,8 +30,9 @@ export async function createSiteVisit(
 	inspectorName,
 	knowDateTime
 ) {
+	const ids = assertValidNumericIds({ appealId });
 	return apiClient
-		.post(`appeals/${appealId}/site-visits`, {
+		.post(`appeals/${ids.appealId}/site-visits`, {
 			json: {
 				visitDate,
 				visitType,
@@ -50,8 +52,9 @@ export async function createSiteVisit(
  * @param {string} whoMissedSiteVisit
  */
 export async function recordMissedSiteVisit(apiClient, appealId, siteVisitId, whoMissedSiteVisit) {
+	const ids = assertValidNumericIds({ appealId, siteVisitId });
 	return apiClient
-		.post(`appeals/${appealId}/site-visits/${siteVisitId}/missed`, {
+		.post(`appeals/${ids.appealId}/site-visits/${siteVisitId}/missed`, {
 			json: {
 				whoMissedSiteVisit
 			}
@@ -82,8 +85,9 @@ export async function updateSiteVisit(
 	inspectorName,
 	siteVisitChangeType
 ) {
+	const ids = assertValidNumericIds({ appealId, siteVisitId });
 	return apiClient
-		.patch(`appeals/${appealId}/site-visits/${siteVisitId}`, {
+		.patch(`appeals/${ids.appealId}/site-visits/${siteVisitId}`, {
 			json: {
 				visitType,
 				...(visitDate && { visitDate }),
@@ -104,7 +108,8 @@ export async function updateSiteVisit(
  * @returns {Promise<import('@pins/appeals.api/src/server/endpoints/appeals.js').SingleSiteVisitDetailsResponse>}
  */
 export async function getSiteVisit(apiClient, appealId, siteVisitId) {
-	return apiClient.get(`appeals/${appealId}/site-visits/${siteVisitId}`).json();
+	const ids = assertValidNumericIds({ appealId, siteVisitId });
+	return apiClient.get(`appeals/${ids.appealId}/site-visits/${ids.siteVisitId}`).json();
 }
 /**
  * @param {import('got').Got} apiClient
@@ -113,5 +118,6 @@ export async function getSiteVisit(apiClient, appealId, siteVisitId) {
  * @returns {Promise<import('@pins/appeals.api/src/server/endpoints/appeals.js').SingleSiteVisitDetailsResponse>}
  */
 export async function cancelSiteVisit(apiClient, appealId, siteVisitId) {
-	return apiClient.delete(`appeals/${appealId}/site-visits/${siteVisitId}`).json();
+	const ids = assertValidNumericIds({ appealId, siteVisitId });
+	return apiClient.delete(`appeals/${ids.appealId}/site-visits/${ids.siteVisitId}`).json();
 }

--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.service.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @param {import('got').Got} apiClient
  * @returns {Promise<(import('@pins/appeals.api').Api.CaseTeams)>}
@@ -13,7 +14,8 @@ export async function getTeamList(apiClient) {
  * @returns {Promise<{}>}
  */
 export async function postUpdateTeam(apiClient, appealId, teamId) {
-	return apiClient.patch(`appeals/${appealId}/case-team`, {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.patch(`appeals/${ids.appealId}/case-team`, {
 		json: {
 			teamId: teamId
 		}
@@ -26,5 +28,6 @@ export async function postUpdateTeam(apiClient, appealId, teamId) {
  * @returns {Promise<{email:string}>}
  */
 export async function getTeamFromAppealId(apiClient, appealId) {
-	return apiClient.get(`appeals/${appealId}/case-team-email`).json();
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient.get(`appeals/${ids.appealId}/case-team-email`).json();
 }

--- a/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
@@ -1,5 +1,6 @@
 import logger from '#lib/logger.js';
 import { fileType } from '#lib/nunjucks-filters/mime-type.js';
+import { assertValidIds, assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.FolderInfo} FolderInfo */
 /** @typedef {import('@pins/appeals.api').Appeals.DocumentInfo} DocumentInfo */
@@ -12,7 +13,8 @@ import { fileType } from '#lib/nunjucks-filters/mime-type.js';
  */
 export const getAllCaseFolders = async (apiClient, appealId) => {
 	try {
-		const bulkLocationInfo = await apiClient.get(`appeals/${appealId}/document-folders`).json();
+		const ids = assertValidNumericIds({ appealId });
+		const bulkLocationInfo = await apiClient.get(`appeals/${ids.appealId}/document-folders`).json();
 		return bulkLocationInfo;
 	} catch {
 		return undefined;
@@ -30,12 +32,13 @@ export const getAllCaseFolders = async (apiClient, appealId) => {
  */
 export const getFolder = async (apiClient, appealId, folderId, pageNumber, pageSize, repId) => {
 	try {
+		const ids = assertValidNumericIds({ appealId, folderId });
 		const urlParams = new URLSearchParams();
 		urlParams.append('pageNumber', pageNumber.toString());
 		urlParams.append('pageSize', pageSize.toString());
 		if (repId) urlParams.append('repId', repId.toString());
 
-		const url = `appeals/${appealId}/document-folders/${folderId}?${urlParams.toString()}`;
+		const url = `appeals/${ids.appealId}/document-folders/${ids.folderId}?${urlParams.toString()}`;
 
 		const locationInfo = await apiClient.get(url).json();
 		return locationInfo;
@@ -51,8 +54,9 @@ export const getFolder = async (apiClient, appealId, folderId, pageNumber, pageS
  * @returns {Promise<FolderInfo|undefined>}
  * */
 export const getAttachmentsFolder = async (apiClient, appealId, folderPath) => {
+	const ids = assertValidNumericIds({ appealId });
 	const folders = await apiClient
-		.get(`appeals/${appealId}/document-folders?path=${folderPath}`)
+		.get(`appeals/${ids.appealId}/document-folders?path=${folderPath}`)
 		.json();
 	if (!(folders && folders.length > 0)) {
 		throw new Error(`failed to find folder for appeal ID ${appealId}`);
@@ -68,7 +72,8 @@ export const getAttachmentsFolder = async (apiClient, appealId, folderPath) => {
  */
 export const getFileInfo = async (apiClient, fileGuid) => {
 	try {
-		return await apiClient.get(`appeals/documents/${fileGuid}`).json();
+		const ids = assertValidIds({ fileGuid });
+		return await apiClient.get(`appeals/documents/${ids.fileGuid}`).json();
 	} catch {
 		return undefined;
 	}
@@ -81,7 +86,8 @@ export const getFileInfo = async (apiClient, fileGuid) => {
  */
 export const getFileVersionsInfo = async (apiClient, fileGuid) => {
 	try {
-		return await apiClient.get(`appeals/documents/${fileGuid}/versions`).json();
+		const ids = assertValidIds({ fileGuid });
+		return await apiClient.get(`appeals/documents/${ids.fileGuid}/versions`).json();
 	} catch {
 		return undefined;
 	}
@@ -146,8 +152,10 @@ export const getDocumentRedactionStatuses = async (apiClient) => {
 
 export const updateDocument = async (apiClient, appealId, documentDetail) => {
 	try {
+		const ids = assertValidNumericIds({ appealId });
+		const docIds = assertValidIds({ id: documentDetail.document.id });
 		return await apiClient
-			.patch(`appeals/${appealId}/documents/${documentDetail.document.id}`, {
+			.patch(`appeals/${ids.appealId}/documents/${docIds.id}`, {
 				json: {
 					document: documentDetail.document,
 					sharingDocumentType: documentDetail.sharingDocumentType,
@@ -190,8 +198,9 @@ export const updateDocument = async (apiClient, appealId, documentDetail) => {
  */
 export const updateDocuments = async (apiClient, appealId, documentDetails) => {
 	try {
+		const ids = assertValidNumericIds({ appealId });
 		return await apiClient
-			.patch(`appeals/${appealId}/documents`, {
+			.patch(`appeals/${ids.appealId}/documents`, {
 				json: documentDetails
 			})
 			.json();
@@ -214,8 +223,9 @@ export const updateDocuments = async (apiClient, appealId, documentDetails) => {
  */
 export const deleteDocument = async (apiClient, documentId, versionId, appellantCaseId) => {
 	try {
+		const ids = assertValidIds({ documentId, versionId });
 		return await apiClient
-			.delete(`appeals/documents/${documentId}/${versionId}`, {
+			.delete(`appeals/documents/${ids.documentId}/${ids.versionId}`, {
 				json: { appellantCaseId }
 			})
 			.json();
@@ -236,7 +246,8 @@ export const deleteDocument = async (apiClient, documentId, versionId, appellant
  */
 export const getRepresentationAttachments = async (apiClient, appealId) => {
 	try {
-		return await apiClient.get(`appeals/${appealId}/reps`).json();
+		const ids = assertValidNumericIds({ appealId });
+		return await apiClient.get(`appeals/${ids.appealId}/reps`).json();
 	} catch (error) {
 		logger.error(
 			error,

--- a/appeals/web/src/server/lib/api/allocation-details.api.js
+++ b/appeals/web/src/server/lib/api/allocation-details.api.js
@@ -1,3 +1,4 @@
+import { assertValidNumericIds } from '#lib/validators/api-parameters.validator.js';
 /**
  * @typedef {Object} AllocationDetailsLevel
  * @property {string} level
@@ -38,5 +39,9 @@ export const getAllocationDetailsSpecialisms = (apiClient) =>
  * @param {AllocationDetails} allocationDetails
  * @returns {Promise<AllocationDetails>}
  */
-export const setAllocationDetails = (apiClient, appealId, allocationDetails) =>
-	apiClient.patch(`appeals/${appealId}/appeal-allocation`, { json: allocationDetails }).json();
+export const setAllocationDetails = (apiClient, appealId, allocationDetails) => {
+	const ids = assertValidNumericIds({ appealId });
+	return apiClient
+		.patch(`appeals/${ids.appealId}/appeal-allocation`, { json: allocationDetails })
+		.json();
+};

--- a/appeals/web/src/server/lib/validators/api-parameters.validator.js
+++ b/appeals/web/src/server/lib/validators/api-parameters.validator.js
@@ -1,0 +1,170 @@
+/**
+ * Validators used to guard user-provided values (typically route/path parameters
+ * such as `appealId`, `lpaQuestionnaireId`, `documentId`, etc.) before they are
+ * interpolated into a URL and sent to the back-office API.
+ *
+ * These guards are intended to be called at the start of API service functions as
+ * a defence-in-depth measure: even when route middleware already validates the
+ * parameters, the service layer should never build a request from an obviously
+ * invalid value (e.g. a non-numeric id).
+ */
+
+const NUMERIC_ID_PATTERN = /^[0-9]+$/;
+const GUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const GROUND_REF_PATTERN = /^[a-z]+$/i; // only a-g are valid but any letter is safe
+const PROOF_OF_EVIDENCE_TYPE_PATTERN = /^[0-9a-z-]+$/i;
+
+/**
+ * Error thrown when an API parameter fails validation.
+ */
+export class ApiParameterValidationError extends Error {
+	/**
+	 * @param {string} message
+	 */
+	constructor(message) {
+		super(message);
+		this.name = 'ApiParameterValidationError';
+	}
+}
+
+/**
+ * Is the supplied value a valid numeric id (an integer)?
+ *
+ * @param {string|number|null|undefined} value
+ * @returns {boolean}
+ */
+export const isValidNumericId = (value) =>
+	value !== null && value !== undefined && NUMERIC_ID_PATTERN.test(String(value));
+
+/**
+ * Is the supplied value a valid GUID/UUID?
+ *
+ * @param {string|number|null|undefined} value
+ * @returns {value is string}
+ */
+export const isValidGuid = (value) =>
+	value !== null && value !== undefined && GUID_PATTERN.test(String(value));
+
+/**
+ * Is the supplied value a valid resource id, i.e. either a numeric id or a GUID?
+ *
+ * Some resources (most notably documents) are usually a GUID but its not enforced in the database.
+ * Both forms are inherently safe to interpolate into a URL.
+ *
+ * @param {string|number|null|undefined} value
+ * @returns {value is number | string}
+ */
+export const isValidId = (value) => isValidNumericId(value) || isValidGuid(value);
+
+/**
+ * Is the supplied value a valid ground ref?
+ *
+ * @param {string|number|null|undefined} value
+ * @returns {value is string}
+ */
+export const isValidGroundRef = (value) =>
+	typeof value === 'string' && GROUND_REF_PATTERN.test(value);
+
+/**
+ * Is the supplied value a valid proof of evidence type?
+ *
+ * @param {string|number|null|undefined} value
+ * @returns {value is string}
+ */
+export const isValidProofOfEvidenceType = (value) =>
+	typeof value === 'string' && PROOF_OF_EVIDENCE_TYPE_PATTERN.test(value);
+
+/**
+ * Assert that every supplied value is a valid numeric id (positive integer).
+ *
+ * @param {Record<string, string|number|null|undefined>} params - map of parameter name to value
+ * @returns {Record<string, string|number>}
+ * @throws {ApiParameterValidationError} if any value is not a valid numeric id
+ */
+export const assertValidNumericIds = (params) => {
+	for (const [name, value] of Object.entries(params)) {
+		if (!isValidNumericId(value)) {
+			throw new ApiParameterValidationError(
+				`Invalid ${name}: expected a numeric id but received "${value}"`
+			);
+		}
+	}
+	// @ts-expect-error the type is now checked
+	return params;
+};
+
+/**
+ * Assert that every supplied value is a valid GUID.
+ *
+ * @param {Record<string, string|number|null|undefined>} params - map of parameter name to value
+ * @returns {Record<string, string>}
+ * @throws {ApiParameterValidationError} if any value is not a valid GUID
+ */
+export const assertValidGuids = (params) => {
+	for (const [name, value] of Object.entries(params)) {
+		if (!isValidGuid(value)) {
+			throw new ApiParameterValidationError(
+				`Invalid ${name}: expected a GUID but received "${value}"`
+			);
+		}
+	}
+	// @ts-expect-error the type is now checked
+	return params;
+};
+
+/**
+ * Assert that every supplied value is a valid resource id (numeric id or GUID).
+ *
+ * @param {Record<string, string|number|null|undefined>} params - map of parameter name to value
+ * @returns {Record<string, string|number>}
+ * @throws {ApiParameterValidationError} if any value is not a valid id
+ */
+export const assertValidIds = (params) => {
+	for (const [name, value] of Object.entries(params)) {
+		if (!isValidId(value)) {
+			throw new ApiParameterValidationError(
+				`Invalid ${name}: expected a numeric id or GUID but received "${value}"`
+			);
+		}
+	}
+	// @ts-expect-error the type is now checked
+	return params;
+};
+
+/**
+ * Assert that every supplied value is a valid ground reference (only letters).
+ *
+ * @param {Record<string, string|number|null|undefined>} params - map of parameter name to value
+ * @returns {Record<string, string>}
+ * @throws {ApiParameterValidationError} if any value is not a valid id
+ */
+export const assertValidGroundRef = (params) => {
+	for (const [name, value] of Object.entries(params)) {
+		if (!isValidGroundRef(value)) {
+			throw new ApiParameterValidationError(
+				`Invalid ${name}: expected only letters but received "${value}"`
+			);
+		}
+	}
+	// @ts-expect-error the type is now checked
+	return params;
+};
+
+/**
+ * Assert that every supplied value is a valid proof of evidence type
+ *
+ * @param {Record<string, string|number|null|undefined>} params - map of parameter name to value
+ * @returns {Record<string, string>}
+ * @throws {ApiParameterValidationError} if any value is not a valid id
+ */
+export const assertValidProofOfEvidenceType = (params) => {
+	for (const [name, value] of Object.entries(params)) {
+		if (!isValidProofOfEvidenceType(value)) {
+			throw new ApiParameterValidationError(
+				`Invalid ${name}: expected only letters, numbers, or hyphens but received "${value}"`
+			);
+		}
+	}
+	// @ts-expect-error the type is now checked
+	return params;
+};

--- a/appeals/web/src/server/lib/validators/tests/api-parameters.validator.test.js
+++ b/appeals/web/src/server/lib/validators/tests/api-parameters.validator.test.js
@@ -1,0 +1,99 @@
+import {
+	ApiParameterValidationError,
+	assertValidGuids,
+	assertValidIds,
+	assertValidNumericIds,
+	assertValidProofOfEvidenceType,
+	isValidGuid,
+	isValidNumericId
+} from '../api-parameters.validator.js';
+
+describe('api-parameters.validator', () => {
+	describe('isValidNumericId', () => {
+		it.each([['1'], ['123'], [0], [42], ['007']])('returns true for %p', (value) => {
+			expect(isValidNumericId(value)).toBe(true);
+		});
+
+		it.each([
+			[''],
+			['abc'],
+			['1.5'],
+			['-1'],
+			['1a'],
+			[' 1'],
+			[null],
+			[undefined],
+			['APP/Q9999/W/1']
+		])('returns false for %p', (value) => {
+			expect(isValidNumericId(value)).toBe(false);
+		});
+	});
+
+	describe('isValidGuid', () => {
+		it('returns true for a valid GUID', () => {
+			expect(isValidGuid('434bff4e-8191-4ce0-9a0a-91e5d6cdd882')).toBe(true);
+		});
+
+		it.each([[''], ['not-a-guid'], ['123'], [null], [undefined]])(
+			'returns false for %p',
+			(value) => {
+				expect(isValidGuid(value)).toBe(false);
+			}
+		);
+	});
+
+	describe('assertValidNumericIds', () => {
+		it('does not throw when all values are valid', () => {
+			expect(() => assertValidNumericIds({ appealId: '1', lpaQuestionnaireId: 2 })).not.toThrow();
+		});
+
+		it('throws an ApiParameterValidationError naming the invalid parameter', () => {
+			expect(() => assertValidNumericIds({ appealId: 'abc' })).toThrow(ApiParameterValidationError);
+			expect(() => assertValidNumericIds({ appealId: 'abc' })).toThrow(/Invalid appealId/);
+		});
+	});
+
+	describe('assertValidGuids', () => {
+		it('does not throw when all values are valid', () => {
+			expect(() =>
+				assertValidGuids({ documentId: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882' })
+			).not.toThrow();
+		});
+
+		it('throws an ApiParameterValidationError naming the invalid parameter', () => {
+			expect(() => assertValidGuids({ documentId: '123' })).toThrow(ApiParameterValidationError);
+			expect(() => assertValidGuids({ documentId: '123' })).toThrow(/Invalid documentId/);
+		});
+	});
+
+	describe('assertValidIds', () => {
+		it('does not throw when all values are valid', () => {
+			expect(() =>
+				assertValidIds({ documentId: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882', anotherId: 1 })
+			).not.toThrow();
+		});
+
+		it('throws an ApiParameterValidationError naming the invalid parameter', () => {
+			expect(() => assertValidIds({ anotherId: null })).toThrow(ApiParameterValidationError);
+			expect(() => assertValidIds({ documentId: 'A1' })).toThrow(/Invalid documentId/);
+		});
+	});
+
+	describe('assertValidProofOfEvidenceType', () => {
+		it('does not throw when all values are valid', () => {
+			expect(() =>
+				assertValidProofOfEvidenceType({
+					poe: 'abc-123-b',
+					anotherOne: 'aaaa'
+				})
+			).not.toThrow();
+		});
+
+		it('throws an ApiParameterValidationError naming the invalid parameter', () => {
+			expect(() => assertValidProofOfEvidenceType({ anotherId: null })).toThrow(
+				ApiParameterValidationError
+			);
+			expect(() => assertValidProofOfEvidenceType({ poe: 'a1&shdn' })).toThrow(/Invalid poe/);
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

Ensure API requests from the web app which use request parameters are safe, checking parameters are valid before making the network request.

The majority of this code was written by GitHub Copilot, but I have checked it over and validated the tests.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-8645
