### PR TITLE
fix(web): handle zip download safely (a2-8558)

### DIFF
--- a/appeals/web/src/server/app/components/__tests__/file-downloader.component.test.js
+++ b/appeals/web/src/server/app/components/__tests__/file-downloader.component.test.js
@@ -6,6 +6,7 @@ const mockArchive = {
 	append: jest.fn(),
 	finalize: jest.fn().mockResolvedValue(),
 	on: jest.fn(),
+	once: jest.fn(),
 	destroyed: false,
 	destroy: jest.fn()
 };
@@ -67,7 +68,8 @@ describe('getBulkDocumentDownload', () => {
 			setHeader: jest.fn(),
 			status: jest.fn().mockReturnThis(),
 			send: jest.fn().mockReturnThis(),
-			destroy: jest.fn()
+			destroy: jest.fn(),
+			once: jest.fn()
 		};
 		mockGenerateAllPdfs.mockReset();
 		mockArchive.pipe.mockClear();
@@ -75,6 +77,7 @@ describe('getBulkDocumentDownload', () => {
 		mockArchive.finalize.mockClear();
 		mockArchive.destroy.mockClear();
 		mockArchive.on.mockClear();
+		mockArchive.once.mockClear();
 		mockArchive.destroyed = false;
 		mockConfig.featureFlags.featureFlagPdfDownload = false;
 	});
@@ -119,7 +122,7 @@ describe('getBulkDocumentDownload', () => {
 		expect(mockArchive.pipe).toHaveBeenCalledWith(mockResponse);
 		expect(mockArchive.finalize).toHaveBeenCalled();
 		expect(mockResponse.status).toHaveBeenCalledWith(200);
-		expect(mockResponse.send).toHaveBeenCalled();
+		expect(mockResponse.send).not.toHaveBeenCalled();
 	});
 
 	it('downloads files and appends pdfs if feature flag enabled', async () => {
@@ -162,7 +165,7 @@ describe('getBulkDocumentDownload', () => {
 		expect(mockArchive.append).toHaveBeenCalledWith(expect.any(Buffer), { name: 'foo.pdf' });
 		expect(mockArchive.finalize).toHaveBeenCalled();
 		expect(mockResponse.status).toHaveBeenCalledWith(200);
-		expect(mockResponse.send).toHaveBeenCalled();
+		expect(mockResponse.send).not.toHaveBeenCalled();
 	});
 
 	it('handles no files found', async () => {
@@ -183,7 +186,7 @@ describe('getBulkDocumentDownload', () => {
 		});
 		expect(mockArchive.finalize).toHaveBeenCalled();
 		expect(mockResponse.status).toHaveBeenCalledWith(200);
-		expect(mockResponse.send).toHaveBeenCalled();
+		expect(mockResponse.send).not.toHaveBeenCalled();
 	});
 
 	it('handles error and destroys archive/response', async () => {

--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -324,7 +324,7 @@ const addBlobsToArchive = async (archive, blobStorageClient, bulkFileInfo, missi
  *
  * @param {{apiClient: import('got').Got, params: {caseId: string, filename?: string, representationType?: string}, session: SessionWithAuth, currentAppeal: WebAppeal}} request
  * @param {Response} response
- * @returns {Promise<Response>}
+ * @returns {Promise<void>}
  */
 export const getBulkDocumentDownload = async (
 	{ apiClient, params, session, currentAppeal },
@@ -343,16 +343,53 @@ export const getBulkDocumentDownload = async (
 	const archive = archiver('zip', {
 		zlib: { level: 1 } // compression level 1 to avoid excessive cpu usage
 	});
-	archive.on('warning', function (err) {
+
+	let hasEnded = false;
+	const handleUnexpectedClose = () => {
+		if (hasEnded) return;
+		hasEnded = true;
+
+		try {
+			if (!archive.destroyed) archive.destroy();
+		} catch (err) {
+			logger.error(err, 'Error destroying archive');
+		}
+		try {
+			if (!response.headersSent) response.status(500);
+			if (!response.destroyed) {
+				response.destroy();
+			}
+		} catch (err) {
+			logger.error(err, 'Error destroying response');
+		}
+	};
+
+	/** @param {unknown} err */
+	const handleError = (err) => {
+		logger.error(err, 'getBulkDocumentDownload error:');
+		handleUnexpectedClose();
+	};
+
+	/** @param {import('archiver').ArchiverError} err */
+	const handleWarning = (err) => {
 		if (err.code === 'ENOENT') {
 			logger.warn(err, 'Archiver warning:');
 		} else {
-			throw err;
+			logger.warn(err, 'Archiver warning:');
+			archive.emit('error', err);
+		}
+	};
+
+	response.once('close', () => {
+		if (!response.writableFinished) {
+			logger.warn('getBulkDocumentDownload aborted');
+			return handleUnexpectedClose();
 		}
 	});
-	archive.on('error', function (err) {
-		throw err;
-	});
+	archive.on('warning', handleWarning);
+	archive.once('error', handleError);
+
+	response.status(200);
 	archive.pipe(response);
 
 	try {
@@ -379,15 +416,11 @@ export const getBulkDocumentDownload = async (
 			archive.append(Buffer.from(JSON.stringify(missingFiles)), { name: 'missing-files.json' });
 		}
 
-		await archive.finalize();
-		return response.status(200).send();
+		// Avoid awaiting finalize despite it being a promise https://github.com/archiverjs/node-archiver/issues/772
+		// avoid calling send on response as it will end the stream potentially before archiver has finalised
+		archive.finalize().catch(handleError);
 	} catch (error) {
-		if (archive && !archive.destroyed) {
-			archive.destroy();
-		}
-
-		logger.error(error, 'Error during bulk document download:');
-		return response.destroy();
+		handleError(error);
 	}
 };
 


### PR DESCRIPTION
## Describe your changes

- archiver finalise returns a promise but cannot be safely awaited
- calling send will end the response before finalise finishes writing the end of file bytes
- tidied up event handlers to handle aborted requests and handled async errors safely

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-8558