### PR TITLE
fix(web): stop routing to env services review page from lpaq if already set (a2-8463)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/outcome-valid.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/__tests__/outcome-valid.test.js
@@ -650,12 +650,18 @@ describe('Appellant Case Valid Flow', () => {
 					})
 					.reply(200);
 				nock('http://test/')
+					.patch(`/appeals/${appealId}/eia-screening-required`, {
+						eiaScreeningRequired: true
+					})
+					.reply(200);
+				nock('http://test/')
 					.get(`/appeals/${appealId}/appellant-cases/0`)
 					.reply(200, {
 						screeningOpinionIndicatesEiaRequired: true,
 						applicationDate: '2026-05-01',
 						applicationDecision: 'refused',
-						typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL
+						typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
+						documents: {}
 					})
 					.persist();
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.controller.js
@@ -7,6 +7,7 @@ import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { APPEAL_TYPE, PROCEDURE_TYPE_ID_MAP } from '@pins/appeals/constants/common.js';
 import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
 import { isBefore } from 'date-fns';
+import { setEnvironmentalImpactAssessmentScreening } from '../../appeal-details.service.js';
 import * as appellantCaseService from '../appellant-case.service.js';
 import {
 	checkAndConfirmEnforcementPage,
@@ -618,6 +619,8 @@ export const postEnvironmentalServicesReview = async (request, response) => {
 			year
 		})
 	);
+
+	await setEnvironmentalImpactAssessmentScreening(request.apiClient, appealId, true);
 
 	delete session.updatedValidDate;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -2115,11 +2115,79 @@ describe('LPA Questionnaire review', () => {
 			['enforcement', APPEAL_TYPE.ENFORCEMENT_NOTICE]
 			//['enforcement listed building', APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING_NOTICE]
 		])(
-			'should redirect to the environmental services page if no errors are present and posted outcome is "complete" for appeal type: %s',
+			'should redirect to the environmental services page if no errors are present and posted outcome is "complete" for appeal type: %s (when eiaScreeningRequired is not set)',
 			async (_, appealType) => {
 				nock('http://test/')
 					.get(`/appeals/2?include=all`)
 					.reply(200, { ...lpaqAppealData, appealType: appealType, appealId: 2 })
+					.persist();
+				nock('http://test/')
+					.get('/appeals/2/lpa-questionnaires/2')
+					.reply(200, lpaQuestionnaireDataIncompleteOutcome)
+					.patch('/appeals/2/lpa-questionnaires/2')
+					.reply(200, { validationOutcome: 'complete' });
+
+				const response = await request
+					.post('/appeals-service/appeal-details/2/lpa-questionnaire/2')
+					.send({
+						'review-outcome': 'complete'
+					});
+
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe(
+					'Found. Redirecting to /appeals-service/appeal-details/2/lpa-questionnaire/2/environment-service-team-review-case'
+				);
+			}
+		);
+
+		it.each([
+			['S78', APPEAL_TYPE.S78],
+			['S20', APPEAL_TYPE.PLANNED_LISTED_BUILDING],
+			['enforcement', APPEAL_TYPE.ENFORCEMENT_NOTICE]
+		])(
+			'should redirect to the case details page (NOT environment services page) if eiaScreeningRequired is true for appeal type: %s',
+			async (_, appealType) => {
+				nock('http://test/')
+					.get(`/appeals/2?include=all`)
+					.reply(200, {
+						...lpaqAppealData,
+						appealType: appealType,
+						appealId: 2,
+						eiaScreeningRequired: true
+					})
+					.persist();
+				nock('http://test/')
+					.get('/appeals/2/lpa-questionnaires/2')
+					.reply(200, lpaQuestionnaireDataIncompleteOutcome)
+					.patch('/appeals/2/lpa-questionnaires/2')
+					.reply(200, { validationOutcome: 'complete' });
+
+				const response = await request
+					.post('/appeals-service/appeal-details/2/lpa-questionnaire/2')
+					.send({
+						'review-outcome': 'complete'
+					});
+
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe('Found. Redirecting to /appeals-service/appeal-details/2');
+			}
+		);
+
+		it.each([
+			['S78', APPEAL_TYPE.S78],
+			['S20', APPEAL_TYPE.PLANNED_LISTED_BUILDING],
+			['enforcement', APPEAL_TYPE.ENFORCEMENT_NOTICE]
+		])(
+			'should redirect to the environmental services page if eiaScreeningRequired is false for appeal type: %s',
+			async (_, appealType) => {
+				nock('http://test/')
+					.get(`/appeals/2?include=all`)
+					.reply(200, {
+						...lpaqAppealData,
+						appealType: appealType,
+						appealId: 2,
+						eiaScreeningRequired: false
+					})
 					.persist();
 				nock('http://test/')
 					.get('/appeals/2/lpa-questionnaires/2')

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -110,7 +110,10 @@ export const postLpaQuestionnaire = async (request, response) => {
 		request.session.reviewOutcome = reviewOutcome;
 
 		if (reviewOutcome === 'complete') {
-			if (askEnvironmentServiceTeamReviewQuestion(currentAppeal.appealType)) {
+			if (
+				askEnvironmentServiceTeamReviewQuestion(currentAppeal.appealType) &&
+				!currentAppeal?.eiaScreeningRequired
+			) {
 				return response.redirect(
 					`/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/environment-service-team-review-case`
 				);


### PR DESCRIPTION
- Set environmental impact assessment screening value at validation stage
- Added screening value as condition in LPAQ stage - bypassing the routing if value was previously set
- Added tests

Ticket: https://pins-ds.atlassian.net/browse/A2-8463
