### PR TITLE
feat(web): adding final comments to ldc, enf, elb, disc hearing and i…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-details-page-sections/s78.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details-page-sections/s78.js
@@ -56,9 +56,9 @@ export function generateAppealDetailsPageComponents(appealDetails, mappedData, s
 								mappedData.appeal.planningObligationDueDate.display.summaryListItem,
 								mappedData.appeal.proofOfEvidenceAndWitnessesDueDate.display.summaryListItem,
 								mappedData.appeal.caseManagementConferenceDueDate.display.summaryListItem,
+								mappedData.appeal.finalCommentDueDate.display.summaryListItem,
 								mappedData.appeal.hearingDate.display.summaryListItem,
-								mappedData.appeal.inquiryDate.display.summaryListItem,
-								mappedData.appeal.finalCommentDueDate.display.summaryListItem
+								mappedData.appeal.inquiryDate.display.summaryListItem
 							]
 						: [])
 				].filter(isDefined)

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
@@ -370,54 +370,57 @@ describe('Timetable', () => {
 			}
 		);
 
-		describe.each([APPEAL_TYPE.ENFORCEMENT_NOTICE, APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE])(
-			'Enforcement and LDC',
-			(appealType) => {
-				it(`should render correct "Timetable due dates" page for ${appealType} type inquiry appeal`, async () => {
-					const appealData = {
-						...baseAppealData,
-						appealStatus: 'lpa_questionnaire',
-						appealTimetable: {
-							appealTimetableId: 1
-						},
-						appealType: appealType,
-						procedureType: 'Inquiry'
-					};
+		describe.each([
+			APPEAL_TYPE.ENFORCEMENT_NOTICE,
+			APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING,
+			// APPEAL_TYPE.DISCONTINUANCE_NOTICE, // discontinuance has not been added yet
+			APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE
+		])('Enforcement, ELB, discontinuance and LDC', (appealType) => {
+			it(`should render correct "Timetable due dates" page for ${appealType} type inquiry appeal`, async () => {
+				const appealData = {
+					...baseAppealData,
+					appealStatus: 'lpa_questionnaire',
+					appealTimetable: {
+						appealTimetableId: 1
+					},
+					appealType: appealType,
+					procedureType: 'Inquiry'
+				};
 
-					nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
-					nock('http://test/')
-						.get('/appeals/1/appellant-cases/0')
-						.reply(200, { planningObligation: { hasObligation: false } });
+				nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, { planningObligation: { hasObligation: false } });
 
-					const response = await request.get(`${baseUrl}/edit`);
-					const element = parseHtml(response.text);
+				const response = await request.get(`${baseUrl}/edit`);
+				const element = parseHtml(response.text);
 
-					expect(element.innerHTML).toContain('name="final-comments-due-date-day"');
-				});
+				expect(element.innerHTML).toContain('name="final-comments-due-date-day"');
+			});
 
-				it(`should render correct "Timetable due dates" page for ${appealType} type hearing appeal`, async () => {
-					const appealData = {
-						...baseAppealData,
-						appealStatus: 'lpa_questionnaire',
-						appealTimetable: {
-							appealTimetableId: 1
-						},
-						appealType: appealType,
-						procedureType: 'Hearing'
-					};
+			it(`should render correct "Timetable due dates" page for ${appealType} type hearing appeal`, async () => {
+				const appealData = {
+					...baseAppealData,
+					appealStatus: 'lpa_questionnaire',
+					appealTimetable: {
+						appealTimetableId: 1
+					},
+					appealType: appealType,
+					procedureType: 'Hearing'
+				};
 
-					nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
-					nock('http://test/')
-						.get('/appeals/1/appellant-cases/0')
-						.reply(200, { planningObligation: { hasObligation: false } });
+				nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, { planningObligation: { hasObligation: false } });
 
-					const response = await request.get(`${baseUrl}/edit`);
-					const element = parseHtml(response.text);
+				const response = await request.get(`${baseUrl}/edit`);
+				const element = parseHtml(response.text);
 
-					expect(element.innerHTML).toContain('name="final-comments-due-date-day"');
-				});
-			}
-		);
+				expect(element.innerHTML).toContain('name="final-comments-due-date-day"');
+				expect(element.innerHTML).not.toContain('name="statement-of-common-ground-due-date-day"');
+			});
+		});
 	});
 
 	describe('POST /edit', () => {

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
@@ -2,12 +2,11 @@ import { appealShortReference } from '#lib/appeals-formatter.js';
 import { dateISOStringToDayMonthYearHourMinute, getExampleDateHint } from '#lib/dates.js';
 import { dateInput } from '#lib/mappers/index.js';
 import { appealTypeToAppealCaseTypeMapper } from '@pins/appeals/utils/appeal-type-case.mapper.js';
-import { isExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
 import {
-	APPEAL_CASE_PROCEDURE,
-	APPEAL_CASE_STATUS,
-	APPEAL_CASE_TYPE
-} from '@planning-inspectorate/data-model';
+	isExpeditedAppealType,
+	isLdcOrDiscontinuanceOrEnforcementCaseType
+} from '@pins/appeals/utils/appeal-type-checks.js';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
 /**
  * @typedef {import('../appeal-details.types.js').WebAppeal} Appeal
@@ -138,17 +137,6 @@ export const getIdText = (timetableType) => {
 };
 
 /**
- * @param {AppealTimetableType[]} validAppealTimetableType
- * @param {AppellantCase} appellantCase
- */
-const addHearingOrInquiryTimetableTypes = (validAppealTimetableType, appellantCase) => {
-	validAppealTimetableType.push('statementOfCommonGroundDueDate');
-	if (appellantCase.planningObligation?.hasObligation) {
-		validAppealTimetableType.push('planningObligationDueDate');
-	}
-};
-
-/**
  * @param {Appeal} appeal
  * @param {AppellantCase} appellantCase
  * @returns {AppealTimetableType[]}
@@ -176,19 +164,25 @@ export const getAppealTimetableTypes = (appeal, appellantCase) => {
 		}
 		if (
 			appeal.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN ||
-			([APPEAL_CASE_TYPE.C, APPEAL_CASE_TYPE.F, APPEAL_CASE_TYPE.G, APPEAL_CASE_TYPE.X].includes(
-				caseType
-			) &&
+			(isLdcOrDiscontinuanceOrEnforcementCaseType(caseType) &&
 				(appeal.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING ||
 					appeal.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.INQUIRY))
 		) {
 			validAppealTimetableType.push('finalCommentsDueDate');
 		}
 		if (appeal.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING) {
-			addHearingOrInquiryTimetableTypes(validAppealTimetableType, appellantCase);
+			if (!isLdcOrDiscontinuanceOrEnforcementCaseType(caseType)) {
+				validAppealTimetableType.push('statementOfCommonGroundDueDate');
+			}
+			if (appellantCase.planningObligation?.hasObligation) {
+				validAppealTimetableType.push('planningObligationDueDate');
+			}
 		}
 		if (appeal.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.INQUIRY) {
-			addHearingOrInquiryTimetableTypes(validAppealTimetableType, appellantCase);
+			validAppealTimetableType.push('statementOfCommonGroundDueDate');
+			if (appellantCase.planningObligation?.hasObligation) {
+				validAppealTimetableType.push('planningObligationDueDate');
+			}
 			validAppealTimetableType.push('proofOfEvidenceAndWitnessesDueDate');
 			validAppealTimetableType.push('caseManagementConferenceDueDate');
 		}

--- a/appeals/web/src/server/lib/mappers/data/appeal/common.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/common.js
@@ -11,11 +11,7 @@ import {
 	APPEAL_PROOF_OF_EVIDENCE_STATUS,
 	APPEAL_REPRESENTATION_STATUS
 } from '@pins/appeals/constants/common.js';
-import { isLdcOrDiscontinuanceOrEnforcementAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
-import {
-	APPEAL_CASE_PROCEDURE,
-	APPEAL_VIRUS_CHECK_STATUS
-} from '@planning-inspectorate/data-model';
+import { APPEAL_VIRUS_CHECK_STATUS } from '@planning-inspectorate/data-model';
 /**
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal
  */
@@ -160,11 +156,3 @@ export const proofsReceivedText = (statusText, receivedAt) => {
 		receivedAt instanceof Date ? receivedAt.toDateString() : receivedAt
 	);
 };
-
-/**
- * @param {WebAppeal} appealDetails
- * @returns {boolean}
- */
-export const doNotDisplayFinalComments = (appealDetails) =>
-	appealDetails?.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING &&
-	!isLdcOrDiscontinuanceOrEnforcementAppealType(appealDetails?.appealType);

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/final-comments-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/final-comments-due-date.mapper.test.js
@@ -20,7 +20,9 @@ describe.each([
 		};
 	});
 
-	it(`should not display Final Comments due date`, () => {
+	it(`should not display Final Comments due date when appeal has not started yet`, () => {
+		data.appealDetails.procedureType = 'written';
+		data.appealDetails.appealType = appealType;
 		const mappedData = mapFinalCommentDueDate(data);
 		expect(mappedData).toEqual({
 			display: {},
@@ -28,7 +30,7 @@ describe.each([
 		});
 	});
 
-	it(`should display Final Comments due date with new Change action link`, () => {
+	it(`should display Final Comments due date with Change action link when appeal has started with written procedure`, () => {
 		data.appealDetails.startedAt = '2025-01-01';
 		data.appealDetails.procedureType = 'written';
 		data.appealDetails.appealType = appealType;
@@ -60,4 +62,85 @@ describe.each([
 			id: 'final-comments-due-date'
 		});
 	});
+
+	it(`should not display Final Comments due date when procedure type is hearing`, () => {
+		// Final comments are only available for hearing procedure for LDC, discontinuance, enforcement and ELB case types
+		data.appealDetails.startedAt = '2025-01-01';
+		data.appealDetails.procedureType = 'hearing';
+		data.appealDetails.appealType = appealType;
+		const mappedData = mapFinalCommentDueDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'final-comments-due-date'
+		});
+	});
+
+	it(`should not display Final Comments due date when procedure type is inquiry`, () => {
+		// Final comments are only available for inquiry procedure for LDC, discontinuance, enforcement and ELB case types
+		data.appealDetails.startedAt = '2025-01-01';
+		data.appealDetails.procedureType = 'inquiry';
+		data.appealDetails.appealType = appealType;
+		const mappedData = mapFinalCommentDueDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'final-comments-due-date'
+		});
+	});
+});
+
+// Test coverage for case types which have final comments for hearing/inquiry procedures
+describe.each([
+	['LDC', APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE],
+	['discontinuance', APPEAL_TYPE.DISCONTINUANCE_NOTICE],
+	['enforcement notice', APPEAL_TYPE.ENFORCEMENT_NOTICE],
+	['enforcement listed building', APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING]
+])('final-comments-due-date.mapper - %s', (label, appealType) => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				appealTimetable: { finalCommentsDueDate: '2025-01-10' },
+				documentationSummary: { finalComments: { representationStatus: 'published' } },
+				startedAt: '2025-01-01'
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it.each(['written', 'hearing', 'inquiry'])(
+		`should display Final Comments due date with Change action link - %s`,
+		(procedureType) => {
+			data.appealDetails.procedureType = procedureType;
+			data.appealDetails.appealType = appealType;
+			const mappedData = mapFinalCommentDueDate(data);
+			expect(mappedData).toEqual({
+				display: {
+					summaryListItem: {
+						actions: {
+							items: [
+								{
+									attributes: {
+										'data-cy': 'change-final-comments-due-date'
+									},
+									href: '/test/timetable/edit',
+									text: 'Change',
+									visuallyHiddenText: 'Final comments due'
+								}
+							]
+						},
+						classes: 'appeal-final-comments-due-date',
+						key: {
+							text: 'Final comments due'
+						},
+						value: {
+							text: '10 January 2025'
+						}
+					}
+				},
+				id: 'final-comments-due-date'
+			});
+		}
+	);
 });

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/statement-of-common-ground.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/statement-of-common-ground.mapper.test.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { mapStatementOfCommonGroundDueDate } from '#lib/mappers/data/appeal/submappers/statement-of-common-ground-due-date.mapper.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common';
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 describe('S78 expedited appeal - statement-of-common-ground-due-date.mapper', () => {
 	let data;
@@ -22,6 +23,28 @@ describe('S78 expedited appeal - statement-of-common-ground-due-date.mapper', ()
 	});
 
 	it('should not display Statement of Common Ground due date for S78 expedited appeal', () => {
+		const mappedData = mapStatementOfCommonGroundDueDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'statement-of-common-ground-due-date'
+		});
+	});
+});
+
+describe('enforcement hearing appeal - statement-of-common-ground-due-date.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				appealTimetable: { statementOfCommonGroundDueDate: '' },
+				appealType: APPEAL_TYPE.ENFORCEMENT_NOTICE,
+				procedureType: APPEAL_CASE_PROCEDURE.HEARING
+			}
+		};
+	});
+
+	it('should not display Statement of Common Ground due date for enforcement hearing appeal', () => {
 		const mappedData = mapStatementOfCommonGroundDueDate(data);
 		expect(mappedData).toEqual({
 			display: {},

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
@@ -9,7 +9,7 @@ import {
 	mapRepresentationDocumentSummaryActionLink
 } from '#lib/representation-utilities.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
-import { doNotDisplayFinalComments } from '../common.js';
+import { displayFinalComments } from '@pins/appeals/utils/business-rules.js';
 
 /**
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal
@@ -59,7 +59,12 @@ export const mapAppellantFinalComments = ({ appealDetails, currentRoute, request
 		return dateISOStringToDisplayDate(receivedAt);
 	})();
 
-	if (doNotDisplayFinalComments(appealDetails)) {
+	if (
+		!displayFinalComments(
+			appealDetails.appealType ?? undefined,
+			appealDetails.procedureType ?? undefined
+		)
+	) {
 		const id = 'start-case-date';
 		return { id, display: {} };
 	} else {

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/final-comment-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/final-comment-due-date.mapper.js
@@ -2,7 +2,8 @@ import { isStatePassed } from '#lib/appeal-status.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
-import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { displayFinalComments } from '@pins/appeals/utils/business-rules.js';
+import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapFinalCommentDueDate = ({
@@ -12,9 +13,14 @@ export const mapFinalCommentDueDate = ({
 }) => {
 	const id = 'final-comments-due-date';
 
+	// if it is an enforcement, ELB, LDC or discontinuance appeal we have final comments for all procedure types
+	// otherwise we only have final comments for written procedure type
 	if (
 		!appealDetails.startedAt ||
-		appealDetails.procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.WRITTEN
+		!displayFinalComments(
+			appealDetails.appealType ?? undefined,
+			appealDetails.procedureType ?? undefined
+		)
 	) {
 		return { id, display: {} };
 	}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
@@ -9,7 +9,7 @@ import {
 	mapRepresentationDocumentSummaryActionLink
 } from '#lib/representation-utilities.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
-import { doNotDisplayFinalComments } from '../common.js';
+import { displayFinalComments } from '@pins/appeals/utils/business-rules.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapLPAFinalComments = ({ appealDetails, currentRoute, request }) => {
@@ -55,7 +55,12 @@ export const mapLPAFinalComments = ({ appealDetails, currentRoute, request }) =>
 		return dateISOStringToDisplayDate(receivedAt);
 	})();
 
-	if (doNotDisplayFinalComments(appealDetails)) {
+	if (
+		!displayFinalComments(
+			appealDetails.appealType ?? undefined,
+			appealDetails.procedureType ?? undefined
+		)
+	) {
 		const id = 'start-case-date';
 		return { id, display: {} };
 	} else {

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/statement-of-common-ground-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/statement-of-common-ground-due-date.mapper.js
@@ -1,7 +1,10 @@
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
-import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
+import {
+	isLdcOrDiscontinuanceOrEnforcementAppealType,
+	isS78ExpeditedAppealType
+} from '@pins/appeals/utils/appeal-type-checks.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
@@ -21,7 +24,9 @@ export const mapStatementOfCommonGroundDueDate = ({
 			appellantCase?.applicationDate,
 			appellantCase?.applicationDecision,
 			appellantCase?.typeOfPlanningApplication
-		)
+		) ||
+		(appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING &&
+			isLdcOrDiscontinuanceOrEnforcementAppealType(appealDetails.appealType))
 	) {
 		return { id, display: {} };
 	}

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -626,10 +626,7 @@ export const CONFIG_APPEAL_TIMETABLE = {
 	[APPEAL_CASE_TYPE.C]: {
 		[APPEAL_CASE_PROCEDURE.WRITTEN]: { ...enforcementNoticeTimetable },
 		[APPEAL_CASE_PROCEDURE.HEARING]: {
-			...enforcementNoticeTimetable,
-			statementOfCommonGroundDueDate: {
-				daysFromStartDate: 25
-			}
+			...enforcementNoticeTimetable
 		},
 		[APPEAL_CASE_PROCEDURE.INQUIRY]: {
 			...enforcementInquiryTimetable

--- a/packages/appeals/utils/__tests__/appeal-type-checks.test.js
+++ b/packages/appeals/utils/__tests__/appeal-type-checks.test.js
@@ -1,0 +1,49 @@
+import { APPEAL_TYPE } from '../../constants/common';
+import {
+	isAnyEnforcementAppealType,
+	isLdcOrDiscontinuanceOrEnforcementAppealType
+} from '../appeal-type-checks';
+
+describe('isAnyEnforcementAppealType', () => {
+	it.each([APPEAL_TYPE.ENFORCEMENT_NOTICE, APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING])(
+		'returns true for %s',
+		(appealType) => {
+			expect(isAnyEnforcementAppealType(appealType)).toBe(true);
+		}
+	);
+
+	it.each([
+		APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE,
+		APPEAL_TYPE.DISCONTINUANCE_NOTICE,
+		APPEAL_TYPE.HOUSEHOLDER,
+		APPEAL_TYPE.S78,
+		APPEAL_TYPE.ADVERTISEMENT,
+		APPEAL_TYPE.PLANNED_LISTED_BUILDING,
+		APPEAL_TYPE.CAS_PLANNING,
+		APPEAL_TYPE.CAS_ADVERTISEMENT
+	])('returns false for %s', (appealType) => {
+		expect(isAnyEnforcementAppealType(appealType)).toBe(false);
+	});
+});
+
+describe('isLdcOrDiscontinuanceOrEnforcementAppealType', () => {
+	it.each([
+		APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE,
+		APPEAL_TYPE.DISCONTINUANCE_NOTICE,
+		APPEAL_TYPE.ENFORCEMENT_NOTICE,
+		APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
+	])('returns true for %s', (appealType) => {
+		expect(isLdcOrDiscontinuanceOrEnforcementAppealType(appealType)).toBe(true);
+	});
+
+	it.each([
+		APPEAL_TYPE.HOUSEHOLDER,
+		APPEAL_TYPE.S78,
+		APPEAL_TYPE.ADVERTISEMENT,
+		APPEAL_TYPE.PLANNED_LISTED_BUILDING,
+		APPEAL_TYPE.CAS_PLANNING,
+		APPEAL_TYPE.CAS_ADVERTISEMENT
+	])('returns false for %s', (appealType) => {
+		expect(isLdcOrDiscontinuanceOrEnforcementAppealType(appealType)).toBe(false);
+	});
+});

--- a/packages/appeals/utils/__tests__/business-rules.test.js
+++ b/packages/appeals/utils/__tests__/business-rules.test.js
@@ -1,0 +1,40 @@
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { APPEAL_TYPE } from '../../constants/common';
+import { displayFinalComments } from '../business-rules.js';
+
+describe('displayFinalComments', () => {
+	describe.each([
+		APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE,
+		APPEAL_TYPE.DISCONTINUANCE_NOTICE,
+		APPEAL_TYPE.ENFORCEMENT_NOTICE,
+		APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
+	])('appeal type: %s', (appealType) => {
+		it.each([
+			APPEAL_CASE_PROCEDURE.WRITTEN,
+			APPEAL_CASE_PROCEDURE.HEARING,
+			APPEAL_CASE_PROCEDURE.INQUIRY
+		])('returns true for %s', (procedureType) => {
+			expect(displayFinalComments(appealType, procedureType)).toBe(true);
+		});
+	});
+
+	describe.each([
+		APPEAL_TYPE.HOUSEHOLDER,
+		APPEAL_TYPE.S78,
+		APPEAL_TYPE.ADVERTISEMENT,
+		APPEAL_TYPE.PLANNED_LISTED_BUILDING,
+		APPEAL_TYPE.CAS_PLANNING,
+		APPEAL_TYPE.CAS_ADVERTISEMENT
+	])('appeal type: %s', (appealType) => {
+		it('returns true for written', () => {
+			expect(displayFinalComments(appealType, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(true);
+		});
+
+		it.each([APPEAL_CASE_PROCEDURE.HEARING, APPEAL_CASE_PROCEDURE.INQUIRY])(
+			'returns false for %s',
+			(procedureType) => {
+				expect(displayFinalComments(appealType, procedureType)).toBe(false);
+			}
+		);
+	});
+});

--- a/packages/appeals/utils/appeal-type-case.mapper.js
+++ b/packages/appeals/utils/appeal-type-case.mapper.js
@@ -3,7 +3,7 @@ import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
 
 /**
  *
- * @param {string} appealType
+ * @param {string | undefined} appealType
  * @returns string
  */
 export const appealTypeToAppealCaseTypeMapper = (appealType) => {

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -7,6 +7,7 @@ import {
 import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '../constants/common.js';
 import { EXPEDITED_ORIGINAL_APPLICATION_CUTOFF } from '../constants/dates.js';
 
+import { appealTypeToAppealCaseTypeMapper } from './appeal-type-case.mapper.js';
 import { dateIsOnOrAfterDate } from './date-utils.js';
 
 /**
@@ -113,8 +114,7 @@ export const isEnforcementCaseType = (caseType) =>
  * @returns {boolean}
  */
 export const isAnyEnforcementAppealType = (appealType) =>
-	appealType === APPEAL_TYPE.ENFORCEMENT_NOTICE ||
-	appealType === APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING;
+	isEnforcementCaseType(appealTypeToAppealCaseTypeMapper(appealType));
 
 /**
  *
@@ -122,9 +122,7 @@ export const isAnyEnforcementAppealType = (appealType) =>
  * @returns {boolean}
  */
 export const isLdcOrDiscontinuanceOrEnforcementAppealType = (appealType) =>
-	appealType === APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE ||
-	appealType === APPEAL_TYPE.DISCONTINUANCE_NOTICE ||
-	isAnyEnforcementAppealType(appealType);
+	isLdcOrDiscontinuanceOrEnforcementCaseType(appealTypeToAppealCaseTypeMapper(appealType));
 
 /**
  *

--- a/packages/appeals/utils/business-rules.js
+++ b/packages/appeals/utils/business-rules.js
@@ -1,0 +1,12 @@
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { isLdcOrDiscontinuanceOrEnforcementAppealType } from './appeal-type-checks.js';
+
+/**
+ * @param {string | undefined} appealType
+ * @param {string | undefined} procedureType
+ * @returns {boolean}
+ */
+export const displayFinalComments = (appealType, procedureType) =>
+	isLdcOrDiscontinuanceOrEnforcementAppealType(appealType) ||
+	(procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.HEARING &&
+		procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.INQUIRY);


### PR DESCRIPTION
…nquiry (A2-8533)

## Describe your changes

- Reordering the rows so that the hearing/inquiry row is at the bottom of the timetable section
- Removing statement of common ground for enforcement, ELB, discontinuance and LDC hearing
- Change timetable dates shows only the correct dates based on appeal type and procedure based on the above changes
- Updating tests to cover the above changes
- Created new function displayFinalComments in business-rules and replaced logic in various places with this
- Test for displayFinalComments
- Updating appeal-type-checks to use the mappers
- Adding some tests for appeal-type-checks

Tested locally:
<img width="1205" height="547" alt="image" src="https://github.com/user-attachments/assets/7384bea8-9769-4857-8cec-748bc899edac" />
<img width="537" height="904" alt="image" src="https://github.com/user-attachments/assets/0dce3a0a-23f0-483c-996b-6f068ad79483" />

with planning obligation
<img width="1209" height="614" alt="image" src="https://github.com/user-attachments/assets/34a1fff7-18ec-4dad-9e83-ff21d7f68bec" />
<img width="591" height="1125" alt="image" src="https://github.com/user-attachments/assets/0da1d68f-7268-4a29-8198-53850b569c94" />

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8533)
