### PR TITLE
fix(api): update stockton lpa email (A2-8660)

### DIFF
--- a/appeals/api/src/database/seed/LPAs/prod.js
+++ b/appeals/api/src/database/seed/LPAs/prod.js
@@ -1888,7 +1888,7 @@ export const localPlanningDepartmentList = [
 	{
 		lpaCode: 'H0738',
 		name: 'Stockton-on-Tees Borough Council',
-		email: 'planning.administration@stockton.gov.uk',
+		email: 'planningdevelopmentservices@stockton.gov.uk',
 		teamId: 16 // North2
 	},
 	{

--- a/appeals/api/src/database/seed/LPAs/training.js
+++ b/appeals/api/src/database/seed/LPAs/training.js
@@ -1889,7 +1889,7 @@ export const localPlanningDepartmentList = [
 	{
 		lpaCode: 'H0738',
 		name: 'Stockton-on-Tees Borough Council',
-		email: 'planning.administration@example.gov.uk',
+		email: 'planningdevelopmentservices@example.gov.uk',
 		teamId: 16 // North2
 	},
 	{


### PR DESCRIPTION
## Describe your changes

- Update the email address for Stockton LPA
- also updated the name part in the training seed, but still keeping the example.com domain


## Issue ticket number and link
## A2-8660 Change LPA email address - Stockton LPA
[Ticket](https://pins-ds.atlassian.net/browse/A2-8660)
