### PR TITLE
fix(appeals): adding decision letter guids to decision table + removi…

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -18,6 +18,7 @@ const mockAppealRelationshipFindMany = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipFindFirst = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipCreateMany = jest.fn().mockResolvedValue({});
 const mockAppealDecision = jest.fn().mockResolvedValue({});
+const mockAppealDecisionUpdate = jest.fn().mockResolvedValue({});
 const mockAppealDecisionDeleteMany = jest.fn().mockResolvedValue({});
 const mockAppealFindUnique = jest.fn().mockResolvedValue({});
 const mockAppealCreate = jest.fn().mockResolvedValue({});
@@ -716,6 +717,7 @@ class MockPrismaClient {
 	get inspectorDecision() {
 		return {
 			create: mockAppealDecision,
+			update: mockAppealDecisionUpdate,
 			deleteMany: mockAppealDecisionDeleteMany
 		};
 	}

--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -750,42 +750,9 @@ describe('decision routes', () => {
 				})
 				.set('azureAdUserId', azureAdUserId);
 
-			expect(databaseConnector.document.createMany).toHaveBeenCalledWith({
-				data: [
-					{
-						caseId: childAppeal.childId,
-						folderId: 23,
-						guid: 'mock-uuid',
-						name: 'mydoc-1345264.pdf'
-					}
-				]
-			});
+			expect(databaseConnector.document.createMany).not.toHaveBeenCalled();
 
-			expect(databaseConnector.documentVersion.createMany).toHaveBeenCalledWith({
-				data: [
-					{
-						blobStorageContainer: 'document-service-uploads',
-						blobStoragePath: 'appeal/CHILD123/mock-uuid/v1/mydoc-1345264.pdf',
-						dateReceived: expect.any(Date),
-						documentGuid: 'mock-uuid',
-						documentType: 'appellantCostApplication',
-						documentURI:
-							'https://127.0.0.1:10000/document-service-uploads/appeal/CHILD123/mock-uuid/v1/mydoc-1345264.pdf',
-						draft: false,
-						fileName: 'mydoc-1345264.pdf',
-						isLateEntry: false,
-						lastModified: expect.any(Date),
-						mime: 'application/pdf',
-						originalFilename: 'mydoc-1345264.pdf',
-						published: false,
-						redactionStatusId: 1,
-						size: 14699,
-						stage: 'appeal-decision',
-						version: 1,
-						virusCheckStatus: 'not_scanned'
-					}
-				]
-			});
+			expect(databaseConnector.documentVersion.createMany).not.toHaveBeenCalled();
 
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -91,13 +91,7 @@ export const postInspectorDecision = async (req, res) => {
 							);
 
 							if (childAppeal) {
-								return publishChildDecision(
-									childAppeal,
-									outcome,
-									documentDate,
-									azureAdUserId,
-									appeal
-								);
+								return publishChildDecision(childAppeal, outcome, documentDate, azureAdUserId);
 							}
 						}
 						return publishDecision(

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -2,7 +2,6 @@ import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatte
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
-import { duplicateFiles } from '#endpoints/link-appeals/link-appeals.service.js';
 import { getInterestedPartyEmails } from '#endpoints/representations/representations.service.js';
 import { generateNotifyPreview } from '#notify/emulate-notify.js';
 import { notifySend, renderTemplate } from '#notify/notify-send.js';
@@ -331,18 +330,12 @@ export const publishDecision = async (
  * @param {string} outcome
  * @param {Date} documentDate
  * @param {string} azureAdUserId
- * @param {Appeal} leadAppeal
  * @returns
  */
-export const publishChildDecision = async (
-	childAppeal,
-	outcome,
-	documentDate,
-	azureAdUserId,
-	leadAppeal
-) => {
+export const publishChildDecision = async (childAppeal, outcome, documentDate, azureAdUserId) => {
 	const { id: appealId } = childAppeal;
 
+	// note that the decision letter is copied on unlinking and then added to the appeal decision
 	const result = await appealRepository.setAppealDecision(appealId, {
 		documentDate,
 		version: 1,
@@ -350,8 +343,6 @@ export const publishChildDecision = async (
 	});
 
 	if (result) {
-		await duplicateFiles(leadAppeal, childAppeal, APPEAL_CASE_STAGE.APPEAL_DECISION);
-
 		await createAuditTrail({
 			appealId,
 			azureAdUserId: azureAdUserId,

--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeals.service.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeals.service.test.js
@@ -1,9 +1,13 @@
 // @ts-nocheck
 import { householdAppeal as appeal } from '#tests/appeals/mocks.js';
 import { jest } from '@jest/globals';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { APPEAL_CASE_STATUS, APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 
-import { checkAppealsStatusBeforeLPAQ, copyRepresentations } from '../link-appeals.service.js';
+import {
+	checkAppealsStatusBeforeLPAQ,
+	copyRepresentations,
+	duplicateFiles
+} from '../link-appeals.service.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -136,6 +140,82 @@ describe('Link Appeals Service', () => {
 			expect(databaseConnector.folder.findMany).toHaveBeenCalledTimes(2);
 			expect(databaseConnector.document.findMany).toHaveBeenCalledTimes(1);
 			expect(databaseConnector.representation.createMany).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('duplicateFiles', () => {
+		it('calls updateAppealDecisionLetter with destination appeal id and copied decision letter guid', async () => {
+			const sourceAppeal = { id: 100, reference: 'SRC-REF' };
+			const destinationAppeal = { id: 200, reference: 'DST-REF' };
+			databaseConnector.documentVersion.createMany.mockResolvedValue([]);
+
+			databaseConnector.folder.findMany.mockResolvedValueOnce([
+				{
+					id: 1,
+					path: 'appeal-decision/caseDecisionLetter',
+					documents: [
+						{
+							name: 'decision-letter.pdf',
+							guid: 'source-guid',
+							isDeleted: false,
+							latestDocumentVersion: {
+								blobStoragePath: 'appeal/SRC-REF/source-guid/v1/decision-letter.pdf',
+								mime: 'application/pdf',
+								documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER,
+								size: 123,
+								stage: 'appeal-decision',
+								virusCheckStatus: 'clean',
+								redactionStatusId: 1,
+								dateReceived: new Date('2026-01-01T00:00:00.000Z'),
+								version: 1
+							}
+						}
+					]
+				}
+			]);
+
+			await duplicateFiles(sourceAppeal, destinationAppeal, null);
+
+			expect(databaseConnector.inspectorDecision.update).toHaveBeenCalledTimes(1);
+			expect(databaseConnector.inspectorDecision.update).toHaveBeenCalledWith({
+				where: { appealId: destinationAppeal.id },
+				data: { decisionLetterGuid: 'mock-uuid' }
+			});
+		});
+
+		it('does not call updateAppealDecisionLetter when no decision letter is copied', async () => {
+			const sourceAppeal = { id: 100, reference: 'SRC-REF' };
+			const destinationAppeal = { id: 200, reference: 'DST-REF' };
+			databaseConnector.documentVersion.createMany.mockResolvedValue([]);
+
+			databaseConnector.folder.findMany.mockResolvedValueOnce([
+				{
+					id: 1,
+					path: 'costs/appellantCostsCorrespondence',
+					documents: [
+						{
+							name: 'supporting-note.pdf',
+							guid: 'source-guid-2',
+							isDeleted: false,
+							latestDocumentVersion: {
+								blobStoragePath: 'appeal/SRC-REF/source-guid-2/v1/supporting-note.pdf',
+								mime: 'application/pdf',
+								documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_CASE_CORRESPONDENCE,
+								size: 123,
+								stage: 'costs',
+								virusCheckStatus: 'clean',
+								redactionStatusId: 1,
+								dateReceived: new Date('2026-01-01T00:00:00.000Z'),
+								version: 1
+							}
+						}
+					]
+				}
+			]);
+
+			await duplicateFiles(sourceAppeal, destinationAppeal, null);
+
+			expect(databaseConnector.inspectorDecision.update).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -441,7 +441,9 @@ export const updateLinkedAppeals = async (req, res) => {
 			`${APPEAL_CASE_STAGE.APPELLANT_CASE}/${APPEAL_DOCUMENT_TYPE.GROUND_D_SUPPORTING}`,
 			`${APPEAL_CASE_STAGE.APPELLANT_CASE}/${APPEAL_DOCUMENT_TYPE.GROUND_E_SUPPORTING}`,
 			`${APPEAL_CASE_STAGE.APPELLANT_CASE}/${APPEAL_DOCUMENT_TYPE.GROUND_F_SUPPORTING}`,
-			`${APPEAL_CASE_STAGE.APPELLANT_CASE}/${APPEAL_DOCUMENT_TYPE.GROUND_G_SUPPORTING}`
+			`${APPEAL_CASE_STAGE.APPELLANT_CASE}/${APPEAL_DOCUMENT_TYPE.GROUND_G_SUPPORTING}`,
+			// representation docs are accounted for in moveRepresentations/copyRepresentations
+			`representation/representationAttachments`
 		];
 
 		const options = { omitFolders };

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -3,12 +3,14 @@
 /** @typedef {import('@pins/appeals.api').Schema.Document} Document */
 /** @typedef {import('@pins/appeals.api').Schema.DocumentVersion} DocumentVersion */
 
+import config from '#config/config.js';
 import {
 	addDocumentsToAppeal,
 	getFoldersForAppeal
 } from '#endpoints/documents/documents.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import appealRepository from '#repositories/appeal.repository.js';
+import { updateAppealDecisionLetter } from '#repositories/decision.repository.js';
 import { getDocumentsInFolder } from '#repositories/document.repository.js';
 import representationRepository from '#repositories/representation.repository.js';
 import transitionState from '#state/transition-state.js';
@@ -22,7 +24,11 @@ import {
 	VALIDATION_OUTCOME_COMPLETE
 } from '@pins/appeals/constants/support.js';
 import { EventType } from '@pins/event-client';
-import { APPEAL_CASE_STATUS, SERVICE_USER_TYPE } from '@planning-inspectorate/data-model';
+import {
+	APPEAL_CASE_STATUS,
+	APPEAL_DOCUMENT_TYPE,
+	SERVICE_USER_TYPE
+} from '@planning-inspectorate/data-model';
 import { omit } from 'lodash-es';
 import rhea from 'rhea';
 
@@ -267,10 +273,11 @@ export const copyRepresentations = async (sourceAppeal, destinationAppeal) => {
 				copyBlobs(copyBlobList),
 				addDocumentsToAppeal(
 					{
-						// @ts-ignore
+						blobStorageHost: config.BO_BLOB_STORAGE_ACCOUNT,
+						blobStorageContainer: config.BO_BLOB_CONTAINER,
 						documents: copyList.map((copyDetails) => copyDetails.destinationDocument)
 					},
-					destinationAppeal,
+					/** @type {Appeal} */ (destinationAppeal),
 					true
 				)
 			]);
@@ -387,7 +394,7 @@ export const duplicateAllFiles = async (sourceAppeal, destinationAppeal, options
  * @param {Appeal | {id: number, reference: string}} sourceAppeal
  * @param {string[]} [existingDocuments]
  * @param {string | null} [stage]
- * @returns {{sourceBlobName: string, destinationBlobName: string, destinationDocument: Partial<Document>, sourceGuid: string, destinationGuid: string, version: number} | undefined}
+ * @returns {{sourceBlobName: string, destinationBlobName: string, destinationDocument: MappedDocument, sourceGuid: string, destinationGuid: string, version: number} | undefined}
  */
 export const buildFileCopyDetails = (
 	sourceDocument,
@@ -473,6 +480,21 @@ export const duplicateFiles = async (sourceAppeal, destinationAppeal, stage, opt
 				.filter((copyDetails) => copyDetails != undefined);
 		})
 		.flat();
+
+	// we need to add the new case decision letter guid to the decision on the destination appeal
+	const caseDecisionLetter = copyList.find((copyDetails) => {
+		return (
+			copyDetails.destinationDocument.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+		);
+	});
+
+	if (caseDecisionLetter?.destinationDocument?.GUID) {
+		await updateAppealDecisionLetter(
+			destinationAppeal.id,
+			caseDecisionLetter.destinationDocument.GUID
+		);
+	}
+
 	const copyBlobList = copyList.map(({ sourceBlobName, destinationBlobName }) => ({
 		sourceBlobName,
 		destinationBlobName
@@ -481,10 +503,11 @@ export const duplicateFiles = async (sourceAppeal, destinationAppeal, stage, opt
 		copyBlobs(copyBlobList),
 		addDocumentsToAppeal(
 			{
-				// @ts-ignore
+				blobStorageHost: config.BO_BLOB_STORAGE_ACCOUNT,
+				blobStorageContainer: config.BO_BLOB_CONTAINER,
 				documents: copyList.map((copyDetails) => copyDetails.destinationDocument)
 			},
-			destinationAppeal,
+			/** @type {Appeal} */ (destinationAppeal),
 			true
 		)
 	]);

--- a/appeals/api/src/server/repositories/decision.repository.js
+++ b/appeals/api/src/server/repositories/decision.repository.js
@@ -1,0 +1,21 @@
+import { databaseConnector } from '#utils/database-connector.js';
+
+/** @typedef {import('@pins/appeals.api').Schema.InspectorDecision} InspectorDecision */
+/**
+ * @typedef {import('#db-client/client.ts').Prisma.PrismaPromise<T>} PrismaPromise
+ * @template T
+ */
+
+/**
+ * @param {number} appealId
+ * @param {string} documentGuid
+ * @returns {PrismaPromise<InspectorDecision>}
+ */
+export const updateAppealDecisionLetter = (appealId, documentGuid) => {
+	return databaseConnector.inspectorDecision.update({
+		where: { appealId: appealId },
+		data: {
+			decisionLetterGuid: documentGuid
+		}
+	});
+};

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -895,10 +895,10 @@ export const renderViewDecision = async (request, response) => {
 		currentAppeal.decision.documentId || '',
 		currentAppeal
 	);
-	let latestDecsionDocumentText;
+	let latestDecisionDocumentText;
 
 	if (currentAppeal.decision?.outcome) {
-		latestDecsionDocumentText =
+		latestDecisionDocumentText =
 			letterDateObject.latestFileVersion && letterDateObject.latestFileVersion?.version > 1
 				? `${letterDateObject.originalLetterDate} (reissued on ${letterDateObject.latestLetterDate})`
 				: `${letterDateObject.originalLetterDate}`;
@@ -916,7 +916,7 @@ export const renderViewDecision = async (request, response) => {
 		);
 	}
 
-	const mappedPageContent = viewDecisionPage(currentAppeal, request, latestDecsionDocumentText);
+	const mappedPageContent = viewDecisionPage(currentAppeal, request, latestDecisionDocumentText);
 
 	return response.status(200).render('appeals/appeal/issue-decision.njk', {
 		pageContent: mappedPageContent,


### PR DESCRIPTION
## Describe your changes

- Removing copying of the decision letter when it is issued
- Putting the guid into the InspectorDecision table when the decision letter is copied (including creating a repository to store this function)
- Removing the second copying of representation docs in duplicateAllFiles (they are copied in copyRepresentations)
- Updating JSDocs
- Updating tests
- Small spelling mistake fix

Tested locally to check that the decision docs show up as expected and aren't copied more times than necessary

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8381)
