### PR TITLE
fix(appeals): update date comparison function to cover on the day changes (A2-8662)

### DIFF
--- a/packages/appeals/utils/__tests__/date-utils.test.js
+++ b/packages/appeals/utils/__tests__/date-utils.test.js
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { nextUKDay } from '../date-utils.js';
+import { dateIsOnOrAfterDate, nextUKDay } from '../date-utils.js';
 
 describe('nextUKDay', () => {
 	it('returns the next day at 00:00 in the UK timezone', () => {
@@ -18,5 +18,37 @@ describe('nextUKDay', () => {
 		const date = new Date('2026-12-31T10:00:00Z');
 		const result = nextUKDay(date);
 		expect(result.toISOString()).toBe('2027-01-01T00:00:00.000Z');
+	});
+});
+
+describe('dateIsOnOrAfterDate', () => {
+	const cutoff = new Date('2026-04-01T00:00:00.000Z');
+
+	it('returns true when the date is exactly the cutoff', () => {
+		expect(dateIsOnOrAfterDate(new Date('2026-04-01T00:00:00.000Z'), cutoff)).toBe(true);
+	});
+
+	it('returns true when the date is after the cutoff', () => {
+		expect(dateIsOnOrAfterDate(new Date('2026-04-02T10:00:00.000Z'), cutoff)).toBe(true);
+	});
+
+	it('returns false when the date is clearly before the cutoff', () => {
+		expect(dateIsOnOrAfterDate(new Date('2026-03-30T10:00:00.000Z'), cutoff)).toBe(false);
+	});
+
+	it('returns true when the date is April 1st in BST (represented as March 31st 23:00 UTC)', () => {
+		expect(dateIsOnOrAfterDate(new Date('2026-03-31T23:00:00.000Z'), cutoff)).toBe(true);
+	});
+
+	it('returns true when the date is stored as 2026-04-01T23:00:00.000Z', () => {
+		expect(dateIsOnOrAfterDate(new Date('2026-04-01T23:00:00.000Z'), cutoff)).toBe(true);
+	});
+
+	it('returns false when the date is stored as 2026-03-31T22:59:59.000Z (before BST cutoff)', () => {
+		expect(dateIsOnOrAfterDate(new Date('2026-03-31T22:59:59.000Z'), cutoff)).toBe(false);
+	});
+
+	it('returns false when date is invalid', () => {
+		expect(dateIsOnOrAfterDate('invalid-date', cutoff)).toBe(false);
 	});
 });

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -7,15 +7,7 @@ import {
 import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '../constants/common.js';
 import { EXPEDITED_ORIGINAL_APPLICATION_CUTOFF } from '../constants/dates.js';
 
-/**
- *
- * @param {Date} date
- * @param {Date} afterDate
- * @returns {boolean}
- */
-export const dateIsAfterDate = (date, afterDate) => {
-	return date.getTime() >= afterDate.getTime();
-};
+import { dateIsOnOrAfterDate } from './date-utils.js';
 
 /**
  * Returns true if the original application was submitted before the expedited process start date
@@ -26,7 +18,7 @@ export const dateIsAfterDate = (date, afterDate) => {
 export const beforeExpeditedOriginalApplicationCutOff = (applicationDate) => {
 	return (
 		!applicationDate ||
-		!dateIsAfterDate(new Date(applicationDate), EXPEDITED_ORIGINAL_APPLICATION_CUTOFF)
+		!dateIsOnOrAfterDate(new Date(applicationDate), EXPEDITED_ORIGINAL_APPLICATION_CUTOFF)
 	);
 };
 
@@ -79,10 +71,7 @@ export const isS78ExpeditedAppealType = (
 	if (!appealType || !caseSubmissionDate) return false;
 
 	const isS78 = appealType === APPEAL_CASE_TYPE.W || appealType === APPEAL_TYPE.S78;
-	const isAfterCutoff = dateIsAfterDate(
-		new Date(caseSubmissionDate),
-		EXPEDITED_ORIGINAL_APPLICATION_CUTOFF
-	);
+	const isAfterCutoff = !beforeExpeditedOriginalApplicationCutOff(caseSubmissionDate);
 
 	if (!isS78 || !isAfterCutoff) {
 		return false;

--- a/packages/appeals/utils/date-utils.js
+++ b/packages/appeals/utils/date-utils.js
@@ -1,5 +1,5 @@
 import { add } from 'date-fns';
-import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
+import { formatInTimeZone, utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
 import { DEFAULT_TIMEZONE } from '../constants/dates.js';
 
 /**
@@ -11,4 +11,23 @@ export const nextUKDay = (date) => {
 	const nextDayUkDate = add(ukDate, { days: 1 });
 	const startOfTomorrow = nextDayUkDate.setHours(0, 0, 0, 0);
 	return zonedTimeToUtc(startOfTomorrow, DEFAULT_TIMEZONE);
+};
+/**
+ *
+ * @param {Date} date
+ * @param {Date} afterDate
+ * @returns {boolean}
+ */
+
+export const dateIsOnOrAfterDate = (date, afterDate) => {
+	const d1 = new Date(date);
+	const d2 = new Date(afterDate);
+
+	if (isNaN(d1.getTime()) || isNaN(d2.getTime())) {
+		return false;
+	}
+
+	const dateStr = formatInTimeZone(d1, DEFAULT_TIMEZONE, 'yyyy-MM-dd');
+	const afterDateStr = formatInTimeZone(d2, DEFAULT_TIMEZONE, 'yyyy-MM-dd');
+	return dateStr >= afterDateStr;
 };


### PR DESCRIPTION
## Describe your changes

Updated date function to to convert date time to yyyy-MM-dd for comparison.
Covers issue where 1st April was not included in date range for the expedited cutoff check.

Added unit tests to cover new function logic
Manually tested in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8662)
