### PR TITLE
feat(api): update state machine transition for enfLdcDisc hearing (A2…

### DIFF
--- a/appeals/api/src/server/state/__tests__/state-machine.test.js
+++ b/appeals/api/src/server/state/__tests__/state-machine.test.js
@@ -17,15 +17,15 @@ import createStateMachine from '../create-state-machine';
  * Function to get the next state for HAS appeals based on the initial state and event.
  * @param {string} initial - The initial state of the appeal.
  * @param {string} event - The event that triggers the state transition.
- * @param {boolean} [siteVisitElapsed] - Whether the site visit has elapsed.
+ * @param {boolean} [eventElapsed] - Whether the event has elapsed.
  * @return {import('xstate').StateValue} - The next state of the appeal.
  **/
-const nextStateHAS = (initial, event, siteVisitElapsed = false) => {
+const nextStateHAS = (initial, event, eventElapsed = false) => {
 	const machine = createStateMachine(
 		APPEAL_CASE_TYPE.D,
 		APPEAL_CASE_PROCEDURE.WRITTEN,
 		initial,
-		siteVisitElapsed
+		eventElapsed
 	);
 	const service = interpret(machine).start();
 
@@ -38,11 +38,24 @@ const nextStateHAS = (initial, event, siteVisitElapsed = false) => {
  * @param {string} initial - The initial state of the appeal.
  * @param {string} event - The event that triggers the state transition.
  * @param {string} procedureType - The event that triggers the state transition.
- * @param {boolean} [siteVisitElapsed] - Whether the site visit has elapsed.
+ * @param {boolean} [eventElapsed] - Whether the event has elapsed.
+ * @param {boolean} [ldcEnforcementDiscontinuance] - Whether the case type is ldc, enforcement, elb or discontinuance
  * @return {import('xstate').StateValue} - The next state of the appeal.
  **/
-const nextStateFPA = (initial, event, procedureType, siteVisitElapsed = false) => {
-	const machine = createStateMachine(APPEAL_CASE_TYPE.W, procedureType, initial, siteVisitElapsed);
+const nextStateFPA = (
+	initial,
+	event,
+	procedureType,
+	eventElapsed = false,
+	ldcEnforcementDiscontinuance = false
+) => {
+	const machine = createStateMachine(
+		APPEAL_CASE_TYPE.W,
+		procedureType,
+		initial,
+		eventElapsed,
+		ldcEnforcementDiscontinuance
+	);
 	const service = interpret(machine).start();
 
 	service.send(event);
@@ -324,7 +337,7 @@ describe('State Machine Transitions', () => {
 				APPEAL_CASE_STATUS.INVALID
 			]
 		])(
-			'correctly transitions from %s state on %s event to %s state for FPA',
+			'correctly transitions from %s state on %s event to %s state for FPA - non ldcEnfDiscontinuance',
 			(initial, event, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
 				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
 					expectedFPAWritten
@@ -337,6 +350,58 @@ describe('State Machine Transitions', () => {
 				);
 			}
 		);
+
+		test.each([
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				VALIDATION_OUTCOME_COMPLETE,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS
+			],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				VALIDATION_OUTCOME_INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state for FPA - ldcEnfDiscontinuance',
+			(initial, event, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN, false, true)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING, false, true)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY, false, true)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+
 		test.each([
 			[APPEAL_CASE_STATUS.STATEMENTS, VALIDATION_OUTCOME_COMPLETE, APPEAL_CASE_STATUS.STATEMENTS],
 			[APPEAL_CASE_STATUS.STATEMENTS, APPEAL_CASE_STATUS.CLOSED, APPEAL_CASE_STATUS.STATEMENTS],
@@ -373,7 +438,33 @@ describe('State Machine Transitions', () => {
 				);
 			}
 		);
-		test('should transition to AWAITING_EVENT if site visit has NOT elapsed', () => {
+
+		test.each([
+			[APPEAL_CASE_STATUS.FINAL_COMMENTS, VALIDATION_OUTCOME_COMPLETE, APPEAL_CASE_STATUS.EVENT],
+			[APPEAL_CASE_STATUS.FINAL_COMMENTS, APPEAL_CASE_STATUS.CLOSED, APPEAL_CASE_STATUS.CLOSED],
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state for FPA - hearing and inquiry ldcEnfDisc',
+			(initial, event, expectedFPAHearingInquiry) => {
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING, false, true)).toBe(
+					expectedFPAHearingInquiry
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY, false, true)).toBe(
+					expectedFPAHearingInquiry
+				);
+			}
+		);
+
+		test('should transition to EVENT if site visit has NOT elapsed - written', () => {
 			const initialState = APPEAL_CASE_STATUS.FINAL_COMMENTS;
 			const event = VALIDATION_OUTCOME_COMPLETE;
 			const procedure = APPEAL_CASE_PROCEDURE.WRITTEN;
@@ -384,7 +475,25 @@ describe('State Machine Transitions', () => {
 			expect(nextStateFPA(initialState, event, procedure, siteVisitElapsed)).toBe(expectedState);
 		});
 
-		test('should transition to ISSUE_DETERMINATION if site visit HAS elapsed', () => {
+		test('should transition to EVENT if event has NOT elapsed - hearing and inquiry ldcEnfDisc', () => {
+			const initialState = APPEAL_CASE_STATUS.FINAL_COMMENTS;
+			const event = VALIDATION_OUTCOME_COMPLETE;
+			const hearing = APPEAL_CASE_PROCEDURE.HEARING;
+			const inquiry = APPEAL_CASE_PROCEDURE.INQUIRY;
+			const eventElapsed = false;
+			const isLdcEnfDisc = true;
+
+			const expectedState = APPEAL_CASE_STATUS.EVENT;
+
+			expect(nextStateFPA(initialState, event, hearing, eventElapsed, isLdcEnfDisc)).toBe(
+				expectedState
+			);
+			expect(nextStateFPA(initialState, event, inquiry, eventElapsed, isLdcEnfDisc)).toBe(
+				expectedState
+			);
+		});
+
+		test('should transition to ISSUE_DETERMINATION if site visit HAS elapsed - written', () => {
 			const initialState = APPEAL_CASE_STATUS.FINAL_COMMENTS;
 			const event = VALIDATION_OUTCOME_COMPLETE;
 			const procedure = APPEAL_CASE_PROCEDURE.WRITTEN;
@@ -393,6 +502,24 @@ describe('State Machine Transitions', () => {
 			const expectedState = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
 
 			expect(nextStateFPA(initialState, event, procedure, siteVisitElapsed)).toBe(expectedState);
+		});
+
+		test('should transition to ISSUE_DETERMINATION if event HAS elapsed - hearing and inquiry ldcEnfDisc', () => {
+			const initialState = APPEAL_CASE_STATUS.FINAL_COMMENTS;
+			const event = VALIDATION_OUTCOME_COMPLETE;
+			const hearing = APPEAL_CASE_PROCEDURE.HEARING;
+			const inquiry = APPEAL_CASE_PROCEDURE.INQUIRY;
+			const eventElapsed = true;
+			const isLdcEnfDisc = true;
+
+			const expectedState = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
+
+			expect(nextStateFPA(initialState, event, hearing, eventElapsed, isLdcEnfDisc)).toBe(
+				expectedState
+			);
+			expect(nextStateFPA(initialState, event, inquiry, eventElapsed, isLdcEnfDisc)).toBe(
+				expectedState
+			);
 		});
 
 		test.each([
@@ -432,7 +559,7 @@ describe('State Machine Transitions', () => {
 				APPEAL_CASE_STATUS.INVALID
 			]
 		])(
-			'correctly remains at %s state for HAS and FPA - hearing and inquiry',
+			'correctly remains at %s state for HAS and FPA - hearing and inquiry (non-ldcEnfDisc)',
 			(initial, event, expectedHAS, expectedFPAHearing, expectedFPAInquiry) => {
 				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
 				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(

--- a/appeals/api/src/server/state/create-state-machine.js
+++ b/appeals/api/src/server/state/create-state-machine.js
@@ -15,26 +15,33 @@ import {
 import { createMachine } from 'xstate';
 
 /**
- * @typedef {import('@planning-inspectorate/data-model').APPEAL_CASE_TYPE} AppealType
+ * @typedef {import('@planning-inspectorate/data-model').APPEAL_CASE_TYPE} AppealTypeKey
  * @typedef {import('@planning-inspectorate/data-model').APPEAL_CASE_PROCEDURE} ProcedureType
  * @typedef {import('@planning-inspectorate/data-model').APPEAL_CASE_STATUS} CaseStatus
  * @typedef {object} AdditionalCheckObject
  * */
 
 /**
- * @param {AppealType} appealType
+ * @param {AppealTypeKey} appealTypeKey NOTE - at present implementations only pass 'W' or 'D' to this function
  * @param {ProcedureType} procedureType
  * @param {string} currentState
  * @param {boolean} [eventElapsed]
+ * @param {boolean} [isLdcOrDiscontinuanceOrEnforcementCaseType]
  */
-const createStateMachine = (appealType, procedureType, currentState, eventElapsed = false) => {
+const createStateMachine = (
+	appealTypeKey,
+	procedureType,
+	currentState,
+	eventElapsed = false,
+	isLdcOrDiscontinuanceOrEnforcementCaseType = false
+) => {
 	const normalizedProcedureType = normalizeProcedureType(procedureType);
 
 	return createMachine({
 		id: 'appeals-state-machine',
 		initial: currentState || APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
 		context: {
-			appealType,
+			appealType: appealTypeKey,
 			procedureType,
 			eventElapsed
 		},
@@ -108,7 +115,7 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 			[APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE]: {
 				on: {
 					[VALIDATION_OUTCOME_COMPLETE]: {
-						target: targetStateOnLpaqComplete(appealType, procedureType, eventElapsed)
+						target: targetStateOnLpaqComplete(appealTypeKey, procedureType, eventElapsed)
 					},
 					[VALIDATION_OUTCOME_INCOMPLETE]: undefined,
 					[APPEAL_CASE_STATUS.CLOSED]: { target: APPEAL_CASE_STATUS.CLOSED },
@@ -134,7 +141,10 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 					//@ts-ignore
 					[VALIDATION_OUTCOME_COMPLETE]: {
 						//@ts-ignore
-						target: targetStateOnStatementsComplete[normalizedProcedureType],
+						target: targetStateOnStatementsComplete(
+							isLdcOrDiscontinuanceOrEnforcementCaseType,
+							normalizedProcedureType
+						),
 						cond: isAppealTypeAndProcedureTypeValid
 					},
 					[APPEAL_CASE_STATUS.CLOSED]: {
@@ -188,7 +198,9 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 				},
 				meta: {
 					validAppealTypes: [APPEAL_CASE_TYPE.W],
-					validProcedureTypes: [APPEAL_CASE_PROCEDURE.WRITTEN]
+					validProcedureTypes: finalCommentsValidProcedures(
+						isLdcOrDiscontinuanceOrEnforcementCaseType
+					)
 				}
 			},
 			[APPEAL_CASE_STATUS.EVENT]: {
@@ -373,7 +385,7 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 };
 
 /**
- * @typedef {{ appealType: string, procedureType: string, eventElapsed: boolean }} Ctx
+ * @typedef {{ appealType: AppealTypeKey, procedureType: string, eventElapsed: boolean }} Ctx
  * @typedef {{ state: { value: string, meta: Record<string, any> } }} State
  * @typedef {import('xstate').EventObject} _evt
  */
@@ -420,12 +432,6 @@ const isEventElapsedAndValid = (ctx, _evt, meta) => {
 	return isAppealTypeAndProcedureTypeValid(ctx, _evt, meta) && isEventElapsed(ctx);
 };
 
-const targetStateOnStatementsComplete = {
-	[APPEAL_CASE_PROCEDURE.HEARING]: APPEAL_CASE_STATUS.EVENT,
-	[APPEAL_CASE_PROCEDURE.INQUIRY]: APPEAL_CASE_STATUS.EVIDENCE,
-	[APPEAL_CASE_PROCEDURE.WRITTEN]: APPEAL_CASE_STATUS.FINAL_COMMENTS
-};
-
 const targetStateOnEventCancelled = {
 	[APPEAL_CASE_PROCEDURE.HEARING]: APPEAL_CASE_STATUS.EVENT,
 	[APPEAL_CASE_PROCEDURE.INQUIRY]: APPEAL_CASE_STATUS.EVENT,
@@ -436,16 +442,53 @@ const targetStateOnEventCancelled = {
 
 /**
  * Determines the next state after the LPAQ is complete based on the appeal type and procedure type.
- * @param {AppealType} appealType
+ * @param {AppealTypeKey} appealTypeKey
  * @param {ProcedureType} procedureType
  * @param {boolean} [eventElapsed]
  * @returns {CaseStatus}
  */
-const targetStateOnLpaqComplete = (appealType, procedureType, eventElapsed = false) => {
-	if (appealType === APPEAL_CASE_TYPE.D || procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1) {
+const targetStateOnLpaqComplete = (appealTypeKey, procedureType, eventElapsed = false) => {
+	if (
+		appealTypeKey === APPEAL_CASE_TYPE.D ||
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1
+	) {
 		return eventElapsed ? APPEAL_CASE_STATUS.ISSUE_DETERMINATION : APPEAL_CASE_STATUS.EVENT;
 	}
 	return APPEAL_CASE_STATUS.STATEMENTS;
+};
+
+const nonLdcEnfDiscStatementsTargetState = {
+	[APPEAL_CASE_PROCEDURE.WRITTEN]: APPEAL_CASE_STATUS.FINAL_COMMENTS,
+	[APPEAL_CASE_PROCEDURE.HEARING]: APPEAL_CASE_STATUS.EVENT,
+	[APPEAL_CASE_PROCEDURE.INQUIRY]: APPEAL_CASE_STATUS.EVIDENCE
+};
+
+/**
+ * Determines the next state after statements are complete based on the appeal type and procedure type.
+ * @param {boolean} isLdcOrDiscontinuanceOrEnforcementCaseType
+ * @param {ProcedureType} procedureType
+ * @returns {CaseStatus}
+ */
+const targetStateOnStatementsComplete = (
+	isLdcOrDiscontinuanceOrEnforcementCaseType,
+	procedureType
+) => {
+	return isLdcOrDiscontinuanceOrEnforcementCaseType
+		? //@ts-ignore
+			APPEAL_CASE_STATUS.FINAL_COMMENTS
+		: //@ts-ignore
+			nonLdcEnfDiscStatementsTargetState[procedureType];
+};
+
+/**
+ * Determines the next state after statements are complete based on the appeal type and procedure type.
+ * @param {boolean} isLdcOrDiscontinuanceOrEnforcementCaseType
+ * @returns {ProcedureType[]}
+ */
+const finalCommentsValidProcedures = (isLdcOrDiscontinuanceOrEnforcementCaseType) => {
+	return isLdcOrDiscontinuanceOrEnforcementCaseType
+		? [APPEAL_CASE_PROCEDURE.WRITTEN, APPEAL_CASE_PROCEDURE.HEARING, APPEAL_CASE_PROCEDURE.INQUIRY]
+		: [APPEAL_CASE_PROCEDURE.WRITTEN];
 };
 
 export default createStateMachine;

--- a/appeals/api/src/server/state/list-states.js
+++ b/appeals/api/src/server/state/list-states.js
@@ -17,11 +17,11 @@ import createStateMachine from './create-state-machine.js';
  * @returns {StateStub[]}
  * */
 function listStates(appealType, procedureType, currentState) {
-	const appealTypeKey = !isExpeditedAppealType(appealType.key)
+	const normalizedAppealTypeKey = !isExpeditedAppealType(appealType.key)
 		? APPEAL_CASE_TYPE.W
 		: APPEAL_CASE_TYPE.D;
 	const stateMachine = createStateMachine(
-		appealTypeKey,
+		normalizedAppealTypeKey,
 		procedureType?.key || APPEAL_CASE_PROCEDURE.WRITTEN,
 		currentState
 	);
@@ -37,13 +37,14 @@ function listStates(appealType, procedureType, currentState) {
 			const { validAppealTypes, validProcedureTypes } = state.meta;
 
 			if (!procedureType) {
-				return validAppealTypes.includes(appealTypeKey);
+				return validAppealTypes.includes(normalizedAppealTypeKey);
 			}
 
 			const procedureTypeKey = normalizeProcedureType(procedureType.key);
 
 			return (
-				validAppealTypes.includes(appealTypeKey) && validProcedureTypes.includes(procedureTypeKey)
+				validAppealTypes.includes(normalizedAppealTypeKey) &&
+				validProcedureTypes.includes(procedureTypeKey)
 			);
 		})
 		.sort((a, b) => states[a].order - states[b].order);

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -20,6 +20,7 @@ import {
 } from '@pins/appeals/constants/support.js';
 import {
 	isExpeditedAppealType,
+	isLdcOrDiscontinuanceOrEnforcementCaseType,
 	normalizeProcedureType
 } from '@pins/appeals/utils/appeal-type-checks.js';
 import { nextUKDay } from '@pins/appeals/utils/date-utils.js';
@@ -69,13 +70,22 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 
 	const procedureKey = procedureType?.key ?? APPEAL_CASE_PROCEDURE.WRITTEN;
 	const normalizedProcedureKey = normalizeProcedureType(procedureKey);
-	const appealTypeKey = !isExpeditedAppealType(appealType.key)
+	const normalizedAppealTypeKey = !isExpeditedAppealType(appealType.key)
 		? APPEAL_CASE_TYPE.W
 		: APPEAL_CASE_TYPE.D;
+	const isLdcOrDiscontinuanceOrEnforcement = isLdcOrDiscontinuanceOrEnforcementCaseType(
+		appealType.key
+	);
 
 	const eventElapsed = getEventElapsed(appeal, appealType, normalizedProcedureKey);
 
-	const stateMachine = createStateMachine(appealTypeKey, procedureKey, currentState, eventElapsed);
+	const stateMachine = createStateMachine(
+		normalizedAppealTypeKey,
+		procedureKey,
+		currentState,
+		eventElapsed,
+		isLdcOrDiscontinuanceOrEnforcement
+	);
 	const stateMachineService = interpret(stateMachine);
 
 	stateMachineService.onTransition((/** @type {{value: StateValue}} */ state) => {
@@ -112,7 +122,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 
 	if (
 		newState === APPEAL_CASE_STATUS.EVENT &&
-		[APPEAL_CASE_TYPE.D, APPEAL_CASE_TYPE.W].includes(appealTypeKey) &&
+		[APPEAL_CASE_TYPE.D, APPEAL_CASE_TYPE.W].includes(normalizedAppealTypeKey) &&
 		((normalizedProcedureKey === APPEAL_CASE_PROCEDURE.WRITTEN && appeal.siteVisit) ||
 			(normalizedProcedureKey === APPEAL_CASE_PROCEDURE.HEARING &&
 				appeal.hearing &&
@@ -127,7 +137,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 	if (
 		newState === APPEAL_CASE_STATUS.EVIDENCE &&
 		//@ts-ignore
-		[APPEAL_CASE_TYPE.W].includes(appealTypeKey) &&
+		[APPEAL_CASE_TYPE.W].includes(normalizedAppealTypeKey) &&
 		procedureKey === APPEAL_CASE_PROCEDURE.INQUIRY
 	) {
 		const evidenceRepresentations = await representationRepository.getRepresentations([appealId], {


### PR DESCRIPTION
…-7383)

Update state machine:
- new ctx field - isLdcEnfdiscontinuance, defaults to false.
- amend trasitions from statements and final comments to cater for hearings for isLdcEnfDisc

NOTE - this should also be useful for inquiries for ldc/enf/disc.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7383)
