### PR TITLE
fix(api): transition to issue determination from LPA complete when site visit elapsed (A2-8667)

### DIFF
--- a/appeals/api/src/server/state/__tests__/state-machine.test.js
+++ b/appeals/api/src/server/state/__tests__/state-machine.test.js
@@ -777,10 +777,16 @@ describe('State Machine Transitions', () => {
 			return service.state.value;
 		};
 
-		test('transitions from LPA_QUESTIONNAIRE to EVENT on VALIDATION_OUTCOME_COMPLETE', () => {
+		test('transitions from LPA_QUESTIONNAIRE to EVENT on VALIDATION_OUTCOME_COMPLETE if site visit has NOT elapsed', () => {
 			expect(
-				nextStateExpedited(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, VALIDATION_OUTCOME_COMPLETE)
+				nextStateExpedited(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, VALIDATION_OUTCOME_COMPLETE, false)
 			).toBe(APPEAL_CASE_STATUS.EVENT);
+		});
+
+		test('transitions from LPA_QUESTIONNAIRE to ISSUE_DETERMINATION on VALIDATION_OUTCOME_COMPLETE if site visit HAS elapsed', () => {
+			expect(
+				nextStateExpedited(APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, VALIDATION_OUTCOME_COMPLETE, true)
+			).toBe(APPEAL_CASE_STATUS.ISSUE_DETERMINATION);
 		});
 
 		test('transitions from LPA_QUESTIONNAIRE to closed and withdrawn states', () => {
@@ -820,6 +826,15 @@ describe('State Machine Transitions', () => {
 			expect(
 				nextStateExpedited(APPEAL_CASE_STATUS.AWAITING_EVENT, VALIDATION_OUTCOME_COMPLETE, true)
 			).toBe(APPEAL_CASE_STATUS.ISSUE_DETERMINATION);
+		});
+
+		test('transitions from EVENT to AWAITING_EVENT on VALIDATION_OUTCOME_COMPLETE unconditionally', () => {
+			expect(nextStateExpedited(APPEAL_CASE_STATUS.EVENT, VALIDATION_OUTCOME_COMPLETE, false)).toBe(
+				APPEAL_CASE_STATUS.AWAITING_EVENT
+			);
+			expect(nextStateExpedited(APPEAL_CASE_STATUS.EVENT, VALIDATION_OUTCOME_COMPLETE, true)).toBe(
+				APPEAL_CASE_STATUS.AWAITING_EVENT
+			);
 		});
 
 		test('validates and maps procedure types using isAppealTypeAndProcedureTypeValid guard', () => {

--- a/appeals/api/src/server/state/__tests__/transition-state.test.js
+++ b/appeals/api/src/server/state/__tests__/transition-state.test.js
@@ -237,6 +237,98 @@ describe('transitionState', () => {
 				);
 				expect(result).toEqual(true);
 			});
+
+			test.each([
+				{
+					type: APPEAL_CASE_TYPE.W,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+					description: 'S78 expedited (W + WRITTEN_PART_1)'
+				},
+				{
+					type: APPEAL_CASE_TYPE.D,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+					description: 'HAS (D + WRITTEN)'
+				},
+				{
+					type: APPEAL_CASE_TYPE.ZA,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+					description: 'CAS Advert (ZA + WRITTEN)'
+				},
+				{
+					type: APPEAL_CASE_TYPE.ZP,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+					description: 'CAS Planning (ZP + WRITTEN)'
+				}
+			])(
+				'transitions a $description appeal with arranged site visit in the past from lpaq to issue_determination',
+				async ({ type, procedure }) => {
+					const expeditedAppeal = {
+						...appealFixture,
+						appealStatus: [{ status: 'lpa_questionnaire', valid: true }],
+						appealType: { key: type },
+						procedureType: { key: procedure },
+						siteVisit: {
+							visitDate: new Date(Date.now() - oneDayinMS).toISOString()
+						}
+					};
+
+					databaseConnector.appeal.findUnique.mockResolvedValue(expeditedAppeal);
+
+					const result = await transitionState(11, 'user-123', VALIDATION_OUTCOME_COMPLETE);
+
+					expect(appealStatusRepository.updateAppealStatusByAppealId).toHaveBeenCalledWith(
+						11,
+						'issue_determination'
+					);
+					expect(appealStatusRepository.updateAppealStatusByAppealId).toHaveBeenCalledTimes(1);
+					expect(result).toEqual(true);
+				}
+			);
+
+			test.each([
+				{
+					type: APPEAL_CASE_TYPE.W,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+					description: 'S78 expedited (W + WRITTEN_PART_1)'
+				},
+				{
+					type: APPEAL_CASE_TYPE.D,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+					description: 'HAS (D + WRITTEN)'
+				},
+				{
+					type: APPEAL_CASE_TYPE.ZA,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+					description: 'CAS Advert (ZA + WRITTEN)'
+				},
+				{
+					type: APPEAL_CASE_TYPE.ZP,
+					procedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+					description: 'CAS Planning (ZP + WRITTEN)'
+				}
+			])(
+				'transitions a $description appeal from lpaq to event if site visit is not scheduled',
+				async ({ type, procedure }) => {
+					const expeditedAppeal = {
+						...appealFixture,
+						appealStatus: [{ status: 'lpa_questionnaire', valid: true }],
+						appealType: { key: type },
+						procedureType: { key: procedure },
+						siteVisit: null
+					};
+
+					databaseConnector.appeal.findUnique.mockResolvedValue(expeditedAppeal);
+
+					const result = await transitionState(11, 'user-123', VALIDATION_OUTCOME_COMPLETE);
+
+					expect(appealStatusRepository.updateAppealStatusByAppealId).toHaveBeenCalledWith(
+						11,
+						'event'
+					);
+					expect(appealStatusRepository.updateAppealStatusByAppealId).toHaveBeenCalledTimes(1);
+					expect(result).toEqual(true);
+				}
+			);
 		});
 
 		describe('Error Handling', () => {

--- a/appeals/api/src/server/state/create-state-machine.js
+++ b/appeals/api/src/server/state/create-state-machine.js
@@ -108,7 +108,7 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 			[APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE]: {
 				on: {
 					[VALIDATION_OUTCOME_COMPLETE]: {
-						target: targetStateOnLpaqComplete(appealType, procedureType)
+						target: targetStateOnLpaqComplete(appealType, procedureType, eventElapsed)
 					},
 					[VALIDATION_OUTCOME_INCOMPLETE]: undefined,
 					[APPEAL_CASE_STATUS.CLOSED]: { target: APPEAL_CASE_STATUS.CLOSED },
@@ -435,17 +435,15 @@ const targetStateOnEventCancelled = {
 };
 
 /**
- * Determins the next state after the LPAQ is complete based on the appeal type and procedure type.
+ * Determines the next state after the LPAQ is complete based on the appeal type and procedure type.
  * @param {AppealType} appealType
  * @param {ProcedureType} procedureType
+ * @param {boolean} [eventElapsed]
  * @returns {CaseStatus}
  */
-const targetStateOnLpaqComplete = (appealType, procedureType) => {
+const targetStateOnLpaqComplete = (appealType, procedureType, eventElapsed = false) => {
 	if (appealType === APPEAL_CASE_TYPE.D || procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1) {
-		return APPEAL_CASE_STATUS.EVENT;
-	}
-	if (appealType === APPEAL_CASE_TYPE.W) {
-		return APPEAL_CASE_STATUS.STATEMENTS;
+		return eventElapsed ? APPEAL_CASE_STATUS.ISSUE_DETERMINATION : APPEAL_CASE_STATUS.EVENT;
 	}
 	return APPEAL_CASE_STATUS.STATEMENTS;
 };


### PR DESCRIPTION
## Describe your changes

This PR adds a check to the targetStateOnLpaqComplete function. Checking for elapsed site visit. If the the function is true it will automatically progress the case to issue decision - skipping the event and awaiting evant statuses.

This change will also impact HAS, CAS planning and CAS adverts as the follow the same flow from LPAQ to event. These scenarios are covered in transition-state.test.js

No changes to the process when a site visit is scheduled in the past for in event status - the case will move to awaiting event before it is picked up by the scheduled job that runs every 2 minutes.

Scenarios tested in browser:
Site visit scheduled on S78 expedited appeal before LPAQ reviewed
Schedule site visit on S78 expedited appeal in event status
Site visit scheduled on HAS appeal before LPAQ reviewed
Schedule site visit on HAS expedited appeal in event status


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8667)
