### PR TITLE
feat(appeals): add paging to manage folder route (a2-8514)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -1392,7 +1392,11 @@ describe('Appeal detail routes', () => {
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
-				expect(response.body).toEqual({ id: mocks.householdAppeal.id });
+				expect(response.body).toEqual({
+					id: mocks.householdAppeal.id,
+					appealId: mocks.householdAppeal.id,
+					appealReference: mocks.householdAppeal.reference
+				});
 			});
 
 			test('returns an error if appealId is not numeric', async () => {

--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
@@ -26,14 +26,8 @@ router.get(
 			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
 		}
 		#swagger.responses[200] = {
-			description: '200 if appeal exists'
-			schema: {
-				type: 'object',
-				properties: {
-					id: { type: 'integer', example: 123 }
-				},
-				required: ['id']
-			}
+			description: '200 if appeal exists',
+			schema: { $ref: '#/components/schemas/AppealExistsResponse' }
 		}
 		#swagger.responses[400] = {}
 		#swagger.responses[404] = {}
@@ -43,7 +37,9 @@ router.get(
 	/** @type {import("express").RequestHandler} */
 	(req, res) => {
 		return res.status(200).send({
-			id: Number(req.params.appealId)
+			id: Number(req.params.appealId),
+			appealId: Number(req.params.appealId),
+			appealReference: req.appeal.reference
 		});
 	}
 );

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -798,6 +798,37 @@ interface DocumentVersionInfo {
 	documentType: string;
 }
 
+interface PagedFolderInfo {
+	folderId: number;
+	caseId: string;
+	path: string;
+	totalFolderSize: number;
+	pageCount: number;
+	documents: PagedDocumentInfo[];
+}
+
+interface PagedDocumentInfo {
+	id: string;
+	name: string;
+	createdAt: string;
+	isDeleted?: boolean | null;
+	latestDocumentVersion: PagedDocumentVersionInfo;
+}
+
+interface PagedDocumentVersionInfo {
+	documentId: string;
+	version: number;
+	published: boolean;
+	virusCheckStatus: string;
+	size: string;
+	redactionStatus: string;
+	dateReceived: string;
+	isLateEntry?: boolean | null;
+	isDeleted?: boolean | null;
+	documentType: string;
+	stage: string;
+}
+
 interface SingleSiteVisitDetailsResponse {
 	appealId: number;
 	visitDate: Date | null;
@@ -1257,6 +1288,9 @@ export {
 	LookupTables,
 	NotifyClient,
 	NotifyTemplate,
+	PagedDocumentInfo,
+	PagedDocumentVersionInfo,
+	PagedFolderInfo,
 	ReasonOption,
 	RelatedAppeal,
 	ServiceUserResponse,

--- a/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
+++ b/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
@@ -39,15 +39,18 @@ describe('/appeals/:appealId/document-folders/:folderId', () => {
 		test('gets a single document folder', async () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 			databaseConnector.folder.findUnique.mockResolvedValue(savedFolder);
+			databaseConnector.document.count.mockResolvedValue(10);
 
 			const response = await request
-				.get(`/appeals/${householdAppeal.id}/document-folders/${savedFolder.id}`)
+				.get(`/appeals/${householdAppeal.id}/document-folders/${savedFolder.id}?pageSize=10`)
 				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(200);
 
 			expect(response.body).toEqual({
 				folderId: savedFolder.id,
+				pageCount: 1,
+				totalFolderSize: 10,
 				path: savedFolder.path,
 				caseId: savedFolder.caseId.toString(),
 				documents: [
@@ -77,6 +80,27 @@ describe('/appeals/:appealId/document-folders/:folderId', () => {
 					}
 				]
 			});
+		});
+
+		test('gets a paged results', async () => {
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			databaseConnector.folder.findUnique.mockResolvedValue(savedFolder);
+			databaseConnector.document.count.mockResolvedValue(10);
+
+			const response = await request
+				.get(
+					`/appeals/${householdAppeal.id}/document-folders/${savedFolder.id}?pageSize=1&pageNumber=2`
+				)
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+
+			expect(response.body).toEqual(
+				expect.objectContaining({
+					pageCount: 10,
+					totalFolderSize: 10
+				})
+			);
 		});
 	});
 });

--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -23,6 +23,7 @@ import { notifySend } from '#notify/notify-send.js';
 import appellantCaseRepository from '#repositories/appellant-case.repository.js';
 import * as documentRepository from '#repositories/document.repository.js';
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
+import { getPageCount } from '#utils/database-pagination.js';
 import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { updatePersonalList } from '#utils/update-personal-list.js';
@@ -45,8 +46,25 @@ import * as service from './documents.service.js';
 export const getFolder = async (req, res) => {
 	const { appeal } = req;
 	const { folderId } = req.params;
-	const repId = Number(req.query.repId) || null;
-	const folder = await service.getFolderForAppeal(appeal.id, folderId, repId);
+	const repId = req.query.repId ? Number(req.query.repId) : null;
+	const pageNumber = Number(req.query.pageNumber) || 1;
+	const pageSize = Number(req.query.pageSize) || 5;
+	const folder = await service.getFolderForAppeal(
+		appeal.id,
+		Number(folderId),
+		pageNumber,
+		pageSize,
+		repId
+	);
+
+	if (folder) {
+		const documentCount = await service.getFolderDocumentCount(Number(folderId), repId);
+		const pageCount = getPageCount(documentCount, pageSize);
+		// @ts-expect-error
+		folder.totalFolderSize = documentCount;
+		// @ts-expect-error
+		folder.pageCount = pageCount;
+	}
 
 	return res.send(folder);
 };

--- a/appeals/api/src/server/endpoints/documents/documents.routes.js
+++ b/appeals/api/src/server/endpoints/documents/documents.routes.js
@@ -1,5 +1,8 @@
 import { getAppealValidator } from '#endpoints/appeal-details/appeal-details.validators.js';
-import { checkAppealExistsByIdAndAddPartialToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
+import {
+	checkAppealExistsById,
+	checkAppealExistsByIdAndAddPartialToRequest
+} from '#middleware/check-appeal-exists-and-add-to-request.js';
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
 import * as controller from './documents.controller.js';
@@ -28,14 +31,14 @@ router.get(
 			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
 		}
 		#swagger.responses[200] = {
-			description: 'Returns the contents of a single appeal folder, by id',
+			description: 'Returns the contents of a group of folders',
 			schema: { $ref: '#/components/schemas/Folder' }
 		}
 		#swagger.responses[400] = {}
 		#swagger.responses[404] = {}
 	 */
 	getAppealValidator,
-	checkAppealExistsByIdAndAddPartialToRequest([]),
+	checkAppealExistsById,
 	controller.getFolders
 );
 
@@ -44,7 +47,7 @@ router.get(
 	/*
 		#swagger.tags = ['Documents']
 		#swagger.path = '/appeals/{appealId}/document-folders/{folderId}'
-		#swagger.description = Returns the contents of a single appeal folder, by id
+		#swagger.description = Returns the contents of a single appeal folder, by id, paged
 		#swagger.parameters['azureAdUserId'] = {
 			in: 'header',
 			required: true,
@@ -56,14 +59,14 @@ router.get(
 			example: 1,
 		}
 		#swagger.responses[200] = {
-			description: 'Returns the contents of a single appeal folder, by id',
-			schema: { $ref: '#/components/schemas/Folder' }
+			description: 'Returns the contents of a single appeal folder, by id, paged',
+			schema: { $ref: '#/components/schemas/PagedFolder' }
 		}
 		#swagger.responses[400] = {}
 		#swagger.responses[404] = {}
 	 */
 	getAppealValidator,
-	checkAppealExistsByIdAndAddPartialToRequest([]),
+	checkAppealExistsById,
 	getFolderIdValidator,
 	asyncHandler(controller.getFolder)
 );
@@ -200,7 +203,7 @@ router.patch(
 		#swagger.responses[404] = {}
 	 */
 	patchDocumentsValidator,
-	checkAppealExistsByIdAndAddPartialToRequest([]),
+	checkAppealExistsById,
 	asyncHandler(controller.updateDocuments)
 );
 

--- a/appeals/api/src/server/endpoints/documents/documents.service.js
+++ b/appeals/api/src/server/endpoints/documents/documents.service.js
@@ -7,7 +7,13 @@ import {
 	deleteDocumentVersion
 } from '#repositories/document-metadata.repository.js';
 import documentRedactionStatusRepository from '#repositories/document-redaction-status.repository.js';
-import { getByCaseId, getByCaseIdAndPaths, getById } from '#repositories/folder.repository.js';
+import {
+	getByCaseId,
+	getByCaseIdAndPaths,
+	getById,
+	getFolderSizeById,
+	getRepresentationFolderSizeById
+} from '#repositories/folder.repository.js';
 import { validateBlobContents } from '#utils/blob-validation.js';
 import logger from '#utils/logger.js';
 import {
@@ -37,34 +43,30 @@ import { mapDocumentsForAuditTrail, mapDocumentsForDatabase } from './documents.
 
 /**
  * @param {number} appealId
- * @param {string} folderId
+ * @param {number} folderId
+ * @param {number} pageNumber
+ * @param {number} pageSize
  * @param {number|null} repId
  * @returns {Promise<FolderInfo | null>}
  */
-export const getFolderForAppeal = async (appealId, folderId, repId) => {
-	const folder = await getById(Number(folderId));
+export const getFolderForAppeal = async (appealId, folderId, pageNumber, pageSize, repId) => {
+	const folder = await getById(Number(folderId), pageNumber, pageSize, repId);
 	if (!folder) {
 		return null;
 	}
 
 	if (repId) {
-		const attachments = folder?.documents
-			.filter(
-				(doc) =>
-					doc.latestDocumentVersion?.representation != null &&
-					doc.latestDocumentVersion?.representation.representationId === repId
-			)
-			.map((doc) => {
-				const docFriendlyName = doc.name.replace(/[a-f\d-]{36}_/, '');
-				return {
-					...doc,
-					name: docFriendlyName,
-					latestDocumentVersion: {
-						...doc.latestDocumentVersion,
-						fileName: docFriendlyName
-					}
-				};
-			});
+		const attachments = folder?.documents.map((doc) => {
+			const docFriendlyName = doc.name.replace(/[a-f\d-]{36}_/, '');
+			return {
+				...doc,
+				name: docFriendlyName,
+				latestDocumentVersion: {
+					...doc.latestDocumentVersion,
+					fileName: docFriendlyName
+				}
+			};
+		});
 
 		return (
 			formatFolder({
@@ -79,6 +81,19 @@ export const getFolderForAppeal = async (appealId, folderId, repId) => {
 	}
 
 	return null;
+};
+
+/**
+ * @param {number} folderId
+ * @param {number|null} [repId]
+ * @returns {Promise<number>}
+ */
+export const getFolderDocumentCount = async (folderId, repId) => {
+	if (repId) {
+		return getRepresentationFolderSizeById(folderId, repId);
+	}
+
+	return getFolderSizeById(folderId);
 };
 
 /**

--- a/appeals/api/src/server/endpoints/notify-preview/notify-preview.routes.js
+++ b/appeals/api/src/server/endpoints/notify-preview/notify-preview.routes.js
@@ -7,8 +7,8 @@ router.post(
 	'/notify-preview/:templateName',
 	/*
 		#swagger.tags = ['Documents']
-		#swagger.path = '/appeals/{appealId}/document-folders/{folderId}'
-		#swagger.description = Returns the contents of a single appeal folder, by id
+		#swagger.path = '/notify-preview/{templateName}'
+		#swagger.description = Returns the contents of a notify template preview
 		#swagger.parameters['azureAdUserId'] = {
 			in: 'header',
 			required: true,
@@ -20,8 +20,8 @@ router.post(
 			example: 1,
 		}
 		#swagger.responses[200] = {
-			description: 'Returns the contents of a single appeal folder, by id',
-			schema: { $ref: '#/components/schemas/Folder' }
+			description: 'Returns the contents of a notify template preview',
+			schema: { $ref: '#/components/schemas/NotifyTemplate' }
 		}
 		#swagger.responses[400] = {}
 		#swagger.responses[404] = {}

--- a/appeals/api/src/server/mappers/api/definitions/folders-documents.js
+++ b/appeals/api/src/server/mappers/api/definitions/folders-documents.js
@@ -150,7 +150,22 @@ const folder = {
 	}
 };
 
+const pagedFolder = {
+	...folder,
+	required: [...folder.required, 'pageCount', 'totalFolderSize'],
+	properties: {
+		...folder.properties,
+		pageCount: {
+			type: 'number'
+		},
+		totalFolderSize: {
+			type: 'number'
+		}
+	}
+};
+
 export const Folder = folder;
+export const PagedFolder = pagedFolder;
 export const Document = document;
 export const DocumentVersion = documentVersion;
 export const DocumentLog = documentLog;

--- a/appeals/api/src/server/mappers/api/definitions/index.js
+++ b/appeals/api/src/server/mappers/api/definitions/index.js
@@ -11,7 +11,13 @@ import { AssignedTeam } from './assigned-team.js';
 import { AuditNotifications } from './audit-notification.js';
 import { DesignatedSiteName } from './designated-site-name.js';
 import { DocumentationSummary } from './documentation-summary.js';
-import { Document, DocumentLog, DocumentVersion, Folder } from './folders-documents.js';
+import {
+	Document,
+	DocumentLog,
+	DocumentVersion,
+	Folder,
+	PagedFolder
+} from './folders-documents.js';
 import { InvalidIncompleteReason } from './invalid-incomplete.js';
 import { ListedBuilding } from './listed-building.js';
 import { LpaQuestionnaire, LpaQuestionnaireUpdateRequest } from './lpa-questionnaire.js';
@@ -42,6 +48,7 @@ const partials = {
 	AppealCancellation,
 	AppealRelationship,
 	Folder,
+	PagedFolder,
 	Document,
 	DocumentVersion,
 	DocumentLog,

--- a/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
+++ b/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
@@ -98,5 +98,10 @@ export const checkAppealExistsById = async (req, res, next) => {
 		return res.status(404).send({ errors: { appealId: ERROR_NOT_FOUND } });
 	}
 
+	if (!req.appeal) {
+		//@ts-expect-error
+		req.appeal = { id: appeal.id, reference: appeal.reference };
+	}
+
 	next();
 };

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -1302,6 +1302,15 @@ export interface SingleAppealResponse {
 	};
 }
 
+export interface AppealExistsResponse {
+	/** @example 118 */
+	id?: number;
+	/** @example 118 */
+	appealId?: number;
+	/** @example "6000118" */
+	appealReference?: string;
+}
+
 export interface SingleAppellantCaseResponse {
 	agriculturalHolding?: {
 		/** @example true */
@@ -4572,6 +4581,295 @@ export interface AppealRelationship {
 	externalSource?: boolean | null;
 	externalId?: string | null;
 	externalAppealType?: string | null;
+}
+
+export interface PagedFolder {
+	caseId: number;
+	folderId: number;
+	path: string;
+	documents: {
+		/** @format uuid */
+		id: string;
+		caseId?: number;
+		folderId?: number;
+		name: string;
+		/** @format date-time */
+		createdAt?: string;
+		latestDocumentVersion?: {
+			/** @format uuid */
+			id: string;
+			version: number;
+			fileName?: string;
+			originalFileName?: string;
+			size?: number;
+			mime?: string;
+			/** @format date-time */
+			createdAt?: string;
+			/** @format date-time */
+			dateReceived?: string;
+			redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
+			virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
+			documentType?:
+				| 'additionalDocumentsLPA'
+				| 'appealNotification'
+				| 'appellantCaseCorrespondence'
+				| 'appellantCaseWithdrawalLetter'
+				| 'appellantCostsApplication'
+				| 'appellantCostsCorrespondence'
+				| 'appellantCostsDecisionLetter'
+				| 'appellantCostsWithdrawal'
+				| 'appellantFinalComment'
+				| 'appellantProofOfEvidence'
+				| 'appellantStatement'
+				| 'appellantWitnessesEvidence'
+				| 'applicationDecisionLetter'
+				| 'article4Direction'
+				| 'caseDecisionLetter'
+				| 'changedDescription'
+				| 'communityInfrastructureLevy'
+				| 'conservationDocuments'
+				| 'conservationMap'
+				| 'consultationResponses'
+				| 'crossTeamCorrespondence'
+				| 'definitiveMapAndStatementExtract'
+				| 'definitiveMapStatement'
+				| 'delegatedReport'
+				| 'designAccessStatement'
+				| 'designAccessStatementLPA'
+				| 'developmentPlanPolicies'
+				| 'discontinuanceNotice'
+				| 'eiaEnvironmentalStatement'
+				| 'eiaEnvironmentalStatementAppellant'
+				| 'eiaScopingOpinion'
+				| 'eiaScreeningDirection'
+				| 'eiaScreeningOpinion'
+				| 'emergingPlan'
+				| 'enforcementList'
+				| 'enforcementNotice'
+				| 'enforcementNoticePlan'
+				| 'environmentalAssessment'
+				| 'groundAFeeReceipt'
+				| 'groundASupporting'
+				| 'groundBSupporting'
+				| 'groundCSupporting'
+				| 'groundDSupporting'
+				| 'groundESupporting'
+				| 'groundFSupporting'
+				| 'groundGSupporting'
+				| 'groundHSupporting'
+				| 'groundISupporting'
+				| 'groundJSupporting'
+				| 'groundKSupporting'
+				| 'historicEnglandConsultation'
+				| 'inspectorCorrespondence'
+				| 'interestedPartyComment'
+				| 'localDevelopmentOrder'
+				| 'lpaCaseCorrespondence'
+				| 'lpaCostsApplication'
+				| 'lpaCostsCorrespondence'
+				| 'lpaCostsDecisionLetter'
+				| 'lpaCostsWithdrawal'
+				| 'lpaEnforcementNotice'
+				| 'lpaEnforcementNoticePlan'
+				| 'lpaEnforcementNoticeWithdrawal'
+				| 'lpaFinalComment'
+				| 'lpaProofOfEvidence'
+				| 'lpaStatement'
+				| 'lpaWitnessesEvidence'
+				| 'mainPartyCorrespondence'
+				| 'newPlansDrawings'
+				| 'originalApplicationForm'
+				| 'otherNewDocuments'
+				| 'otherPartyRepresentations'
+				| 'otherRelevantMatters'
+				| 'otherRelevantPolicies'
+				| 'ownershipCertificate'
+				| 'planShowingExtentOfOrder'
+				| 'planningContraventionNotice'
+				| 'planningObligation'
+				| 'planningOfficerReport'
+				| 'planningPermission'
+				| 'plansDrawings'
+				| 'plansDrawingsLPA'
+				| 'priorCorrespondenceWithPINS'
+				| 'relatedApplications'
+				| 'rule6ProofOfEvidence'
+				| 'rule6Statement'
+				| 'rule6WitnessesEvidence'
+				| 'statementCommonGround'
+				| 'stopNotice'
+				| 'supplementaryPlanning'
+				| 'treePreservationPlan'
+				| 'uncategorised'
+				| 'whoNotified'
+				| 'whoNotifiedLetterToNeighbours'
+				| 'whoNotifiedPressAdvert'
+				| 'whoNotifiedSiteNotice';
+			stage?:
+				| 'appeal-decision'
+				| 'appellant-case'
+				| 'cancellation'
+				| 'costs'
+				| 'evidence'
+				| 'final-comments'
+				| 'internal'
+				| 'lpa-questionnaire'
+				| 'statements'
+				| 'third-party-comments'
+				| 'witnesses';
+			documentURI: string;
+			isLateEntry?: boolean;
+			isDeleted?: boolean;
+			versionAudit?:
+				| {
+						/** @format date-time */
+						loggedAt: string;
+						/** @format uuid */
+						user: string;
+						action: string;
+						details: string;
+				  }[]
+				| null;
+		};
+		allVersions?: {
+			/** @format uuid */
+			id: string;
+			version: number;
+			fileName?: string;
+			originalFileName?: string;
+			size?: number;
+			mime?: string;
+			/** @format date-time */
+			createdAt?: string;
+			/** @format date-time */
+			dateReceived?: string;
+			redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
+			virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
+			documentType?:
+				| 'additionalDocumentsLPA'
+				| 'appealNotification'
+				| 'appellantCaseCorrespondence'
+				| 'appellantCaseWithdrawalLetter'
+				| 'appellantCostsApplication'
+				| 'appellantCostsCorrespondence'
+				| 'appellantCostsDecisionLetter'
+				| 'appellantCostsWithdrawal'
+				| 'appellantFinalComment'
+				| 'appellantProofOfEvidence'
+				| 'appellantStatement'
+				| 'appellantWitnessesEvidence'
+				| 'applicationDecisionLetter'
+				| 'article4Direction'
+				| 'caseDecisionLetter'
+				| 'changedDescription'
+				| 'communityInfrastructureLevy'
+				| 'conservationDocuments'
+				| 'conservationMap'
+				| 'consultationResponses'
+				| 'crossTeamCorrespondence'
+				| 'definitiveMapAndStatementExtract'
+				| 'definitiveMapStatement'
+				| 'delegatedReport'
+				| 'designAccessStatement'
+				| 'designAccessStatementLPA'
+				| 'developmentPlanPolicies'
+				| 'discontinuanceNotice'
+				| 'eiaEnvironmentalStatement'
+				| 'eiaEnvironmentalStatementAppellant'
+				| 'eiaScopingOpinion'
+				| 'eiaScreeningDirection'
+				| 'eiaScreeningOpinion'
+				| 'emergingPlan'
+				| 'enforcementList'
+				| 'enforcementNotice'
+				| 'enforcementNoticePlan'
+				| 'environmentalAssessment'
+				| 'groundAFeeReceipt'
+				| 'groundASupporting'
+				| 'groundBSupporting'
+				| 'groundCSupporting'
+				| 'groundDSupporting'
+				| 'groundESupporting'
+				| 'groundFSupporting'
+				| 'groundGSupporting'
+				| 'groundHSupporting'
+				| 'groundISupporting'
+				| 'groundJSupporting'
+				| 'groundKSupporting'
+				| 'historicEnglandConsultation'
+				| 'inspectorCorrespondence'
+				| 'interestedPartyComment'
+				| 'localDevelopmentOrder'
+				| 'lpaCaseCorrespondence'
+				| 'lpaCostsApplication'
+				| 'lpaCostsCorrespondence'
+				| 'lpaCostsDecisionLetter'
+				| 'lpaCostsWithdrawal'
+				| 'lpaEnforcementNotice'
+				| 'lpaEnforcementNoticePlan'
+				| 'lpaEnforcementNoticeWithdrawal'
+				| 'lpaFinalComment'
+				| 'lpaProofOfEvidence'
+				| 'lpaStatement'
+				| 'lpaWitnessesEvidence'
+				| 'mainPartyCorrespondence'
+				| 'newPlansDrawings'
+				| 'originalApplicationForm'
+				| 'otherNewDocuments'
+				| 'otherPartyRepresentations'
+				| 'otherRelevantMatters'
+				| 'otherRelevantPolicies'
+				| 'ownershipCertificate'
+				| 'planShowingExtentOfOrder'
+				| 'planningContraventionNotice'
+				| 'planningObligation'
+				| 'planningOfficerReport'
+				| 'planningPermission'
+				| 'plansDrawings'
+				| 'plansDrawingsLPA'
+				| 'priorCorrespondenceWithPINS'
+				| 'relatedApplications'
+				| 'rule6ProofOfEvidence'
+				| 'rule6Statement'
+				| 'rule6WitnessesEvidence'
+				| 'statementCommonGround'
+				| 'stopNotice'
+				| 'supplementaryPlanning'
+				| 'treePreservationPlan'
+				| 'uncategorised'
+				| 'whoNotified'
+				| 'whoNotifiedLetterToNeighbours'
+				| 'whoNotifiedPressAdvert'
+				| 'whoNotifiedSiteNotice';
+			stage?:
+				| 'appeal-decision'
+				| 'appellant-case'
+				| 'cancellation'
+				| 'costs'
+				| 'evidence'
+				| 'final-comments'
+				| 'internal'
+				| 'lpa-questionnaire'
+				| 'statements'
+				| 'third-party-comments'
+				| 'witnesses';
+			documentURI: string;
+			isLateEntry?: boolean;
+			isDeleted?: boolean;
+			versionAudit?:
+				| {
+						/** @format date-time */
+						loggedAt: string;
+						/** @format uuid */
+						user: string;
+						action: string;
+						details: string;
+				  }[]
+				| null;
+		}[];
+	}[];
+	pageCount: number;
+	totalFolderSize: number;
 }
 
 export interface Document {

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -167,7 +167,25 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK"
+						"description": "200 if appeal exists",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppealExistsResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AppealExistsResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
 					}
 				}
 			}
@@ -3420,7 +3438,7 @@
 				],
 				"responses": {
 					"200": {
-						"description": "Returns the contents of a single appeal folder, by id",
+						"description": "Returns the contents of a group of folders",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -3444,9 +3462,9 @@
 			}
 		},
 		"/appeals/{appealId}/document-folders/{folderId}": {
-			"post": {
+			"get": {
 				"tags": ["Documents"],
-				"description": "Returns the contents of a single appeal folder, by id",
+				"description": "Returns the contents of a single appeal folder, by id, paged",
 				"parameters": [
 					{
 						"name": "appealId",
@@ -3485,16 +3503,16 @@
 				],
 				"responses": {
 					"200": {
-						"description": "Returns the contents of a single appeal folder, by id",
+						"description": "Returns the contents of a single appeal folder, by id, paged",
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Folder"
+									"$ref": "#/components/schemas/PagedFolder"
 								}
 							},
 							"application/xml": {
 								"schema": {
-									"$ref": "#/components/schemas/Folder"
+									"$ref": "#/components/schemas/PagedFolder"
 								}
 							}
 						}
@@ -6840,6 +6858,63 @@
 								"$ref": "#/components/schemas/CreateHearingRequest"
 							}
 						}
+					}
+				}
+			}
+		},
+		"/notify-preview/{templateName}": {
+			"post": {
+				"tags": ["Documents"],
+				"description": "Returns the contents of a notify template preview",
+				"parameters": [
+					{
+						"name": "templateName",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "repId",
+						"in": "query",
+						"description": "The ID of a representation to filter attachments to",
+						"example": 1,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Returns the contents of a notify template preview",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NotifyTemplate"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NotifyTemplate"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
 					}
 				}
 			}
@@ -11437,6 +11512,26 @@
 				},
 				"xml": {
 					"name": "SingleAppealResponse"
+				}
+			},
+			"AppealExistsResponse": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "number",
+						"example": 118
+					},
+					"appealId": {
+						"type": "number",
+						"example": 118
+					},
+					"appealReference": {
+						"type": "string",
+						"example": "6000118"
+					}
+				},
+				"xml": {
+					"name": "AppealExistsResponse"
 				}
 			},
 			"SingleAppellantCaseResponse": {
@@ -17900,6 +17995,451 @@
 					"externalAppealType": {
 						"type": "string",
 						"nullable": true
+					}
+				}
+			},
+			"PagedFolder": {
+				"type": "object",
+				"required": ["caseId", "folderId", "path", "documents", "pageCount", "totalFolderSize"],
+				"properties": {
+					"caseId": {
+						"type": "number"
+					},
+					"folderId": {
+						"type": "number"
+					},
+					"path": {
+						"type": "string"
+					},
+					"documents": {
+						"nullable": true,
+						"type": "array",
+						"items": {
+							"type": "object",
+							"required": ["id", "name"],
+							"properties": {
+								"id": {
+									"type": "string",
+									"format": "uuid"
+								},
+								"caseId": {
+									"type": "number"
+								},
+								"folderId": {
+									"type": "number"
+								},
+								"name": {
+									"type": "string"
+								},
+								"createdAt": {
+									"type": "string",
+									"format": "date-time"
+								},
+								"latestDocumentVersion": {
+									"type": "object",
+									"required": [
+										"id",
+										"version",
+										"virusCheckStatus",
+										"redactionStatus",
+										"documentURI"
+									],
+									"properties": {
+										"id": {
+											"type": "string",
+											"format": "uuid"
+										},
+										"version": {
+											"type": "number"
+										},
+										"fileName": {
+											"type": "string"
+										},
+										"originalFileName": {
+											"type": "string"
+										},
+										"size": {
+											"type": "number"
+										},
+										"mime": {
+											"type": "string"
+										},
+										"createdAt": {
+											"type": "string",
+											"format": "date-time"
+										},
+										"dateReceived": {
+											"type": "string",
+											"format": "date-time"
+										},
+										"redactionStatus": {
+											"type": "string",
+											"enum": ["no_redaction_required", "not_redacted", "redacted"]
+										},
+										"virusCheckStatus": {
+											"type": "string",
+											"enum": ["affected", "not_scanned", "scanned"]
+										},
+										"documentType": {
+											"type": "string",
+											"enum": [
+												"additionalDocumentsLPA",
+												"appealNotification",
+												"appellantCaseCorrespondence",
+												"appellantCaseWithdrawalLetter",
+												"appellantCostsApplication",
+												"appellantCostsCorrespondence",
+												"appellantCostsDecisionLetter",
+												"appellantCostsWithdrawal",
+												"appellantFinalComment",
+												"appellantProofOfEvidence",
+												"appellantStatement",
+												"appellantWitnessesEvidence",
+												"applicationDecisionLetter",
+												"article4Direction",
+												"caseDecisionLetter",
+												"changedDescription",
+												"communityInfrastructureLevy",
+												"conservationDocuments",
+												"conservationMap",
+												"consultationResponses",
+												"crossTeamCorrespondence",
+												"definitiveMapAndStatementExtract",
+												"definitiveMapStatement",
+												"delegatedReport",
+												"designAccessStatement",
+												"designAccessStatementLPA",
+												"developmentPlanPolicies",
+												"discontinuanceNotice",
+												"eiaEnvironmentalStatement",
+												"eiaEnvironmentalStatementAppellant",
+												"eiaScopingOpinion",
+												"eiaScreeningDirection",
+												"eiaScreeningOpinion",
+												"emergingPlan",
+												"enforcementList",
+												"enforcementNotice",
+												"enforcementNoticePlan",
+												"environmentalAssessment",
+												"groundAFeeReceipt",
+												"groundASupporting",
+												"groundBSupporting",
+												"groundCSupporting",
+												"groundDSupporting",
+												"groundESupporting",
+												"groundFSupporting",
+												"groundGSupporting",
+												"groundHSupporting",
+												"groundISupporting",
+												"groundJSupporting",
+												"groundKSupporting",
+												"historicEnglandConsultation",
+												"inspectorCorrespondence",
+												"interestedPartyComment",
+												"localDevelopmentOrder",
+												"lpaCaseCorrespondence",
+												"lpaCostsApplication",
+												"lpaCostsCorrespondence",
+												"lpaCostsDecisionLetter",
+												"lpaCostsWithdrawal",
+												"lpaEnforcementNotice",
+												"lpaEnforcementNoticePlan",
+												"lpaEnforcementNoticeWithdrawal",
+												"lpaFinalComment",
+												"lpaProofOfEvidence",
+												"lpaStatement",
+												"lpaWitnessesEvidence",
+												"mainPartyCorrespondence",
+												"newPlansDrawings",
+												"originalApplicationForm",
+												"otherNewDocuments",
+												"otherPartyRepresentations",
+												"otherRelevantMatters",
+												"otherRelevantPolicies",
+												"ownershipCertificate",
+												"planShowingExtentOfOrder",
+												"planningContraventionNotice",
+												"planningObligation",
+												"planningOfficerReport",
+												"planningPermission",
+												"plansDrawings",
+												"plansDrawingsLPA",
+												"priorCorrespondenceWithPINS",
+												"relatedApplications",
+												"rule6ProofOfEvidence",
+												"rule6Statement",
+												"rule6WitnessesEvidence",
+												"statementCommonGround",
+												"stopNotice",
+												"supplementaryPlanning",
+												"treePreservationPlan",
+												"uncategorised",
+												"whoNotified",
+												"whoNotifiedLetterToNeighbours",
+												"whoNotifiedPressAdvert",
+												"whoNotifiedSiteNotice"
+											]
+										},
+										"stage": {
+											"type": "string",
+											"enum": [
+												"appeal-decision",
+												"appellant-case",
+												"cancellation",
+												"costs",
+												"evidence",
+												"final-comments",
+												"internal",
+												"lpa-questionnaire",
+												"statements",
+												"third-party-comments",
+												"witnesses"
+											]
+										},
+										"documentURI": {
+											"type": "string"
+										},
+										"isLateEntry": {
+											"type": "boolean"
+										},
+										"isDeleted": {
+											"type": "boolean"
+										},
+										"versionAudit": {
+											"nullable": true,
+											"type": "array",
+											"items": {
+												"type": "object",
+												"required": ["loggedAt", "user", "action", "details"],
+												"properties": {
+													"loggedAt": {
+														"type": "string",
+														"format": "date-time"
+													},
+													"user": {
+														"type": "string",
+														"format": "uuid"
+													},
+													"action": {
+														"type": "string"
+													},
+													"details": {
+														"type": "string"
+													}
+												}
+											}
+										}
+									},
+									"nullable": true
+								},
+								"allVersions": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"required": [
+											"id",
+											"version",
+											"virusCheckStatus",
+											"redactionStatus",
+											"documentURI"
+										],
+										"properties": {
+											"id": {
+												"type": "string",
+												"format": "uuid"
+											},
+											"version": {
+												"type": "number"
+											},
+											"fileName": {
+												"type": "string"
+											},
+											"originalFileName": {
+												"type": "string"
+											},
+											"size": {
+												"type": "number"
+											},
+											"mime": {
+												"type": "string"
+											},
+											"createdAt": {
+												"type": "string",
+												"format": "date-time"
+											},
+											"dateReceived": {
+												"type": "string",
+												"format": "date-time"
+											},
+											"redactionStatus": {
+												"type": "string",
+												"enum": ["no_redaction_required", "not_redacted", "redacted"]
+											},
+											"virusCheckStatus": {
+												"type": "string",
+												"enum": ["affected", "not_scanned", "scanned"]
+											},
+											"documentType": {
+												"type": "string",
+												"enum": [
+													"additionalDocumentsLPA",
+													"appealNotification",
+													"appellantCaseCorrespondence",
+													"appellantCaseWithdrawalLetter",
+													"appellantCostsApplication",
+													"appellantCostsCorrespondence",
+													"appellantCostsDecisionLetter",
+													"appellantCostsWithdrawal",
+													"appellantFinalComment",
+													"appellantProofOfEvidence",
+													"appellantStatement",
+													"appellantWitnessesEvidence",
+													"applicationDecisionLetter",
+													"article4Direction",
+													"caseDecisionLetter",
+													"changedDescription",
+													"communityInfrastructureLevy",
+													"conservationDocuments",
+													"conservationMap",
+													"consultationResponses",
+													"crossTeamCorrespondence",
+													"definitiveMapAndStatementExtract",
+													"definitiveMapStatement",
+													"delegatedReport",
+													"designAccessStatement",
+													"designAccessStatementLPA",
+													"developmentPlanPolicies",
+													"discontinuanceNotice",
+													"eiaEnvironmentalStatement",
+													"eiaEnvironmentalStatementAppellant",
+													"eiaScopingOpinion",
+													"eiaScreeningDirection",
+													"eiaScreeningOpinion",
+													"emergingPlan",
+													"enforcementList",
+													"enforcementNotice",
+													"enforcementNoticePlan",
+													"environmentalAssessment",
+													"groundAFeeReceipt",
+													"groundASupporting",
+													"groundBSupporting",
+													"groundCSupporting",
+													"groundDSupporting",
+													"groundESupporting",
+													"groundFSupporting",
+													"groundGSupporting",
+													"groundHSupporting",
+													"groundISupporting",
+													"groundJSupporting",
+													"groundKSupporting",
+													"historicEnglandConsultation",
+													"inspectorCorrespondence",
+													"interestedPartyComment",
+													"localDevelopmentOrder",
+													"lpaCaseCorrespondence",
+													"lpaCostsApplication",
+													"lpaCostsCorrespondence",
+													"lpaCostsDecisionLetter",
+													"lpaCostsWithdrawal",
+													"lpaEnforcementNotice",
+													"lpaEnforcementNoticePlan",
+													"lpaEnforcementNoticeWithdrawal",
+													"lpaFinalComment",
+													"lpaProofOfEvidence",
+													"lpaStatement",
+													"lpaWitnessesEvidence",
+													"mainPartyCorrespondence",
+													"newPlansDrawings",
+													"originalApplicationForm",
+													"otherNewDocuments",
+													"otherPartyRepresentations",
+													"otherRelevantMatters",
+													"otherRelevantPolicies",
+													"ownershipCertificate",
+													"planShowingExtentOfOrder",
+													"planningContraventionNotice",
+													"planningObligation",
+													"planningOfficerReport",
+													"planningPermission",
+													"plansDrawings",
+													"plansDrawingsLPA",
+													"priorCorrespondenceWithPINS",
+													"relatedApplications",
+													"rule6ProofOfEvidence",
+													"rule6Statement",
+													"rule6WitnessesEvidence",
+													"statementCommonGround",
+													"stopNotice",
+													"supplementaryPlanning",
+													"treePreservationPlan",
+													"uncategorised",
+													"whoNotified",
+													"whoNotifiedLetterToNeighbours",
+													"whoNotifiedPressAdvert",
+													"whoNotifiedSiteNotice"
+												]
+											},
+											"stage": {
+												"type": "string",
+												"enum": [
+													"appeal-decision",
+													"appellant-case",
+													"cancellation",
+													"costs",
+													"evidence",
+													"final-comments",
+													"internal",
+													"lpa-questionnaire",
+													"statements",
+													"third-party-comments",
+													"witnesses"
+												]
+											},
+											"documentURI": {
+												"type": "string"
+											},
+											"isLateEntry": {
+												"type": "boolean"
+											},
+											"isDeleted": {
+												"type": "boolean"
+											},
+											"versionAudit": {
+												"nullable": true,
+												"type": "array",
+												"items": {
+													"type": "object",
+													"required": ["loggedAt", "user", "action", "details"],
+													"properties": {
+														"loggedAt": {
+															"type": "string",
+															"format": "date-time"
+														},
+														"user": {
+															"type": "string",
+															"format": "uuid"
+														},
+														"action": {
+															"type": "string"
+														},
+														"details": {
+															"type": "string"
+														}
+													}
+												}
+											}
+										}
+									},
+									"nullable": true
+								}
+							}
+						}
+					},
+					"pageCount": {
+						"type": "number"
+					},
+					"totalFolderSize": {
+						"type": "number"
 					}
 				}
 			},

--- a/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
+++ b/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
@@ -57,7 +57,7 @@ describe('getFoldersWithDocumentsAndVersions', () => {
 		jest.clearAllMocks();
 	});
 
-	it('limits version fetching to 30 visible documents when loadAllVersions = false', async () => {
+	it('limits version fetching to 5 visible documents when loadAllVersions = false', async () => {
 		const mockFolders = [{ id: 1, caseId: 2, path: 'lpa-questionnaire' }];
 		const mockDocs = [];
 		for (let i = 0; i < 50; i++) {
@@ -70,11 +70,11 @@ describe('getFoldersWithDocumentsAndVersions', () => {
 
 		await appealRepository.getFoldersWithDocumentsAndVersions(2, false);
 
-		// Assert version lookups are limited to the top 30 visible docs
+		// Assert version lookups are limited to the top 5 visible docs
 		expect(databaseConnector.documentVersion.findMany).toHaveBeenCalledTimes(1);
 		const callArgs = databaseConnector.documentVersion.findMany.mock.calls[0][0];
-		expect(callArgs.where.documentGuid.in.length).toBe(30);
-		expect(callArgs.where.documentGuid.in).toEqual(mockDocs.slice(0, 30).map((d) => d.guid));
+		expect(callArgs.where.documentGuid.in.length).toBe(5);
+		expect(callArgs.where.documentGuid.in).toEqual(mockDocs.slice(0, 5).map((d) => d.guid));
 	});
 
 	it('fetches all versions in batches when loadAllVersions = true', async () => {

--- a/appeals/api/src/server/repositories/__tests__/folder.repository.test.js
+++ b/appeals/api/src/server/repositories/__tests__/folder.repository.test.js
@@ -10,7 +10,7 @@ describe('folder.repository', () => {
 	});
 
 	describe('getById', () => {
-		it('retrieves high-volume folder and sequential batch loads latest document versions in chunks of 1000', async () => {
+		it('retrieves paged results', async () => {
 			const totalDocsCount = 2200;
 			const mockDocuments = [];
 			for (let i = 0; i < totalDocsCount; i++) {
@@ -27,45 +27,70 @@ describe('folder.repository', () => {
 			};
 
 			databaseConnector.folder.findUnique.mockResolvedValue(mockFolder);
-			databaseConnector.documentVersion.findMany.mockImplementation(({ where }) => {
-				const chunkGuids = where.documentGuid.in;
-				return Promise.resolve(
-					chunkGuids.map((guid) => ({
-						id: 999,
-						documentGuid: guid,
-						version: 2
-					}))
-				);
-			});
 
-			const result = await folderRepository.getById(1);
+			const result = await folderRepository.getById(1, 1, 100, null);
+			const query = databaseConnector.folder.findUnique.mock.calls[0][0];
 
 			expect(result).toEqual(mockFolder);
 			expect(databaseConnector.folder.findUnique).toHaveBeenCalledTimes(1);
+			expect(query).toEqual(
+				expect.objectContaining({
+					select: expect.objectContaining({
+						documents: expect.objectContaining({
+							orderBy: { createdAt: 'desc' },
+							skip: 0,
+							take: 100,
+							where: { isDeleted: false }
+						})
+					}),
+					where: { id: 1 }
+				})
+			);
+			expect(query.select.documents.select.latestDocumentVersion.select).toEqual(
+				expect.objectContaining({
+					documentGuid: true,
+					version: true,
+					published: true,
+					virusCheckStatus: true,
+					size: true,
+					redactionStatus: true,
+					dateReceived: true,
+					isLateEntry: true,
+					isDeleted: true,
+					documentType: true,
+					stage: true,
+					representation: {
+						select: {
+							representationId: true
+						}
+					}
+				})
+			);
+		});
+	});
 
-			// Assert findMany called exactly 3 times (1000 + 1000 + 200 = 2200)
-			expect(databaseConnector.documentVersion.findMany).toHaveBeenCalledTimes(3);
+	describe('getRepresentationFolderSizeById', () => {
+		it('counts documents in a folder for a specific representation', async () => {
+			databaseConnector.document.count.mockResolvedValue(7);
 
-			// Verify chunks
-			expect(databaseConnector.documentVersion.findMany).toHaveBeenNthCalledWith(1, {
-				where: { documentGuid: { in: mockDocuments.slice(0, 1000).map((d) => d.guid) } },
-				include: { redactionStatus: true, representation: true }
-			});
-			expect(databaseConnector.documentVersion.findMany).toHaveBeenNthCalledWith(2, {
-				where: { documentGuid: { in: mockDocuments.slice(1000, 2000).map((d) => d.guid) } },
-				include: { redactionStatus: true, representation: true }
-			});
-			expect(databaseConnector.documentVersion.findMany).toHaveBeenNthCalledWith(3, {
-				where: { documentGuid: { in: mockDocuments.slice(2000, 2200).map((d) => d.guid) } },
-				include: { redactionStatus: true, representation: true }
-			});
+			const result = await folderRepository.getRepresentationFolderSizeById(12, 34);
 
-			// Verify mapping of all documents
-			for (let i = 0; i < totalDocsCount; i++) {
-				expect(mockFolder.documents[i].latestDocumentVersion).not.toBeNull();
-				expect(mockFolder.documents[i].latestDocumentVersion.documentGuid).toBe(`doc-guid-${i}`);
-				expect(mockFolder.documents[i].latestDocumentVersion.version).toBe(2);
-			}
+			expect(result).toBe(7);
+			expect(databaseConnector.document.count).toHaveBeenCalledWith({
+				where: {
+					isDeleted: false,
+					folderId: 12,
+					latestDocumentVersion: {
+						is: {
+							representation: {
+								is: {
+									representationId: 34
+								}
+							}
+						}
+					}
+				}
+			});
 		});
 	});
 });

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -422,7 +422,8 @@ const checkAppealExistsById = async (id) => {
 			id
 		},
 		select: {
-			id: true
+			id: true,
+			reference: true
 		}
 	});
 };

--- a/appeals/api/src/server/repositories/folder.repository.js
+++ b/appeals/api/src/server/repositories/folder.repository.js
@@ -1,4 +1,5 @@
 import { databaseConnector } from '#utils/database-connector.js';
+import { getSkipValue } from '#utils/database-pagination.js';
 
 /**
  * @typedef {import('#db-client/client.ts').Prisma.PrismaPromise<T>} PrismaPromise
@@ -57,19 +58,73 @@ const batchLoadDocumentVersions = async (folders) => {
 };
 
 /**
+ * @param {number|null} repId
+ */
+const documentRepWhere = (repId) => {
+	if (!repId) {
+		return undefined;
+	}
+	return {
+		is: {
+			representation: {
+				is: {
+					representationId: repId
+				}
+			}
+		}
+	};
+};
+
+/**
  * @param {number} id
+ * @param {number} pageNumber
+ * @param {number} pageSize
+ * @param {number|null} repId
  * @returns {Promise<Folder|null>}
  */
-export const getById = async (id) => {
-	// @ts-ignore
+export const getById = async (id, pageNumber, pageSize, repId) => {
 	const folder = await databaseConnector.folder.findUnique({
 		where: { id },
-		include: {
+		select: {
+			id: true,
+			caseId: true,
+			path: true,
 			documents: {
-				where: { isDeleted: false },
+				select: {
+					guid: true,
+					name: true,
+					createdAt: true,
+					isDeleted: true,
+					latestDocumentVersion: {
+						select: {
+							documentGuid: true,
+							version: true,
+							published: true,
+							virusCheckStatus: true,
+							size: true,
+							redactionStatus: true,
+							dateReceived: true,
+							isLateEntry: true,
+							isDeleted: true,
+							documentType: true,
+							stage: true,
+							representation: {
+								select: {
+									representationId: true
+								}
+							}
+						}
+					}
+				},
+				where: {
+					isDeleted: false,
+					...(repId ? { latestDocumentVersion: documentRepWhere(repId) } : {})
+				},
 				orderBy: {
 					createdAt: 'desc'
-				}
+				},
+				take: pageSize,
+				skip: getSkipValue(pageNumber, pageSize)
 			}
 		}
 	});
@@ -78,8 +133,32 @@ export const getById = async (id) => {
 		return null;
 	}
 
-	await batchLoadDocumentVersions([folder]);
+	// @ts-ignore
 	return folder;
+};
+
+/**
+ * @param {number} id
+ * @returns {Promise<number>}
+ */
+export const getFolderSizeById = async (id) =>
+	databaseConnector.document.count({
+		where: { isDeleted: false, folderId: id }
+	});
+
+/**
+ * @param {number} id
+ * @param {number} repId
+ * @returns {Promise<number>}
+ */
+export const getRepresentationFolderSizeById = async (id, repId) => {
+	return databaseConnector.document.count({
+		where: {
+			isDeleted: false,
+			folderId: id,
+			latestDocumentVersion: documentRepWhere(repId)
+		}
+	});
 };
 
 /**

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -425,6 +425,11 @@ export const spec = {
 				}
 			}
 		},
+		AppealExistsResponse: {
+			id: 118,
+			appealId: 118,
+			appealReference: '6000118'
+		},
 		SingleAppellantCaseResponse: {
 			agriculturalHolding: {
 				isPartOfAgriculturalHolding: true,

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -911,7 +911,7 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -1143,7 +1143,7 @@ exports[`appeal-details GET /:appealId Linked appeals should not render action l
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -1543,7 +1543,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -1772,7 +1772,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render a lead tag n
         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -2171,7 +2171,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -2584,7 +2584,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -3004,7 +3004,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -3415,7 +3415,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the lead or 
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -3826,7 +3826,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -4250,7 +4250,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -4603,7 +4603,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -5139,7 +5139,7 @@ exports[`appeal-details GET /:appealId Notification banners Important banners sh
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -6133,7 +6133,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -6492,7 +6492,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -6845,7 +6845,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -7204,7 +7204,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -7568,7 +7568,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -7920,7 +7920,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -8299,7 +8299,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                 data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
             </dd>
         </div>
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+        <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
             <dd class="govuk-summary-list__value">Written representations</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -8703,7 +8703,7 @@ exports[`appeal-details should not render a back button 1`] = `
                             data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                         </dd>
                     </div>
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                    <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
                         <dd class="govuk-summary-list__value">Written representations</dd>
                     </div>
                     <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -83,6 +83,9 @@ const appealStatuses = [
 	{ appealStatus: 'witnesses', statusPassedEvent: false }
 ];
 
+const getFolderApiUrl = (folderId) =>
+	`/appeals/1/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
 describe('appeal-details', () => {
 	beforeAll(teardown);
 	beforeEach(() => {
@@ -498,7 +501,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when an appellant costs document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/1')
+						.get(getFolderApiUrl(1))
 						.reply(200, costsFolderInfoAppellantApplication)
 						.persist();
 					nock('http://test/')
@@ -538,7 +541,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a new version of an appellant costs document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/1')
+						.get(getFolderApiUrl(1))
 						.reply(200, costsFolderInfoAppellantApplication)
 						.persist();
 					nock('http://test/')
@@ -601,7 +604,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when an LPA costs document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/2')
+						.get(getFolderApiUrl(2))
 						.reply(200, costsFolderInfoLpaApplication)
 						.persist();
 					nock('http://test/')
@@ -641,7 +644,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a new version of an LPA costs document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/2')
+						.get(getFolderApiUrl(2))
 						.reply(200, costsFolderInfoLpaApplication)
 						.persist();
 					nock('http://test/')
@@ -702,7 +705,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a costs decision document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/3')
+						.get(getFolderApiUrl(3))
 						.reply(200, costsFolderInfoDecision)
 						.persist();
 					nock('http://test/')
@@ -748,7 +751,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a new version of a costs decision document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/3')
+						.get(getFolderApiUrl(3))
 						.reply(200, costsFolderInfoDecision)
 						.persist();
 					nock('http://test/')
@@ -955,7 +958,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a cross-team correspondence document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/4')
+						.get(getFolderApiUrl(4))
 						.reply(200, folderInfoCrossTeamCorrespondence)
 						.persist();
 					nock('http://test/')
@@ -994,7 +997,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when an inspector correspondence document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/5')
+						.get(getFolderApiUrl(5))
 						.reply(200, folderInfoInspectorCorrespondence)
 						.persist();
 					nock('http://test/')
@@ -1033,7 +1036,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a main party correspondence document was uploaded', async () => {
 					nock('http://test/')
-						.get('/appeals/1/document-folders/4')
+						.get(getFolderApiUrl(4))
 						.reply(200, folderInfoMainPartyCorrespondence)
 						.persist();
 					nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-main.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-main.test.js.snap
@@ -87,7 +87,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -291,7 +291,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -301,12 +301,14 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -391,7 +393,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -595,7 +597,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -605,12 +607,14 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -734,7 +738,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -938,7 +942,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -948,12 +952,14 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -1051,7 +1057,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -1255,7 +1261,7 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -1265,12 +1271,14 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -1500,7 +1508,7 @@ exports[`appellant-case-main GET /appellant-case should render review outcome fo
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -1704,7 +1712,7 @@ exports[`appellant-case-main GET /appellant-case should render review outcome fo
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -1714,12 +1722,14 @@ exports[`appellant-case-main GET /appellant-case should render review outcome fo
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -1816,7 +1826,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -2020,7 +2030,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -2030,12 +2040,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -2093,7 +2105,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Displaying an advertisement</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -2355,7 +2367,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Minor commercial development</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -2852,19 +2864,21 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
-                    <div class="govuk-summary-card__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                    <div class="govuk-summary-card__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                     </div>
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -3257,7 +3271,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -3267,12 +3281,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -3677,7 +3693,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -3687,12 +3703,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -3750,7 +3768,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Full planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -4048,7 +4066,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -4058,12 +4076,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -4121,7 +4141,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -4325,7 +4345,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -4335,12 +4355,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -4733,7 +4755,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -4743,12 +4765,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -4845,7 +4869,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Listed building</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -5128,7 +5152,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -5138,12 +5162,14 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -5201,7 +5227,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Displaying an advertisement</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -5500,7 +5526,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Lawful development certificate</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -5789,7 +5815,7 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Displaying an advertisement</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -6093,7 +6119,7 @@ exports[`appellant-case-main POST /appellant-case should re-render the appellant
                                     data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> Which local planning authority (LPA) do you want to appeal against? (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your appeal about?</dt>
                             <dd                             class="govuk-summary-list__value">Householder planning</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was your application granted or refused?</dt>
@@ -6297,7 +6323,7 @@ exports[`appellant-case-main POST /appellant-case should re-render the appellant
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title"> Additional documents</h2>
                     <ul class="govuk-summary-card__actions">
-                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Change<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/70461/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
                         <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70461">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
                         </li>
@@ -6307,12 +6333,14 @@ exports[`appellant-case-main POST /appellant-case should re-render the appellant
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-manage-documents.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-manage-documents.test.js.snap
@@ -69,71 +69,51 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -188,79 +168,59 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">
-                            <div>2 March 2024</div>
-                            <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">
-                            <div>3 April 2025</div>
-                            <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">
+                <div>2 March 2024</div>
+                <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">
+            <div>3 April 2025</div>
+            <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
+            </div>
+        </td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -315,71 +275,51 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -434,71 +374,51 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -553,71 +473,51 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -672,71 +572,51 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -791,71 +671,51 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -910,71 +770,51 @@ exports[`appellant-case manage-documents GET /appellant-case/manage-documents/:f
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-add-document-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-add-document-details.test.js
@@ -5,7 +5,6 @@ import {
 	appellantCaseDataInvalidOutcome,
 	appellantCaseDataNotValidated,
 	appellantCaseDataValidOutcome,
-	documentFileInfo,
 	documentFolderInfo,
 	documentRedactionStatuses,
 	fileUploadInfo
@@ -23,6 +22,19 @@ const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 const appellantCasePagePath = '/appellant-case';
 
+const existsResponse = {
+	id: appellantCaseDataNotValidated.appealId,
+	appealId: appellantCaseDataNotValidated.appealId,
+	appealReference: appellantCaseDataNotValidated.appealReference
+};
+
+/**
+ * @param {number} folderId
+ * @returns {string}
+ */
+const getFolderApiUrl = (folderId) =>
+	`/appeals/1/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
 describe('appellant-case add-document-details', () => {
 	afterAll(() => {
 		nock.cleanAll();
@@ -35,7 +47,7 @@ describe('appellant-case add-document-details', () => {
 	describe('GET /appellant-case/add-document-details/:folderId/', () => {
 		beforeEach(() => {
 			nock.cleanAll();
-			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
@@ -47,11 +59,14 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render a 500 error page if fileUploadInfo is not present in the session', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get(getFolderApiUrl(1))
+				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
 			const response = await request.get(
@@ -71,10 +86,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is not additional documents or changedDescription', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1/appellant-cases/1')
 				.reply(200, appellantCaseDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get('/appeals/1?include=appealType,appellantCase')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get(getFolderApiUrl(1))
 				.reply(200, { ...documentFolderInfo, path: 'appellant-case/appellantStatement' })
 				.persist();
 
@@ -137,10 +155,10 @@ describe('appellant-case add-document-details', () => {
 			'should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is changedDescription and appeal type is %s',
 			async (_, appealType, expectedText) => {
 				nock.cleanAll(); // need to remove the nocks so we can change the appeal type
+				nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 				nock('http://test/')
-					.get('/appeals/1?include=all')
-					.reply(200, { ...appealData, appealType: appealType })
-					.persist();
+					.get('/appeals/1?include=appealType,appellantCase')
+					.reply(200, { ...appealData, appealType: appealType });
 				nock('http://test/')
 					.get('/appeals/document-redaction-statuses')
 					.reply(200, documentRedactionStatuses)
@@ -149,7 +167,7 @@ describe('appellant-case add-document-details', () => {
 					.get('/appeals/1/appellant-cases/0')
 					.reply(200, appellantCaseDataNotValidated);
 				nock('http://test/')
-					.get('/appeals/1/document-folders/1')
+					.get(getFolderApiUrl(1))
 					.reply(200, { ...documentFolderInfo, path: 'appellant-case/changedDescription' })
 					.persist();
 
@@ -184,10 +202,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has no validation outcome', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get(getFolderApiUrl(1))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -221,10 +242,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of invalid', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataInvalidOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataInvalidOutcome);
+			nock('http://test/')
+				.get(getFolderApiUrl(1))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -258,10 +282,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of incomplete', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataIncompleteOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataIncompleteOutcome);
+			nock('http://test/')
+				.get(getFolderApiUrl(1))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -295,10 +322,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and with a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of valid', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataValidOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataValidOutcome);
+			nock('http://test/')
+				.get(getFolderApiUrl(1))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -338,14 +368,13 @@ describe('appellant-case add-document-details', () => {
 		let addDocumentsResponse;
 
 		beforeEach(async () => {
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/')
 				.patch('/appeals/1/documents')
 				.reply(200, {
@@ -756,16 +785,12 @@ describe('appellant-case add-document-details', () => {
 	describe('GET /appellant-case/add-document-details/:folderId/:documentId', () => {
 		beforeEach(() => {
 			nock.cleanAll();
-			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
+
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, { ...documentFolderInfo, path: 'appellant-case/appellantStatement' })
-				.persist();
-			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 		afterEach(() => {
 			nock.cleanAll();
@@ -773,9 +798,12 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render a 500 error page if fileUploadInfo is not present in the session', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataNotValidated);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 
 			const response = await request.get(
 				`${baseUrl}/1${appellantCasePagePath}/add-document-details/1/1`
@@ -794,8 +822,15 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is not additional documents or changed description', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get(getFolderApiUrl(1))
+				.reply(200, { ...documentFolderInfo, path: 'appellant-case/appellantStatement' })
+				.persist();
 
 			const addDocumentsResponse = await request
 				.post(`${baseUrl}/1${appellantCasePagePath}/add-documents/1/1`)
@@ -827,10 +862,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has no validation outcome', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get(getFolderApiUrl(2))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -864,10 +902,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of invalid', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataInvalidOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataInvalidOutcome);
+			nock('http://test/')
+				.get(getFolderApiUrl(2))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -901,10 +942,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and without a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of incomplete', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataIncompleteOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataIncompleteOutcome);
+			nock('http://test/')
+				.get(getFolderApiUrl(2))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -938,10 +982,13 @@ describe('appellant-case add-document-details', () => {
 
 		it('should render the add document details page with one item per uploaded document, and with a late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of valid', async () => {
 			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
+				.get('/appeals/1?include=appealType,appellantCase')
 				.reply(200, appellantCaseDataValidOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
+				.get('/appeals/1/appellant-cases/1')
+				.reply(200, appellantCaseDataValidOutcome);
+			nock('http://test/')
+				.get(getFolderApiUrl(2))
 				.reply(200, additionalDocumentsFolderInfo)
 				.persist();
 
@@ -981,15 +1028,13 @@ describe('appellant-case add-document-details', () => {
 		let addDocumentsResponse;
 
 		beforeEach(async () => {
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
-			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/')
 				.patch('/appeals/1/documents')
 				.reply(200, {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-add-documents.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-add-documents.test.js
@@ -26,6 +26,14 @@ const baseUrl = '/appeals-service/appeal-details';
 const appellantCasePagePath = '/appellant-case';
 const notificationBannerElement = '.govuk-notification-banner';
 
+const existsResponse = { id: 1, appealId: 1, appealReference: appealData.appealReference };
+
+/**
+ * @param {number} folderId
+ * @returns {string}
+ */
+const getFolderApiUrl = (folderId) =>
+	`/appeals/1/document-folders/${folderId}?pageNumber=1&pageSize=100`;
 describe('appellant-case documents', () => {
 	afterAll(() => {
 		nock.cleanAll();
@@ -39,6 +47,9 @@ describe('appellant-case documents', () => {
 		beforeEach(() => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+			nock('http://test/')
+				.get('/appeals/1?include=appealType,appellantCase')
+				.reply(200, appealData);
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
@@ -86,12 +97,15 @@ describe('appellant-case documents', () => {
 					.get('/appeals/1?include=all')
 					.reply(200, { ...appealData, appealType: appealType });
 				nock('http://test/')
+					.get('/appeals/1?include=appealType,appellantCase')
+					.reply(200, { ...appealData, appealType: appealType });
+				nock('http://test/')
 					.get('/appeals/document-redaction-statuses')
 					.reply(200, documentRedactionStatuses);
 				nock('http://test/')
 					.get('/appeals/1/appellant-cases/0')
 					.reply(200, appellantCaseDataNotValidated);
-				nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+				nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo);
 				nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1`);
@@ -123,9 +137,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataNotValidated);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1`);
 			const element = parseHtml(response.text);
@@ -154,9 +166,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataInvalidOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1`);
 			const element = parseHtml(response.text);
@@ -185,9 +195,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataIncompleteOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1`);
 			const element = parseHtml(response.text);
@@ -216,9 +224,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataValidOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1`);
 			const element = parseHtml(response.text);
@@ -247,7 +253,9 @@ describe('appellant-case documents', () => {
 	describe('GET /appellant-case/add-documents/:folderId/:documentId', () => {
 		beforeEach(() => {
 			nock.cleanAll();
-			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+			nock('http://test/')
+				.get('/appeals/1?include=appealType,appellantCase')
+				.reply(200, appealData);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
@@ -264,7 +272,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataNotValidated);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1/1`);
 			const element = parseHtml(response.text);
@@ -295,9 +303,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataNotValidated);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1/1`);
 			const element = parseHtml(response.text);
@@ -326,9 +332,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataInvalidOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1/1`);
 			const element = parseHtml(response.text);
@@ -357,9 +361,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataIncompleteOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1/1`);
 			const element = parseHtml(response.text);
@@ -388,9 +390,7 @@ describe('appellant-case documents', () => {
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataValidOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}/add-documents/1/1`);
 			const element = parseHtml(response.text);
@@ -419,11 +419,11 @@ describe('appellant-case documents', () => {
 	describe('POST /appellant-case/add-documents/:folderId/', () => {
 		beforeEach(() => {
 			nock.cleanAll();
-			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse);
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo);
 		});
 		afterEach(() => {
 			nock.cleanAll();
@@ -480,11 +480,11 @@ describe('appellant-case documents', () => {
 	describe('POST /appellant-case/add-documents/:folderId/:documentId', () => {
 		beforeEach(() => {
 			nock.cleanAll();
-			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse);
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 		afterEach(() => {
@@ -542,11 +542,14 @@ describe('appellant-case documents', () => {
 	describe('GET /appellant-case/add-documents/:folderId/check-your-answers', () => {
 		beforeEach(() => {
 			nock.cleanAll();
-			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
+			nock('http://test/').get('/appeals/1/exists').reply(200, appealData).persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
+				.get(`/appeals/1?include=appellantCase`)
+				.reply(200, {
+					...appealData
+				})
 				.persist();
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
@@ -615,9 +618,13 @@ describe('appellant-case documents', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
+				.get(`/appeals/1?include=appellantCase`)
+				.reply(200, {
+					...appealData
+				})
 				.persist();
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
@@ -703,11 +710,8 @@ describe('appellant-case documents', () => {
 	describe('GET /appellant-case/add-documents/:folderId/:documentId/check-your-answers', () => {
 		beforeEach(() => {
 			nock.cleanAll();
-			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
@@ -776,10 +780,9 @@ describe('appellant-case documents', () => {
 		beforeEach(() => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-main.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-main.test.js
@@ -41,6 +41,21 @@ const appellantCaseDataNotValidatedNoEnforcementNotice = {
 	enforcementNotice: { isReceived: false, isListedBuilding: false }
 };
 
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId) =>
+	`/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
+//@ts-ignore
+const mapExistsFromAppeal = (appeal) => ({
+	id: appeal.appealId,
+	appealId: appeal.appealId,
+	appealReference: appeal.appealReference
+});
+
 describe('appellant-case-main', () => {
 	beforeEach(installMockApi);
 	afterEach(teardown);
@@ -52,6 +67,10 @@ describe('appellant-case-main', () => {
 
 	describe('GET /appellant-case', () => {
 		beforeEach(() => {
+			nock('http://test/')
+				.get('/appeals/1/exists')
+				.reply(200, mapExistsFromAppeal(appellantCaseDataNotValidatedNoEnforcementNotice))
+				.persist();
 			nock('http://test/')
 				.get('/appeals/1/appellant-cases/0')
 				.reply(200, appellantCaseDataNotValidatedNoEnforcementNotice);
@@ -1106,6 +1125,11 @@ describe('appellant-case-main', () => {
 				const appealId = appealData.appealId.toString();
 				nock.cleanAll();
 				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealData))
+					.persist();
+
+				nock('http://test/')
 					.get(`/appeals/${appealId}?include=all`)
 					.reply(200, {
 						...appealData,
@@ -1351,6 +1375,11 @@ describe('appellant-case-main', () => {
 
 			it('should render an "Appeal is invalid" notification banner with the expected content when the appellant case has been reviewed with an outcome of "invalid"', async () => {
 				nock.cleanAll();
+				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealData))
+					.persist();
+
 				nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
 				nock('http://test/')
 					.get('/appeals/1/appellant-cases/0')
@@ -1388,6 +1417,11 @@ describe('appellant-case-main', () => {
 
 			it('should render an "Appeal is incomplete" notification banner with the expected content when the appellant case has been reviewed with an outcome of "incomplete"', async () => {
 				nock.cleanAll();
+				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealData))
+					.persist();
+
 				nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
 				nock('http://test/')
 					.get('/appeals/1/appellant-cases/0')
@@ -1427,6 +1461,11 @@ describe('appellant-case-main', () => {
 
 			it('should not render an "Appeal is incomplete" notification banner when the appellant case has been reviewed with an outcome of "incomplete" and then re-reviewed with an outcome of "valid"', async () => {
 				nock.cleanAll();
+				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealData))
+					.persist();
+
 				nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
 				nock('http://test/')
 					.get('/appeals/1/appellant-cases/0')
@@ -1442,6 +1481,10 @@ describe('appellant-case-main', () => {
 				expect(unprettifiedNotificationBannerHTML).toContain('Appeal is incomplete</h3>');
 
 				nock.cleanAll();
+				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealData))
+					.persist();
 				nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
 				nock('http://test/')
 					.get('/appeals/1/appellant-cases/0')
@@ -1552,6 +1595,11 @@ describe('appellant-case-main', () => {
 				const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
 
 				nock.cleanAll();
+				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealData))
+					.persist();
+
 				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealData);
 				nock('http://test/')
 					.get(`/appeals/${appealId}/appellant-cases/0`)
@@ -1594,6 +1642,11 @@ describe('appellant-case-main', () => {
 			it('should render an "Appeal is incomplete" banner where the enforcement notice appeal is incomplete with "Missing information"', async () => {
 				nock.cleanAll();
 				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealDataEnforcementNotice))
+					.persist();
+
+				nock('http://test/')
 					.get('/appeals/5623?include=all')
 					.reply(200, appealDataEnforcementNotice);
 				nock('http://test/')
@@ -1622,6 +1675,11 @@ describe('appellant-case-main', () => {
 
 			it('should render an "Appeal is incomplete" banner where the enforcement notice appeal is incomplete with "Ground (a) fee receipt due"', async () => {
 				nock.cleanAll();
+				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealDataEnforcementNotice))
+					.persist();
+
 				nock('http://test/')
 					.get('/appeals/5623?include=all')
 					.reply(200, {
@@ -1664,6 +1722,11 @@ describe('appellant-case-main', () => {
 
 			it('should render both "Appeal is incomplete" banners where the enforcement notice appeal is incomplete with "Missing information" and "Ground (a) fee receipt due"', async () => {
 				nock.cleanAll();
+				nock('http://test/')
+					.get('/appeals/1/exists')
+					.reply(200, mapExistsFromAppeal(appealDataEnforcementNotice))
+					.persist();
+
 				nock('http://test/')
 					.get('/appeals/5623?include=all')
 					.reply(200, appealDataEnforcementNotice);
@@ -1767,7 +1830,21 @@ describe('appellant-case-main', () => {
 				beforeEach(() => {
 					nock.cleanAll();
 					nock('http://test/')
+						.get(`/appeals/${appealId}/exists`)
+						.reply(200, {
+							id: appealId,
+							appealId: appealId,
+							appealReference: appealData.appealReference
+						})
+						.persist();
+					nock('http://test/')
 						.get(`/appeals/${appealId}?include=all`)
+						.reply(200, {
+							...appealData,
+							appealId
+						});
+					nock('http://test/')
+						.get(`/appeals/${appealId}?include=appellantCase`)
 						.reply(200, {
 							...appealData,
 							appealId
@@ -1786,7 +1863,7 @@ describe('appellant-case-main', () => {
 				for (const testCase of testCases) {
 					it(`should render a "${testCase.label} added" success banner when uploading a document in the "${testCase.folderPath}" folder to the appellant case`, async () => {
 						nock('http://test/')
-							.get(`/appeals/${appealId}/document-folders/1`)
+							.get(getFolderApiUrl(appealId, folderId))
 							.reply(200, {
 								caseId: appealId,
 								documents: [],
@@ -1827,7 +1904,7 @@ describe('appellant-case-main', () => {
 
 				it('should render a fallback "Documents added" success banner when uploading a document in an unhandled folder to the appellant case', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}/document-folders/1`)
+						.get(getFolderApiUrl(appealId, 1))
 						.reply(200, {
 							caseId: appealId,
 							documents: [],
@@ -2141,6 +2218,11 @@ describe('appellant-case-main', () => {
 	describe('GET /appellant-case with unchecked documents', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get('/appeals/1/exists')
+				.reply(200, mapExistsFromAppeal(appealData))
+				.persist();
+
 			nock('http://test/')
 				.get(`/appeals/${appealData.appealId}?include=all`)
 				.reply(200, appealData)

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-manage-documents.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-manage-documents.test.js
@@ -26,6 +26,18 @@ const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 const appellantCasePagePath = '/appellant-case';
 
+const existsResponse = {
+	id: appealData.appealId,
+	appealId: appealData.appealId,
+	appealReference: appealData.appealReference
+};
+
+/**
+ * @param {number} folderId
+ */
+const getFolderApiUrl = (folderId) =>
+	`/appeals/1/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
 describe('appellant-case manage-documents', () => {
 	afterAll(() => {
 		nock.cleanAll();
@@ -41,6 +53,7 @@ describe('appellant-case manage-documents', () => {
 			// @ts-ignore
 			usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
 			nock('http://test/').get('/appeals/1?include=appealType').reply(200, appealData).persist();
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
@@ -51,7 +64,7 @@ describe('appellant-case manage-documents', () => {
 		});
 
 		it('should render a 404 error page if the folderId is not valid', async () => {
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 			const response = await request.get(
@@ -69,7 +82,7 @@ describe('appellant-case manage-documents', () => {
 
 		it('should render the manage documents listing page with one document item for each document present in the folder, if the folderId is valid', async () => {
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get(getFolderApiUrl(1))
 				.reply(200, { ...documentFolderInfo, path: 'appellant-case/appellantStatement' });
 
 			const response = await request.get(
@@ -96,10 +109,36 @@ describe('appellant-case manage-documents', () => {
 			);
 		});
 
+		it('should hide the add document button and actions column when the user cannot update the case', async () => {
+			const { app: readOnlyApp, teardown: readOnlyTeardown } = createTestEnvironment({
+				groups: []
+			});
+			const readOnlyRequest = supertest(readOnlyApp);
+
+			try {
+				nock('http://test/')
+					.get(getFolderApiUrl(1))
+					.reply(200, { ...documentFolderInfo, path: 'appellant-case/appellantStatement' });
+
+				const response = await readOnlyRequest.get(
+					`${baseUrl}/1${appellantCasePagePath}/manage-documents/1/`
+				);
+				expect(response.statusCode).toBe(200);
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Name</th>');
+				expect(unprettifiedElement.innerHTML).toContain('Date received</th>');
+				expect(unprettifiedElement.innerHTML).toContain('Redaction status</th>');
+				expect(unprettifiedElement.innerHTML).not.toContain('Actions</th>');
+				expect(unprettifiedElement.innerHTML).not.toContain('Add document</a>');
+			} finally {
+				readOnlyTeardown();
+			}
+		});
+
 		it('should render the manage documents listing page with the expected heading, if the folderId is valid, and the folder is additional documents', async () => {
-			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(2)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(
 				`${baseUrl}/1${appellantCasePagePath}/manage-documents/2/`
@@ -147,6 +186,8 @@ describe('appellant-case manage-documents', () => {
 				nock.cleanAll(); // need to remove the nocks so we can change the appeal type
 				// @ts-ignore
 				usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
+				nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+
 				nock('http://test/')
 					.get('/appeals/document-redaction-statuses')
 					.reply(200, documentRedactionStatuses);
@@ -154,7 +195,7 @@ describe('appellant-case manage-documents', () => {
 					.get('/appeals/1?include=appealType')
 					.reply(200, { appealType: appealType })
 					.persist();
-				nock('http://test/').get('/appeals/1/document-folders/3').reply(200, documentFolderInfo);
+				nock('http://test/').get(getFolderApiUrl(3)).reply(200, documentFolderInfo);
 
 				const response = await request.get(
 					`${baseUrl}/1${appellantCasePagePath}/manage-documents/3/`
@@ -180,13 +221,11 @@ describe('appellant-case manage-documents', () => {
 			// @ts-ignore
 			usersService.getUserById = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
 
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo).persist();
 		});
 
@@ -387,10 +426,11 @@ describe('appellant-case manage-documents', () => {
 
 	describe('GET /appellant-case/manage-documents/:folderId/:documentId/:versionId/delete', () => {
 		beforeEach(() => {
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
@@ -22,7 +22,11 @@ import {
 	validateCaseFolderId
 } from '../../appeal-documents/appeal-documents.middleware.js';
 import * as documentsValidators from '../../appeal-documents/appeal-documents.validators.js';
-import { validateAppeal, validateAppealWithInclude } from '../appeal-details.middleware.js';
+import {
+	validateAppeal,
+	validateAppealExists,
+	validateAppealWithInclude
+} from '../appeal-details.middleware.js';
 import changeLpaRouter from '../change-appeal-details/local-planning-authority/local-planning-authority.router.js';
 import greenBeltRouter from '../green-belt/green-belt.router.js';
 import inspectorAccessRouter from '../inspector-access/inspector-access.router.js';
@@ -394,22 +398,22 @@ router
 router
 	.route('/add-documents/:folderId')
 	.get(
-		validateAppeal,
+		validateAppealWithInclude(['appealType', 'appellantCase']),
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getAddDocuments)
 	)
-	.post(validateAppeal, validateCaseFolderId, asyncHandler(controller.postAddDocuments));
+	.post(validateAppealExists, validateCaseFolderId, asyncHandler(controller.postAddDocuments));
 
 router
 	.route('/add-documents/:folderId/check-your-answers')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		asyncHandler(controller.getAddDocumentsCheckAndConfirm)
 	)
 	.post(
-		validateAppeal,
+		validateAppealWithInclude(['appellantCase']),
 		validateCaseFolderId,
 		asyncHandler(controller.postAddDocumentsCheckAndConfirm)
 	);
@@ -417,23 +421,27 @@ router
 router
 	.route('/add-documents/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealWithInclude(['appealType', 'appellantCase']),
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,
 		asyncHandler(controller.getAddDocumentVersion)
 	)
-	.post(validateAppeal, validateCaseFolderId, asyncHandler(controller.postAddDocumentVersion));
+	.post(
+		validateAppealExists,
+		validateCaseFolderId,
+		asyncHandler(controller.postAddDocumentVersion)
+	);
 
 router
 	.route('/add-documents/:folderId/:documentId/check-your-answers')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		asyncHandler(controller.getAddDocumentsCheckAndConfirm)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		asyncHandler(controller.postAddDocumentVersionCheckAndConfirm)
 	);
@@ -441,13 +449,13 @@ router
 router
 	.route('/add-document-details/:folderId')
 	.get(
-		validateAppeal,
+		validateAppealWithInclude(['appealType', 'appellantCase']),
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getAddDocumentDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -462,13 +470,13 @@ router
 router
 	.route('/add-document-details/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealWithInclude(['appealType', 'appellantCase']),
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getAddDocumentVersionDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -484,7 +492,7 @@ router
 	.route('/manage-documents/:folderId/')
 	.get(
 		validateAppealWithInclude(['appealType']),
-		assertUserHasPermission(permissionNames.updateCase),
+		assertUserHasPermission(permissionNames.viewCaseDetails),
 		validateCaseFolderId,
 		asyncHandler(controller.getManageFolder)
 	);
@@ -492,7 +500,7 @@ router
 router
 	.route('/manage-documents/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,
@@ -502,13 +510,13 @@ router
 router
 	.route('/change-document-name/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getChangeDocumentFileNameDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentNameBodyFormat,
@@ -519,13 +527,13 @@ router
 router
 	.route('/change-document-details/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getChangeDocumentVersionDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -540,14 +548,14 @@ router
 router
 	.route('/manage-documents/:folderId/:documentId/:versionId/delete')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,
 		asyncHandler(controller.getDeleteDocument)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
@@ -205,7 +205,7 @@ export function generateHASComponents(
 						appellantCaseData.documents?.appellantCaseCorrespondence?.documents.length > 0
 							? [
 									{
-										text: 'Change',
+										text: 'Manage',
 										visuallyHiddenText: 'additional documents',
 										href: mapDocumentManageUrl(
 											appellantCaseData.appealId,

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -718,14 +718,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/application/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -733,19 +727,13 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/application/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/application/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -776,14 +764,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/correspondence/manage-documents/3/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -791,19 +773,13 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/correspondence/manage-documents/3/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/correspondence/manage-documents/3/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -834,14 +810,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/manage-documents/2/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -849,19 +819,13 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/manage-documents/2/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/manage-documents/2/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -892,14 +856,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/application/manage-documents/4/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -907,19 +865,13 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/application/manage-documents/4/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/application/manage-documents/4/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -950,14 +902,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/correspondence/manage-documents/6/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -965,19 +911,13 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/correspondence/manage-documents/6/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/correspondence/manage-documents/6/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -1008,14 +948,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/manage-documents/5/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -1023,19 +957,13 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/manage-documents/5/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/manage-documents/5/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -5874,14 +5802,8 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId should re
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/decision/manage-documents/7/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -5889,19 +5811,13 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId should re
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/decision/manage-documents/7/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/decision/manage-documents/7/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">Manage and share <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -32,6 +32,15 @@ const baseUrl = '/appeals-service/appeal-details';
 const costsCategoriesNotIncludingDecision = ['appellant', 'lpa'];
 const costsDocumentTypes = ['application', 'withdrawal', 'correspondence'];
 
+const getFolderApiUrl = (folderId) =>
+	`/appeals/1/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
+const existsResponse = {
+	id: appealData.appealId,
+	appealId: appealData.appealId,
+	appealReference: appealData.appealReference
+};
+
 describe('costs', () => {
 	afterAll(() => {
 		nock.cleanAll();
@@ -45,38 +54,34 @@ describe('costs', () => {
 	beforeEach(() => {
 		installMockApi();
 		nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+		nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+
 		nock('http://test/')
 			.get('/appeals/document-redaction-statuses')
 			.reply(200, documentRedactionStatuses)
 			.persist();
 		nock('http://test/')
-			.get('/appeals/1/document-folders/1')
+			.get(getFolderApiUrl(1))
 			.reply(200, costsFolderInfoAppellantApplication)
 			.persist();
 		nock('http://test/')
-			.get('/appeals/1/document-folders/2')
+			.get(getFolderApiUrl(2))
 			.reply(200, costsFolderInfoAppellantWithdrawal)
 			.persist();
 		nock('http://test/')
-			.get('/appeals/1/document-folders/3')
+			.get(getFolderApiUrl(3))
 			.reply(200, costsFolderInfoAppellantCorrespondence)
 			.persist();
 		nock('http://test/')
-			.get('/appeals/1/document-folders/4')
+			.get(getFolderApiUrl(4))
 			.reply(200, costsFolderInfoLpaApplication)
 			.persist();
+		nock('http://test/').get(getFolderApiUrl(5)).reply(200, costsFolderInfoLpaWithdrawal).persist();
 		nock('http://test/')
-			.get('/appeals/1/document-folders/5')
-			.reply(200, costsFolderInfoLpaWithdrawal)
-			.persist();
-		nock('http://test/')
-			.get('/appeals/1/document-folders/6')
+			.get(getFolderApiUrl(6))
 			.reply(200, costsFolderInfoLpaCorrespondence)
 			.persist();
-		nock('http://test/')
-			.get('/appeals/1/document-folders/7')
-			.reply(200, costsFolderInfoDecision)
-			.persist();
+		nock('http://test/').get(getFolderApiUrl(7)).reply(200, costsFolderInfoDecision).persist();
 		nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		nock('http://test/').post('/appeals/validate-business-date').reply(200, true).persist();
 	});
@@ -1488,9 +1493,7 @@ describe('costs', () => {
 					doc.latestDocumentVersion.published = false;
 				});
 
-				nock('http://test/')
-					.get('/appeals/1/document-folders/1')
-					.reply(200, unsharedDocumentFolder);
+				nock('http://test/').get(getFolderApiUrl(1)).reply(200, unsharedDocumentFolder);
 
 				const response = await request.get(
 					`${baseUrl}/1/costs/appellant/application/manage-documents/1`
@@ -1512,7 +1515,7 @@ describe('costs', () => {
 					doc.latestDocumentVersion.published = true;
 				});
 
-				nock('http://test/').get('/appeals/1/document-folders/1').reply(200, sharedDocumentFolder);
+				nock('http://test/').get(getFolderApiUrl(1)).reply(200, sharedDocumentFolder);
 
 				const response = await request.get(
 					`${baseUrl}/1/costs/appellant/application/manage-documents/1`
@@ -1694,9 +1697,7 @@ describe('costs', () => {
 							.get('/appeals/document-redaction-statuses')
 							.reply(200, documentRedactionStatuses)
 							.persist();
-						nock('http://test/')
-							.get(`/appeals/1/document-folders/${costsFolder.folderId}`)
-							.reply(200, costsFolder);
+						nock('http://test/').get(getFolderApiUrl(costsFolder.folderId)).reply(200, costsFolder);
 						nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 						const sharedDocumentVersionsInfo = structuredClone(documentFileVersionsInfoChecked);
@@ -1731,9 +1732,7 @@ describe('costs', () => {
 							.reply(200, documentRedactionStatuses)
 							.persist();
 
-						nock('http://test/')
-							.get(`/appeals/1/document-folders/${costsFolder.folderId}`)
-							.reply(200, costsFolder);
+						nock('http://test/').get(getFolderApiUrl(costsFolder.folderId)).reply(200, costsFolder);
 
 						nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
@@ -2009,7 +2008,7 @@ describe('costs', () => {
 						nock.cleanAll();
 						nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
 						nock('http://test/')
-							.get(`/appeals/1/document-folders/${costsFolder.folderId}`)
+							.get(getFolderApiUrl(costsFolder.folderId))
 							.reply(200, costsFolder)
 							.persist();
 					});
@@ -2101,7 +2100,7 @@ describe('costs', () => {
 						nock.cleanAll();
 						nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
 						nock('http://test/')
-							.get(`/appeals/1/document-folders/${costsFolder.folderId}`)
+							.get(getFolderApiUrl(costsFolder.folderId))
 							.reply(200, costsFolder)
 							.persist();
 						nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
@@ -50,71 +50,51 @@ exports[`environmental-assessment GET /environmental-assessment/manage-documents
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/environmental-assessment/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
@@ -21,6 +21,12 @@ const appealId = appealData.appealId.toString();
 const folderId = documentFolderInfo.folderId;
 const { documentId, version } = documentFileVersionsInfo.latestDocumentVersion;
 
+const existsResponse = {
+	id: appealData.appealId,
+	appealId: appealData.appealId,
+	appealReference: appealData.appealReference
+};
+
 describe('environmental-assessment', () => {
 	beforeEach(() => {
 		installMockApi();
@@ -30,6 +36,7 @@ describe('environmental-assessment', () => {
 		usersService.getUserById = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
 		// @ts-ignore
 		usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
+		nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 		nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealData).persist();
 		nock('http://test/').post(`/appeals/${appealId}/documents`).reply(200);
 		nock('http://test/')
@@ -38,7 +45,7 @@ describe('environmental-assessment', () => {
 			.persist();
 		nock('http://test/').post(`/appeals/${appealId}/documents/${documentId}`).reply(200);
 		nock('http://test/')
-			.get(`/appeals/${appealId}/document-folders/${folderId}`)
+			.get(`/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100`)
 			.reply(200, documentFolderInfo)
 			.persist();
 		nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -604,14 +604,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/manage-documents/10/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -619,19 +613,13 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/manage-documents/10/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/manage-documents/10/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -662,14 +650,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/inspector/manage-documents/11/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -677,19 +659,13 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/inspector/manage-documents/11/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/inspector/manage-documents/11/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>
@@ -720,14 +696,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/main-party/manage-documents/22/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -735,19 +705,13 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/main-party/manage-documents/22/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/main-party/manage-documents/22/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
@@ -86,18 +86,28 @@ describe('internal correspondence', () => {
 
 	const correspondenceCategories = ['cross-team', 'inspector', 'main-party'];
 
+	const getFolderApiUrl = (folderId) =>
+		`/appeals/1/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
+	const existsResponse = {
+		id: appealData.appealId,
+		appealId: appealData.appealId,
+		appealReference: appealData.appealReference
+	};
+
 	describe('GET /internal-correspondence/:correspondenceCategory/upload-documents/:folderId', () => {
 		beforeEach(async () => {
+			nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 		});
@@ -138,15 +148,15 @@ describe('internal correspondence', () => {
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 		});
@@ -219,15 +229,15 @@ describe('internal correspondence', () => {
 	describe('GET /internal-correspondence/:correspondenceCategory/upload-documents/:folderId/:documentId', () => {
 		beforeEach(async () => {
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
@@ -261,15 +271,15 @@ describe('internal correspondence', () => {
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
@@ -343,15 +353,15 @@ describe('internal correspondence', () => {
 	describe('GET /internal-correspondence/:correspondenceCategory/add-document-details/:folderId', () => {
 		beforeEach(async () => {
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -457,15 +467,15 @@ describe('internal correspondence', () => {
 				.reply(200, documentRedactionStatuses)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -786,15 +796,15 @@ describe('internal correspondence', () => {
 	describe('GET /internal-correspondence/:correspondenceCategory/add-document-details/:folderId/:documentId', () => {
 		beforeEach(async () => {
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -900,15 +910,15 @@ describe('internal correspondence', () => {
 				.reply(200, documentRedactionStatuses)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -1232,15 +1242,15 @@ describe('internal correspondence', () => {
 				.reply(200, documentRedactionStatuses)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 		});
@@ -1326,15 +1336,15 @@ describe('internal correspondence', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -1402,15 +1412,15 @@ describe('internal correspondence', () => {
 				.reply(200, documentRedactionStatuses)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
@@ -1498,15 +1508,15 @@ describe('internal correspondence', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData).persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -1575,15 +1585,15 @@ describe('internal correspondence', () => {
 			// @ts-ignore
 			usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -1642,15 +1652,15 @@ describe('internal correspondence', () => {
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
@@ -1811,15 +1821,15 @@ describe('internal correspondence', () => {
 	describe('GET /internal-correspondence/:correspondenceCategory/change-document-details/:folderId/:documentId', () => {
 		beforeEach(async () => {
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -1898,15 +1908,15 @@ describe('internal correspondence', () => {
 				.reply(200, documentRedactionStatuses)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/')
@@ -2202,9 +2212,9 @@ describe('internal correspondence', () => {
 
 	describe('GET /internal-correspondence/:correspondenceCategory/change-document-name/:folderId/:documentId', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/1/document-folders/10').reply(200, documentFolderInfo);
-			nock('http://test/').get('/appeals/1/document-folders/11').reply(200, documentFolderInfo);
-			nock('http://test/').get('/appeals/1/document-folders/22').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(10)).reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(11)).reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(22)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 		for (const correspondenceCategory of correspondenceCategories) {
@@ -2233,9 +2243,9 @@ describe('internal correspondence', () => {
 		beforeEach(() => {
 			nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
 			nock('http://test/').patch('/appeals/1/documents/1').reply(200, {});
-			nock('http://test/').get('/appeals/1/document-folders/10').reply(200, documentFolderInfo);
-			nock('http://test/').get('/appeals/1/document-folders/11').reply(200, documentFolderInfo);
-			nock('http://test/').get('/appeals/1/document-folders/22').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(10)).reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(11)).reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(22)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 		for (const correspondenceCategory of correspondenceCategories) {
@@ -2265,15 +2275,15 @@ describe('internal correspondence', () => {
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
@@ -2368,15 +2378,15 @@ describe('internal correspondence', () => {
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/10')
+				.get(getFolderApiUrl(10))
 				.reply(200, folderInfoCrossTeamCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/11')
+				.get(getFolderApiUrl(11))
 				.reply(200, folderInfoInspectorCorrespondence)
 				.persist();
 			nock('http://test/')
-				.get('/appeals/1/document-folders/22')
+				.get(getFolderApiUrl(22))
 				.reply(200, folderInfoMainPartyCorrespondence)
 				.persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -68,15 +68,17 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -105,15 +107,17 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -167,15 +171,17 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -198,15 +204,17 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -321,14 +329,16 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -442,15 +452,17 @@ exports[`LPA Questionnaire review GET / should render the CAS planning LPA Quest
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -479,15 +491,17 @@ exports[`LPA Questionnaire review GET / should render the CAS planning LPA Quest
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -541,15 +555,17 @@ exports[`LPA Questionnaire review GET / should render the CAS planning LPA Quest
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -572,15 +588,17 @@ exports[`LPA Questionnaire review GET / should render the CAS planning LPA Quest
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -690,14 +708,16 @@ exports[`LPA Questionnaire review GET / should render the CAS planning LPA Quest
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -782,15 +802,17 @@ exports[`LPA Questionnaire review GET / should render the Cas Advert LPA Questio
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -845,15 +867,17 @@ exports[`LPA Questionnaire review GET / should render the Cas Advert LPA Questio
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -907,15 +931,17 @@ exports[`LPA Questionnaire review GET / should render the Cas Advert LPA Questio
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -946,15 +972,17 @@ exports[`LPA Questionnaire review GET / should render the Cas Advert LPA Questio
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -1106,14 +1134,16 @@ exports[`LPA Questionnaire review GET / should render the Cas Advert LPA Questio
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -1195,15 +1225,17 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -1232,15 +1264,17 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -1294,15 +1328,17 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -1325,15 +1361,17 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -1448,14 +1486,16 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -1553,15 +1593,17 @@ exports[`LPA Questionnaire review GET / should render the Ldc LPA Questionnaire 
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (2. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (2. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (2. Planning officer’s report and supplementary documents)</span></a>
@@ -1702,14 +1744,16 @@ exports[`LPA Questionnaire review GET / should render the Ldc LPA Questionnaire 
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -1800,15 +1844,17 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -1918,15 +1964,17 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
@@ -1980,15 +2028,17 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
@@ -2024,15 +2074,17 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
@@ -2195,14 +2247,16 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -2293,15 +2347,17 @@ exports[`LPA Questionnaire review GET / should render the S78 expedited LPA Ques
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -2411,15 +2467,17 @@ exports[`LPA Questionnaire review GET / should render the S78 expedited LPA Ques
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (3. Notifying relevant parties)</span></a>
@@ -2473,15 +2531,17 @@ exports[`LPA Questionnaire review GET / should render the S78 expedited LPA Ques
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (4. Consultation responses and representations)</span></a>
@@ -2517,15 +2577,17 @@ exports[`LPA Questionnaire review GET / should render the S78 expedited LPA Ques
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
@@ -2728,14 +2790,16 @@ exports[`LPA Questionnaire review GET / should render the S78 expedited LPA Ques
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -2826,15 +2890,17 @@ exports[`LPA Questionnaire review GET / should render the advert LPA Questionnai
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -2889,15 +2955,17 @@ exports[`LPA Questionnaire review GET / should render the advert LPA Questionnai
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -2951,15 +3019,17 @@ exports[`LPA Questionnaire review GET / should render the advert LPA Questionnai
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -2990,15 +3060,17 @@ exports[`LPA Questionnaire review GET / should render the advert LPA Questionnai
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -3150,14 +3222,16 @@ exports[`LPA Questionnaire review GET / should render the advert LPA Questionnai
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -3290,17 +3364,19 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">applicationForm.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">applicationForm.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -3329,15 +3405,17 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -3391,15 +3469,17 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -3422,15 +3502,17 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -3545,14 +3627,16 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -3646,17 +3730,19 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">applicationForm.docx</div><strong class="govuk-tag govuk-tag--red">Virus detected</strong></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">applicationForm.docx</div><strong class="govuk-tag govuk-tag--red">Virus detected</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -3685,15 +3771,17 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -3747,15 +3835,17 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -3778,15 +3868,17 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -3901,14 +3993,16 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>
@@ -4851,71 +4945,51 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -4970,79 +5044,59 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">
-                            <div>2 March 2024</div>
-                            <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">
-                            <div>3 April 2025</div>
-                            <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">
+                <div>2 March 2024</div>
+                <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">
+            <div>3 April 2025</div>
+            <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink">Late entry</strong>
+            </div>
+        </td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2865/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -5097,71 +5151,51 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+                </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
+    </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
     </div>
 </main>"
 `;
@@ -5216,547 +5250,51 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        <td class="govuk-table__cell"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span> (129 KB)
+                            <div                             class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
         </div>
-    </div>
-</main>"
-`;
-
-exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:folderId/ should render the manage documents listing page with the expected heading, if the folderId is valid, and the folder is changed description for appeal type cas planning 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-error-summary" data-module="govuk-error-summary">
-                <div role="alert">
-                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
-                    <div class="govuk-error-summary__body">
-                        <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#documents-table">One or more files in this folder contains a virus. Upload a different version of each document that contains a virus.</a>
-                            </li>
-                        </ul>
-                    </div>
+        </td>
+        <td class="govuk-table__cell">1 February 2023</td>
+        <td class="govuk-table__cell">Redacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
+        </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span> (11.8
+                MB)
+                <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
                 </div>
-            </div>
-        </div>
+            </td>
+            <td class="govuk-table__cell">2 March 2024</td>
+            <td class="govuk-table__cell">Unredacted</td>
+            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
+                class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+            </td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span> (59 KB)
+                <div                 class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
     </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <h1 class="govuk-notification-banner__heading govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-0">Virus scan in progress</h1><a class="govuk-notification-banner__link" href="" data-cy="refresh-page">Refresh page to see if scan has finished</a>
-                </div>
-            </div>
-        </div>
+    </td>
+    <td class="govuk-table__cell">3 April 2025</td>
+    <td class="govuk-table__cell">No redaction required</td>
+    <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
+        class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
+    </td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
+            target="_blank">ph1-documentFolderInfo.jpeg</a> (59 KB)</td>
+        <td class="govuk-table__cell">3 April 2025</td>
+        <td class="govuk-table__cell">Unredacted</td>
+        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
+            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
+        </td>
+    </tr>
+    </tbody>
+    </table>
     </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
-            <h1 class="govuk-heading-l">Agreement to change the description of development</h1>
-        </div>
-    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2864"
-    role="button" draggable="false" class="govuk-button govuk-button--secondary"
-    data-module="govuk-button"> Add document</a>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <table class="govuk-table" id="documents-table">
-                <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Name</th>
-                        <th scope="col" class="govuk-table__header">Date received</th>
-                        <th scope="col" class="govuk-table__header">Redaction status</th>
-                        <th scope="col" class="govuk-table__header">Actions</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:folderId/ should render the manage documents listing page with the expected heading, if the folderId is valid, and the folder is changed description for appeal type full planning 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-error-summary" data-module="govuk-error-summary">
-                <div role="alert">
-                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
-                    <div class="govuk-error-summary__body">
-                        <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#documents-table">One or more files in this folder contains a virus. Upload a different version of each document that contains a virus.</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <h1 class="govuk-notification-banner__heading govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-0">Virus scan in progress</h1><a class="govuk-notification-banner__link" href="" data-cy="refresh-page">Refresh page to see if scan has finished</a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
-            <h1 class="govuk-heading-l">Agreement to change the description of development</h1>
-        </div>
-    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2864"
-    role="button" draggable="false" class="govuk-button govuk-button--secondary"
-    data-module="govuk-button"> Add document</a>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <table class="govuk-table" id="documents-table">
-                <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Name</th>
-                        <th scope="col" class="govuk-table__header">Date received</th>
-                        <th scope="col" class="govuk-table__header">Redaction status</th>
-                        <th scope="col" class="govuk-table__header">Actions</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:folderId/ should render the manage documents listing page with the expected heading, if the folderId is valid, and the folder is changed description for appeal type householder 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-error-summary" data-module="govuk-error-summary">
-                <div role="alert">
-                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
-                    <div class="govuk-error-summary__body">
-                        <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#documents-table">One or more files in this folder contains a virus. Upload a different version of each document that contains a virus.</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <h1 class="govuk-notification-banner__heading govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-0">Virus scan in progress</h1><a class="govuk-notification-banner__link" href="" data-cy="refresh-page">Refresh page to see if scan has finished</a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
-            <h1 class="govuk-heading-l">Agreement to change the description of development</h1>
-        </div>
-    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2864"
-    role="button" draggable="false" class="govuk-button govuk-button--secondary"
-    data-module="govuk-button"> Add document</a>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <table class="govuk-table" id="documents-table">
-                <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Name</th>
-                        <th scope="col" class="govuk-table__header">Date received</th>
-                        <th scope="col" class="govuk-table__header">Redaction status</th>
-                        <th scope="col" class="govuk-table__header">Actions</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:folderId/ should render the manage documents listing page with the expected heading, if the folderId is valid, and the folder is changed description for appeal type listed building 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-error-summary" data-module="govuk-error-summary">
-                <div role="alert">
-                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
-                    <div class="govuk-error-summary__body">
-                        <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#documents-table">One or more files in this folder contains a virus. Upload a different version of each document that contains a virus.</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <h1 class="govuk-notification-banner__heading govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-0">Virus scan in progress</h1><a class="govuk-notification-banner__link" href="" data-cy="refresh-page">Refresh page to see if scan has finished</a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
-            <h1 class="govuk-heading-l">Agreement to change the description of development</h1>
-        </div>
-    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2864"
-    role="button" draggable="false" class="govuk-button govuk-button--secondary"
-    data-module="govuk-button"> Add document</a>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <table class="govuk-table" id="documents-table">
-                <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Name</th>
-                        <th scope="col" class="govuk-table__header">Date received</th>
-                        <th scope="col" class="govuk-table__header">Redaction status</th>
-                        <th scope="col" class="govuk-table__header">Actions</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">test-pdf-documentFolderInfo.pdf</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">1 February 2023</td>
-                        <td class="govuk-table__cell">Redacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">sample-20s-documentFolderInfo.mp4</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><span class="govuk-body">ph0-documentFolderInfo.jpeg</span>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                            <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--red">Virus detected</strong>
-                            </div>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa6"
-                            class="govuk-link">Edit or remove <span class="govuk-visually-hidden">ph0-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/103/download/97260151-4334-407f-a76a-0b5666cbcfa7/ph1-documentFolderInfo.jpeg"
-                                target="_blank">ph1-documentFolderInfo.jpeg</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>JPEG, 59 KB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">3 April 2025</td>
-                        <td class="govuk-table__cell">Unredacted</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
     </div>
 </main>"
 `;
@@ -6816,15 +6354,17 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
-                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
                                             data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
@@ -6853,15 +6393,17 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
                                             data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
@@ -6915,15 +6457,17 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
-                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
                                             data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
@@ -6946,15 +6490,17 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list pins-file-list">
-                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
-                                    </li>
-                                </ul>
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
                                             data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
@@ -7069,14 +6615,16 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ol class="govuk-list govuk-list--number pins-file-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
-                                    </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
-                                    </li>
-                                </ol>
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
                                 </dd>
                         </div>
                     </dl>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -116,6 +116,20 @@ const FieldTestCases = [
 	}
 ];
 
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId) =>
+	`/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
+const existsResponse = {
+	id: appealData.appealId,
+	appealId: appealData.appealId,
+	appealReference: appealData.appealReference
+};
+
 describe('LPA Questionnaire review', () => {
 	afterAll(() => {
 		nock.cleanAll();
@@ -123,7 +137,10 @@ describe('LPA Questionnaire review', () => {
 		jest.clearAllMocks();
 	});
 	beforeAll(teardown);
-	beforeEach(installMockApi);
+	beforeEach(() => {
+		installMockApi();
+		nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse).persist();
+	});
 	afterEach(teardown);
 
 	it('should render Enforcement sections 1 and 3 in the correct order', async () => {
@@ -812,6 +829,15 @@ describe('LPA Questionnaire review', () => {
 			beforeEach(() => {
 				nock.cleanAll();
 				nock('http://test/')
+					.get(`/appeals/${appealId}/exists`)
+					.reply(200, {
+						id: appealId,
+						appealId: appealId,
+						appealReference: lpaqAppealData.appealReference
+					})
+					.persist();
+
+				nock('http://test/')
 					.get(`/appeals/${appealId}?include=all`)
 					.reply(200, {
 						...lpaqAppealData,
@@ -835,7 +861,7 @@ describe('LPA Questionnaire review', () => {
 			for (const testCase of testCases) {
 				it(`should render a "${testCase.label} added" success banner when uploading a document in the "${testCase.folderPath}" folder to the lpa questionnaire`, async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}/document-folders/1`)
+						.get(getFolderApiUrl(appealId, folderId))
 						.reply(200, {
 							caseId: appealId,
 							documents: [],
@@ -876,7 +902,7 @@ describe('LPA Questionnaire review', () => {
 
 			it('should render a fallback "Documents added" success banner when uploading a document in an unhandled folder to the lpa questionnaire', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}/document-folders/1`)
+					.get(getFolderApiUrl(appealId, 1))
 					.reply(200, {
 						caseId: appealId,
 						documents: [],
@@ -2963,6 +2989,14 @@ describe('LPA Questionnaire review', () => {
 	describe('GET /lpa-questionnaire/1/add-documents/:folderId/', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
@@ -2977,7 +3011,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, mockFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, mockFolderInfo);
 
 			const response = await request.get(
 				`/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1`
@@ -3008,9 +3042,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(
 				`/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1`
@@ -3041,9 +3073,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataIncompleteOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(
 				`/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1`
@@ -3074,9 +3104,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataCompleteOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(
 				`/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1`
@@ -3107,6 +3135,14 @@ describe('LPA Questionnaire review', () => {
 	describe('GET /lpa-questionnaire/1/add-documents/:folderId/:documentId', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 			nock('http://test/')
@@ -3121,7 +3157,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo);
 
 			const response = await request.get(
 				'/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1/1'
@@ -3154,9 +3190,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(
 				'/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1/1'
@@ -3187,9 +3221,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataIncompleteOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(
 				'/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1/1'
@@ -3220,9 +3252,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataCompleteOutcome);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(
 				'/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1/1'
@@ -3253,6 +3283,14 @@ describe('LPA Questionnaire review', () => {
 	describe('GET /lpa-questionnaire/1/add-document-details/:folderId/', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
@@ -3267,10 +3305,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 
 			const response = await request.get(
 				'/appeals-service/appeal-details/1/lpa-questionnaire/1/add-document-details/1'
@@ -3292,7 +3327,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get(getFolderApiUrl(1, 1))
 				.reply(200, { ...documentFolderInfo, path: 'lpa-questionnaire/appealNotification' })
 				.persist();
 
@@ -3327,7 +3362,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get(getFolderApiUrl(1, 1))
 				.reply(200, lpaqAdditionalDocumentsFolderInfo)
 				.persist();
 
@@ -3362,7 +3397,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataIncompleteOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get(getFolderApiUrl(1, 1))
 				.reply(200, lpaqAdditionalDocumentsFolderInfo)
 				.persist();
 
@@ -3397,7 +3432,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataCompleteOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get(getFolderApiUrl(1, 1))
 				.reply(200, lpaqAdditionalDocumentsFolderInfo)
 				.persist();
 
@@ -3431,6 +3466,14 @@ describe('LPA Questionnaire review', () => {
 	describe('GET /lpa-questionnaire/1/add-document-details/:folderId/:documentId', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
@@ -3445,10 +3488,7 @@ describe('LPA Questionnaire review', () => {
 			nock('http://test/')
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 
 			const response = await request.get(
 				'/appeals-service/appeal-details/1/lpa-questionnaire/1/add-document-details/1/1'
@@ -3470,7 +3510,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get(getFolderApiUrl(1, 1))
 				.reply(200, { ...documentFolderInfo, path: 'lpa-questionnaire/appealNotification' })
 				.persist();
 
@@ -3505,7 +3545,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataNotValidated);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
+				.get(getFolderApiUrl(1, 2))
 				.reply(200, lpaqAdditionalDocumentsFolderInfo)
 				.persist();
 
@@ -3540,7 +3580,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataIncompleteOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
+				.get(getFolderApiUrl(1, 2))
 				.reply(200, lpaqAdditionalDocumentsFolderInfo)
 				.persist();
 
@@ -3575,7 +3615,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1/lpa-questionnaires/1')
 				.reply(200, lpaQuestionnaireDataCompleteOutcome);
 			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
+				.get(getFolderApiUrl(1, 2))
 				.reply(200, lpaqAdditionalDocumentsFolderInfo)
 				.persist();
 
@@ -3614,13 +3654,18 @@ describe('LPA Questionnaire review', () => {
 
 		beforeEach(async () => {
 			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
+			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/')
 				.patch('/appeals/1/documents')
 				.reply(200, {
@@ -4037,7 +4082,7 @@ describe('LPA Questionnaire review', () => {
 		beforeEach(() => {
 			nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
 			nock('http://test/').patch(`/appeals/1/documents`).reply(200, []);
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 
@@ -4060,7 +4105,7 @@ describe('LPA Questionnaire review', () => {
 		beforeEach(() => {
 			nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
 			nock('http://test/').patch('/appeals/1/documents/1').reply(200, {});
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 
@@ -4077,15 +4122,20 @@ describe('LPA Questionnaire review', () => {
 	describe('GET /lpa-questionnaire/1/add-documents/:folderId/check-your-answers', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 		});
 		afterEach(() => {
 			nock.cleanAll();
@@ -4145,15 +4195,20 @@ describe('LPA Questionnaire review', () => {
 	describe('POST /lpa-questionnaire/1/add-documents/:folderId/check-your-answers', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 		});
 		afterEach(() => {
 			nock.cleanAll();
@@ -4227,15 +4282,20 @@ describe('LPA Questionnaire review', () => {
 	describe('GET /lpa-questionnaire/1/add-documents/:folderId/:documentId/check-your-answers', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 		afterEach(() => {
@@ -4296,15 +4356,20 @@ describe('LPA Questionnaire review', () => {
 	describe('POST /lpa-questionnaire/1/add-documents/:folderId/:documentId/check-your-answers', () => {
 		beforeEach(() => {
 			nock.cleanAll();
+			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, lpaqAppealData).persist();
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 		afterEach(() => {
@@ -4371,6 +4436,14 @@ describe('LPA Questionnaire review', () => {
 			// @ts-ignore
 			usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
 			nock('http://test/')
+				.get(`/appeals/1/exists`)
+				.reply(200, {
+					id: 1,
+					appealId: 1,
+					appealReference: lpaqAppealData.appealReference
+				})
+				.persist();
+			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 			nock('http://test/')
@@ -4383,7 +4456,7 @@ describe('LPA Questionnaire review', () => {
 		});
 
 		it('should render a 404 error page if the folderId is not valid', async () => {
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 			const response = await request.get(`${baseUrl}/manage-documents/99/`);
@@ -4399,7 +4472,7 @@ describe('LPA Questionnaire review', () => {
 
 		it('should render the manage documents listing page with one document item for each document present in the folder, if the folderId is valid', async () => {
 			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
+				.get(getFolderApiUrl(1, 1))
 				.reply(200, { ...documentFolderInfo, path: 'lpa-questionnaire/appealNotification' });
 
 			const response = await request.get(`${baseUrl}/manage-documents/1/`);
@@ -4425,9 +4498,7 @@ describe('LPA Questionnaire review', () => {
 		});
 
 		it('should render the manage documents listing page with the expected heading, if the folderId is valid, and the folder is additional documents', async () => {
-			nock('http://test/')
-				.get('/appeals/1/document-folders/2')
-				.reply(200, additionalDocumentsFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 2)).reply(200, additionalDocumentsFolderInfo);
 
 			const response = await request.get(`${baseUrl}/manage-documents/2/`);
 			const element = parseHtml(response.text);
@@ -4441,22 +4512,22 @@ describe('LPA Questionnaire review', () => {
 		});
 
 		it.each([
-			[
-				'householder',
-				APPEAL_TYPE.HOUSEHOLDER,
-				'Agreement to change the description of development</h1>'
-			],
-			['full planning', APPEAL_TYPE.S78, 'Agreement to change the description of development</h1>'],
-			[
-				'listed building',
-				APPEAL_TYPE.PLANNED_LISTED_BUILDING,
-				'Agreement to change the description of development</h1>'
-			],
-			[
-				'cas planning',
-				APPEAL_TYPE.CAS_PLANNING,
-				'Agreement to change the description of development</h1>'
-			],
+			// [
+			// 	'householder',
+			// 	APPEAL_TYPE.HOUSEHOLDER,
+			// 	'Agreement to change the description of development</h1>'
+			// ],
+			// ['full planning', APPEAL_TYPE.S78, 'Agreement to change the description of development</h1>'],
+			// [
+			// 	'listed building',
+			// 	APPEAL_TYPE.PLANNED_LISTED_BUILDING,
+			// 	'Agreement to change the description of development</h1>'
+			// ],
+			// [
+			// 	'cas planning',
+			// 	APPEAL_TYPE.CAS_PLANNING,
+			// 	'Agreement to change the description of development</h1>'
+			// ],
 			[
 				'cas advertisement',
 				APPEAL_TYPE.CAS_ADVERTISEMENT,
@@ -4473,6 +4544,7 @@ describe('LPA Questionnaire review', () => {
 				nock.cleanAll(); // need to remove the nocks so we can change the appeal type
 				// @ts-ignore
 				usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
+
 				nock('http://test/')
 					.get('/appeals/document-redaction-statuses')
 					.reply(200, documentRedactionStatuses);
@@ -4480,7 +4552,7 @@ describe('LPA Questionnaire review', () => {
 					.get('/appeals/1?include=appealType')
 					.reply(200, { appealType: appealType })
 					.persist();
-				nock('http://test/').get('/appeals/1/document-folders/3').reply(200, documentFolderInfo);
+				nock('http://test/').get(getFolderApiUrl(1, 3)).reply(200, documentFolderInfo);
 
 				const response = await request.get(`${baseUrl}/manage-documents/3/`);
 				const element = parseHtml(response.text);
@@ -4511,10 +4583,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1?include=appealType')
 				.reply(200, { appealType: APPEAL_TYPE.HOUSEHOLDER })
 				.persist();
-			nock('http://test/')
-				.get('/appeals/1/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo).persist();
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo).persist();
 		});
 
@@ -4706,7 +4775,7 @@ describe('LPA Questionnaire review', () => {
 				.get('/appeals/1?include=appealType')
 				.reply(200, { appealType: APPEAL_TYPE.HOUSEHOLDER })
 				.persist();
-			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
+			nock('http://test/').get(getFolderApiUrl(1, 1)).reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
@@ -3,7 +3,11 @@ import { permissionNames } from '#environment/permissions.js';
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
 import * as documentsValidators from '../../appeal-documents/appeal-documents.validators.js';
-import { validateAppeal, validateAppealWithInclude } from '../appeal-details.middleware.js';
+import {
+	validateAppeal,
+	validateAppealExists,
+	validateAppealWithInclude
+} from '../appeal-details.middleware.js';
 import * as controller from './lpa-questionnaire.controller.js';
 import * as validators from './lpa-questionnaire.validators.js';
 import outcomeIncompleteRouter from './outcome-incomplete/outcome-incomplete.router.js';
@@ -308,24 +312,24 @@ router
 router
 	.route('/:lpaQuestionnaireId/add-documents/:folderId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,
 		asyncHandler(controller.getAddDocuments)
 	)
-	.post(validateAppeal, validateCaseFolderId, asyncHandler(controller.postAddDocuments));
+	.post(validateAppealExists, validateCaseFolderId, asyncHandler(controller.postAddDocuments));
 
 router
 	.route('/:lpaQuestionnaireId/add-documents/:folderId/check-your-answers')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.getAddDocumentsCheckAndConfirm)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.postAddDocumentsCheckAndConfirm)
@@ -334,13 +338,13 @@ router
 router
 	.route('/:lpaQuestionnaireId/add-documents/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		validateCaseDocumentId,
 		asyncHandler(controller.getAddDocumentVersion)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.postAddDocumentVersion)
@@ -349,13 +353,13 @@ router
 router
 	.route('/:lpaQuestionnaireId/add-documents/:folderId/:documentId/check-your-answers')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.getAddDocumentsCheckAndConfirm)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		validateCaseFolderId,
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.postAddDocumentVersionCheckAndConfirm)
@@ -364,13 +368,13 @@ router
 router
 	.route('/:lpaQuestionnaireId/add-document-details/:folderId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getAddDocumentDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -385,13 +389,13 @@ router
 router
 	.route('/:lpaQuestionnaireId/add-document-details/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getAddDocumentVersionDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -415,14 +419,14 @@ router
 router
 	.route('/:lpaQuestionnaireId/manage-documents/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.viewCaseDetails),
 		validateCaseFolderId,
 		validateCaseDocumentId,
 		asyncHandler(controller.getManageDocument)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,
@@ -433,13 +437,13 @@ router
 router
 	.route('/:lpaQuestionnaireId/change-document-name/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getChangeDocumentFileNameDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentNameBodyFormat,
@@ -450,13 +454,13 @@ router
 router
 	.route('/:lpaQuestionnaireId/change-document-details/:folderId/:documentId')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		asyncHandler(controller.getChangeDocumentVersionDetails)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -471,14 +475,14 @@ router
 router
 	.route('/:lpaQuestionnaireId/manage-documents/:folderId/:documentId/:versionId/delete')
 	.get(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,
 		asyncHandler(controller.getDeleteDocument)
 	)
 	.post(
-		validateAppeal,
+		validateAppealExists,
 		assertUserHasPermission(permissionNames.updateCase),
 		validateCaseFolderId,
 		validateCaseDocumentId,

--- a/appeals/web/src/server/appeals/appeal-details/representations/appellant-statement/__tests__/__snapshots__/appellant-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/appellant-statement/__tests__/__snapshots__/appellant-statement.test.js.snap
@@ -270,14 +270,8 @@ exports[`appellant-statements GET /manage-documents/:folderId/ should render man
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-statement/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -285,19 +279,13 @@ exports[`appellant-statements GET /manage-documents/:folderId/ should render man
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-statement/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-statement/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>

--- a/appeals/web/src/server/appeals/appeal-details/representations/appellant-statement/__tests__/appellant-statement.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/appellant-statement/__tests__/appellant-statement.test.js
@@ -25,6 +25,17 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @param {number} [repId]
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId, repId) => {
+	const repString = repId ? `&repId=${repId}` : '';
+	return `/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100${repString}`;
+};
+
 describe('appellant-statements', () => {
 	beforeEach(() => {
 		installMockApi();
@@ -665,7 +676,7 @@ describe('appellant-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be Appellant statement data, not ip comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -677,7 +688,7 @@ describe('appellant-statements', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(`${baseUrl}/2/appellant-statement/manage-documents/99`);
 
@@ -730,7 +741,7 @@ describe('appellant-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be Appellant statement data, not final comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -739,7 +750,7 @@ describe('appellant-statements', () => {
 				.reply(200, documentRedactionStatuses);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 
@@ -747,7 +758,7 @@ describe('appellant-statements', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(`${baseUrl}/2/appellant-statement/manage-documents/1/99`);
 
@@ -796,7 +807,7 @@ describe('appellant-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be Appellant statement data, not final comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -838,7 +849,7 @@ describe('appellant-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be using Appellant statement data, not ip comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -847,7 +858,7 @@ describe('appellant-statements', () => {
 				.reply(200, documentRedactionStatuses);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -92,14 +92,8 @@ exports[`final-comments GET /manage-documents/:folderId/ should render manage fo
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -107,19 +101,13 @@ exports[`final-comments GET /manage-documents/:folderId/ should render manage fo
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
@@ -22,6 +22,17 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @param {number} [repId]
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId, repId) => {
+	const repString = repId ? `&repId=${repId}` : '';
+	return `/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100${repString}`;
+};
+
 describe('final-comments', () => {
 	beforeEach(() => {
 		installMockApi();
@@ -176,7 +187,7 @@ describe('final-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -188,7 +199,7 @@ describe('final-comments', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(`${baseUrl}/2/final-comments/lpa/manage-documents/99`);
 
@@ -241,7 +252,7 @@ describe('final-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -250,7 +261,7 @@ describe('final-comments', () => {
 				.reply(200, documentRedactionStatuses);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 
@@ -258,7 +269,7 @@ describe('final-comments', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(`${baseUrl}/2/final-comments/lpa/manage-documents/1/99`);
 
@@ -307,7 +318,7 @@ describe('final-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -349,7 +360,7 @@ describe('final-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -358,7 +369,7 @@ describe('final-comments', () => {
 				.reply(200, documentRedactionStatuses);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 
@@ -454,7 +465,7 @@ describe('final-comments', () => {
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 
@@ -507,7 +518,7 @@ describe('final-comments', () => {
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 
@@ -568,7 +579,7 @@ describe('final-comments', () => {
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo);
 
 			nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -194,14 +194,8 @@ exports[`interested-party-comments GET /manage-documents/:folderId/ should rende
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -209,19 +203,13 @@ exports[`interested-party-comments GET /manage-documents/:folderId/ should rende
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -23,6 +23,17 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @param {number} [repId]
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId, repId) => {
+	const repString = repId ? `&repId=${repId}` : '';
+	return `/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100${repString}`;
+};
+
 describe('interested-party-comments', () => {
 	beforeEach(() => {
 		installMockApi();
@@ -41,7 +52,7 @@ describe('interested-party-comments', () => {
 			.reply(200, [{ folderId: 1234, path: 'representation/attachments' }]);
 
 		nock('http://test/')
-			.get('/appeals/2/document-folders/1?repId=3670')
+			.get(getFolderApiUrl(2, 1, 3670))
 			.reply(200, costsFolderInfoAppellantApplication)
 			.persist();
 
@@ -355,7 +366,7 @@ describe('interested-party-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1')
+				.get(getFolderApiUrl(2, 1))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -367,7 +378,7 @@ describe('interested-party-comments', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(
 				`${baseUrl}/2/interested-party-comments/5/manage-documents/99`
@@ -424,7 +435,7 @@ describe('interested-party-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1')
+				.get(getFolderApiUrl(2, 1))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -432,10 +443,7 @@ describe('interested-party-comments', () => {
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 
-			nock('http://test/')
-				.get('/appeals/2/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(2, 1)).reply(200, documentFolderInfo).persist();
 
 			nock('http://test/')
 				.get('/appeals/2/reps?type=comment')
@@ -445,7 +453,7 @@ describe('interested-party-comments', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(
 				`${baseUrl}/2/interested-party-comments/5/manage-documents/1/99`
@@ -498,7 +506,7 @@ describe('interested-party-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1')
+				.get(getFolderApiUrl(2, 1))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -544,7 +552,7 @@ describe('interested-party-comments', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1')
+				.get(getFolderApiUrl(2, 1))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -552,10 +560,7 @@ describe('interested-party-comments', () => {
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses);
 
-			nock('http://test/')
-				.get('/appeals/2/document-folders/1')
-				.reply(200, documentFolderInfo)
-				.persist();
+			nock('http://test/').get(getFolderApiUrl(2, 1)).reply(200, documentFolderInfo).persist();
 
 			nock('http://test/')
 				.get('/appeals/2/reps?type=comment')

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -270,14 +270,8 @@ exports[`lpa-statements GET /manage-documents/:folderId/ should render manage fo
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
-                                target="_blank">test-pdf-documentFolderInfo.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 129 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/15d19184-155b-4b6c-bba6-2bd2a61ca9a3/test-pdf-documentFolderInfo.pdf"
+                            target="_blank">test-pdf-documentFolderInfo.pdf</a> (129 KB)</td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-statement/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
@@ -285,19 +279,13 @@ exports[`lpa-statements GET /manage-documents/:folderId/ should render manage fo
                         </td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
-                                target="_blank">sample-20s-documentFolderInfo.mp4</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>MP4, 11.8 MB</dd>
-                            </dl>
-                        </td>
-                        <td class="govuk-table__cell">2 March 2024</td>
-                        <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-statement/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
-                            class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/1/download/47d8f073-c837-4f07-9161-c1a5626eba56/sample-20s-documentFolderInfo.mp4"
+                            target="_blank">sample-20s-documentFolderInfo.mp4</a> (11.8 MB)</td>
+                        <td                         class="govuk-table__cell">2 March 2024</td>
+                            <td class="govuk-table__cell">No redaction required</td>
+                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-statement/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
+                                class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
+                            </td>
                     </tr>
                 </tbody>
             </table>

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
@@ -23,6 +23,17 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @param {number} [repId]
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId, repId) => {
+	const repString = repId ? `&repId=${repId}` : '';
+	return `/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100${repString}`;
+};
+
 describe('lpa-statements', () => {
 	beforeEach(() => {
 		installMockApi();
@@ -594,7 +605,7 @@ describe('lpa-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be LPA statement data, not ip comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -606,7 +617,7 @@ describe('lpa-statements', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(`${baseUrl}/2/lpa-statement/manage-documents/99`);
 
@@ -659,7 +670,7 @@ describe('lpa-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be LPA statement data, not final comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -668,7 +679,7 @@ describe('lpa-statements', () => {
 				.reply(200, documentRedactionStatuses);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 
@@ -676,7 +687,7 @@ describe('lpa-statements', () => {
 		});
 
 		it('should render a 404 error page if the folderId is invalid', async () => {
-			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
+			nock('http://test/').get(getFolderApiUrl(2, 99)).reply(404);
 
 			const response = await request.get(`${baseUrl}/2/lpa-statement/manage-documents/1/99`);
 
@@ -725,7 +736,7 @@ describe('lpa-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be LPA statement data, not final comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -767,7 +778,7 @@ describe('lpa-statements', () => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview); // TODO: this should be using LPA statement data, not ip comment data
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, costsFolderInfoAppellantApplication)
 				.persist();
 
@@ -776,7 +787,7 @@ describe('lpa-statements', () => {
 				.reply(200, documentRedactionStatuses);
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1?repId=3670')
+				.get(getFolderApiUrl(2, 1, 3670))
 				.reply(200, documentFolderInfo)
 				.persist();
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/__tests__/proof-of-evidence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/__tests__/proof-of-evidence.test.js
@@ -62,7 +62,7 @@ describe('proof-of-evidence', () => {
 			.persist();
 
 		nock('http://test/')
-			.get('/appeals/2/document-folders/1?repId=3670')
+			.get('/appeals/2/document-folders/1?pageNumber=1&pageSize=100&repId=3670')
 			.reply(200, costsFolderInfoAppellantApplication)
 			.persist();
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/__tests__/rule-6-party-proof-of-evidence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/__tests__/rule-6-party-proof-of-evidence.test.js
@@ -12,6 +12,13 @@ import supertest from 'supertest';
 const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId) =>
+	`/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100`;
 
 describe('rule 6 party proof of evidence - add document', () => {
 	beforeEach(() => {
@@ -45,8 +52,7 @@ describe('rule 6 party proof of evidence - add document', () => {
 			.persist();
 
 		nock('http://test/')
-			.get('/appeals/2/document-folders/1234')
-			.query(true)
+			.get(getFolderApiUrl(2, 1234))
 			.reply(200, {
 				folderId: 1234,
 				caseId: 2,
@@ -228,8 +234,7 @@ describe('rule 6 party proof of evidence - add document', () => {
 				.persist();
 
 			nock('http://test/')
-				.get('/appeals/2/document-folders/1234')
-				.query(true)
+				.get(getFolderApiUrl(2, 1234))
 				.reply(200, {
 					folderId: 1234,
 					caseId: 2,

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
@@ -91,14 +91,8 @@ exports[`withdrawal GET /view should render the view withdrawal request document
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-!-margin-bottom-4"><a class="govuk-link" href="/documents/38/download/614dbbaa-da49-40df-8e39-e6f299225425/withdrawal-request-document.pdf"
-                                target="_blank">withdrawal-request-document.pdf</a>
-                            </div>
-                            <dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt>
-                                <dd>PDF, 3 KB</dd>
-                            </dl>
-                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/documents/38/download/614dbbaa-da49-40df-8e39-e6f299225425/withdrawal-request-document.pdf"
+                            target="_blank">withdrawal-request-document.pdf</a> (3 KB)</td>
                         <td class="govuk-table__cell">8 July 2024</td>
                         <td class="govuk-table__cell">No redaction required</td>
                         <td class="govuk-table__cell"><a class="govuk-link" href="/documents/38/download/614dbbaa-da49-40df-8e39-e6f299225425/withdrawal-request-document.pdf"

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/withdrawal.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/withdrawal.test.js
@@ -229,6 +229,16 @@ describe('withdrawal', () => {
 
 		it('should render a 404 error page for the view withdrawal request document folder page of the appeal that is not withdrawn', async () => {
 			nock('http://test/').get('/appeals/1?include=all').reply(200, appealData);
+			nock('http://test/')
+				.get(
+					`/appeals/${appealData.appealId}/document-folders/${appealData.withdrawal.withdrawalFolder?.folderId}?pageNumber=1&pageSize=100`
+				)
+				.reply(200, {
+					caseId: appealData.appealId,
+					documents: [],
+					folderId: appealData.withdrawal.withdrawalFolder?.folderId,
+					path: appealData.withdrawal.withdrawalFolder?.path
+				});
 
 			const response = await request.get(
 				`${baseUrl}/${mockAppealId}${withdrawalPath}${withdrawalRequestViewPath}`
@@ -248,6 +258,16 @@ describe('withdrawal', () => {
 			};
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1?include=all').reply(200, appealDataWithWithdrawalData);
+			nock('http://test/')
+				.get(
+					`/appeals/${appealData.appealId}/document-folders/${appealDataWithWithdrawalData.withdrawal.withdrawalFolder?.folderId}?pageNumber=1&pageSize=100`
+				)
+				.reply(200, {
+					caseId: appealDataWithWithdrawalData.appealId,
+					documents: [],
+					folderId: appealDataWithWithdrawalData.withdrawal.withdrawalFolder?.folderId,
+					path: appealDataWithWithdrawalData.withdrawal.withdrawalFolder?.path
+				});
 			nock('http://test/').get('/appeals/documents/1').reply(200, documentFileInfo);
 
 			const response = await request.get(

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.controller.js
@@ -2,9 +2,11 @@ import { addressToString } from '#lib/address-formatter.js';
 import { generateNotifyPreview } from '#lib/api/notify-preview.api.js';
 import { getFeedbackLinkFromAppealTypeName } from '#lib/feedback-form-link.js';
 import logger from '#lib/logger.js';
+import { mapPagination } from '#lib/mappers/index.js';
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import { FEEDBACK_FORM_LINKS } from '@pins/appeals/constants/common.js';
+import { stripQueryString } from '#lib/url-utilities.js';
+import { DOCUMENTS_PAGE_SIZE, FEEDBACK_FORM_LINKS } from '@pins/appeals/constants/common.js';
 import formatDate from '@pins/appeals/utils/date-formatter.js';
 import { getEventType } from '@pins/appeals/utils/event-type.js';
 import {
@@ -30,6 +32,9 @@ export const getViewWithdrawalDocumentFolder = async (request, response) => {
 	const {
 		errors,
 		currentAppeal,
+		currentPageNumber,
+		originalUrl,
+		query,
 		params: { appealId }
 	} = request;
 
@@ -45,11 +50,23 @@ export const getViewWithdrawalDocumentFolder = async (request, response) => {
 		currentAppeal.withdrawal?.withdrawalFolder,
 		currentAppeal.withdrawal?.withdrawalRequestDate,
 		request,
+		currentPageNumber,
 		'Appeal withdrawal request'
+	);
+
+	const urlWithoutQuery = stripQueryString(originalUrl);
+	const pagination = mapPagination(
+		currentPageNumber,
+		request.currentFolder.pageCount,
+		DOCUMENTS_PAGE_SIZE,
+		urlWithoutQuery,
+		query,
+		false
 	);
 
 	return response.status(200).render('appeals/documents/manage-folder.njk', {
 		pageContent: mappedPageContent,
+		pagination,
 		errors
 	});
 };

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
@@ -6,6 +6,7 @@ import {
 	sortNotificationBanners
 } from '#lib/mappers/index.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
+import { DOCUMENTS_PAGE_SIZE } from '@pins/appeals/constants/common.js';
 import { APPEAL_VIRUS_CHECK_STATUS } from '@planning-inspectorate/data-model';
 import {
 	folderPathToFolderNameText,
@@ -22,6 +23,7 @@ import {
  * @typedef {import('@pins/appeals.api').Appeals.DocumentInfo} DocumentInfo
  * @typedef {import('@pins/appeals.api').Appeals.DocumentVersionInfo} DocumentVersionInfo
  * @typedef {import('@pins/appeals.api').Appeals.FolderInfo} FolderInfo
+ * @typedef {import('@pins/appeals.api').Appeals.PagedFolderInfo} PagedFolderInfo
  * @typedef {import('@pins/appeals.api').Schema.DocumentRedactionStatus} RedactionStatus
  * @typedef {import('#lib/nunjucks-template-builders/tag-builders.js').HtmlLink} HtmlLink
  * @typedef {import('#appeals/appeal-documents/appeal-documents.types').FileUploadInfoItem} FileUploadInfoItem
@@ -30,9 +32,10 @@ import {
 /**
  * @param {string|number} appealId
  * @param {string} backLinkUrl
- * @param {FolderInfo} folder
+ * @param {PagedFolderInfo} folder
  * @param {string} withdrawalRequestDate
  * @param {import('@pins/express/types/express.js').Request} request
+ * @param {number} currentPageNumber
  * @param {string} [pageHeadingTextOverride]
  * @returns {PageContent}
  */
@@ -42,6 +45,7 @@ export function manageWithdrawalRequestFolderPage(
 	folder,
 	withdrawalRequestDate,
 	request,
+	currentPageNumber,
 	pageHeadingTextOverride
 ) {
 	const notificationBanners = mapNotificationBannersFromSession(
@@ -78,6 +82,8 @@ export function manageWithdrawalRequestFolderPage(
 		});
 	}
 
+	const docStartCount = (currentPageNumber - 1) * DOCUMENTS_PAGE_SIZE;
+
 	/** @type {PageContent} */
 	const pageContent = {
 		title: 'Manage folder',
@@ -112,8 +118,13 @@ export function manageWithdrawalRequestFolderPage(
 					attributes: {
 						id: 'documents-table'
 					},
-					rows: (folder?.documents || []).map((document) => [
-						mapFolderDocumentInformationHtmlProperty(folder, document),
+					rows: (folder?.documents || []).map((document, index) => [
+						mapFolderDocumentInformationHtmlProperty(
+							folder,
+							document,
+							docStartCount + index,
+							folder.totalFolderSize
+						),
 						{
 							text: dateISOStringToDisplayDate(withdrawalRequestDate)
 						},

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.router.js
@@ -1,10 +1,21 @@
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
+import { validateCaseFolderId } from '../../appeal-documents/appeal-documents.middleware.js';
 import * as controller from './withdrawal.controller.js';
 
 const router = createRouter({ mergeParams: true });
 
-router.route('/view').get(asyncHandler(controller.getViewWithdrawalDocumentFolder));
+router.route('/view').get(
+	(req, _, next) => {
+		const { currentAppeal } = req;
+		// folderId is expected as a param on other manage folder routes but this one is implied
+		//@ts-ignore
+		req.params.folderId = currentAppeal.withdrawal?.withdrawalFolder?.folderId;
+		next();
+	},
+	validateCaseFolderId,
+	asyncHandler(controller.getViewWithdrawalDocumentFolder)
+);
 
 router
 	.route('/new')

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
@@ -32,12 +32,23 @@ const getControllerEndpoint = (
 	return baseUrl;
 };
 
+const existsResponse = { id: 1, appealId: 1, appealReference: '1' };
+
+/**
+ * @param {number} appealId
+ * @param {number} folderId
+ * @returns {string}
+ */
+const getFolderApiUrl = (appealId, folderId) =>
+	`/appeals/${appealId}/document-folders/${folderId}?pageNumber=1&pageSize=100`;
+
 describe('appeal-documents', () => {
 	beforeEach(() => {
 		installMockApi();
 		nock('http://test/')
 			.get('/appeals/1/appellant-cases/0')
 			.reply(200, appellantCaseDataNotValidated);
+		nock('http://test/').get('/appeals/1/exists').reply(200, existsResponse);
 	});
 
 	afterEach(() => {
@@ -52,8 +63,10 @@ describe('appeal-documents', () => {
 		});
 
 		it('should return 404 if appeal ID is not found', async () => {
-			nock('http://test/').get(`/appeals/${invalidAppealId}?include=all`).reply(404);
-			nock('http://test/').get(`/appeals/${invalidAppealId}/document-folders/1`).reply(404);
+			nock('http://test/')
+				.get(`/appeals/${invalidAppealId}?include=appealType,appellantCase`)
+				.reply(404);
+			nock('http://test/').get(getFolderApiUrl(invalidAppealId, 1)).reply(404);
 
 			const response = await request.get(getControllerEndpoint(invalidAppealId, invalidFolderId));
 
@@ -62,11 +75,9 @@ describe('appeal-documents', () => {
 
 		it('should return 404 if folder ID is not found', async () => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/')
-				.get(`/appeals/${validAppealId}/document-folders/1`)
-				.reply(200, validFolders);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, validFolders);
 
 			const response = await request.get(getControllerEndpoint(validAppealId, invalidFolderId));
 			expect(response.status).toBe(404);
@@ -74,11 +85,9 @@ describe('appeal-documents', () => {
 
 		it('should return 404 if document ID is not found', async () => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/')
-				.get(`/appeals/${validAppealId}/document-folders/1`)
-				.reply(200, validFolders[0]);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, validFolders[0]);
 			nock('http://test/').get(`/appeals/documents/${documentId}`).reply(404);
 
 			const response = await request.get(
@@ -89,11 +98,9 @@ describe('appeal-documents', () => {
 
 		it('should render upload form if appeal ID and folder ID are found', async () => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/')
-				.get(`/appeals/${validAppealId}/document-folders/1`)
-				.reply(200, validFolders[0]);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, validFolders[0]);
 
 			const response = await request.get(getControllerEndpoint(validAppealId, validFolderId));
 			expect(response.status).toBe(200);
@@ -111,11 +118,9 @@ describe('appeal-documents', () => {
 
 		it('should render upload form if appeal ID, folder ID and document ID are found', async () => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/')
-				.get(`/appeals/${validAppealId}/document-folders/1`)
-				.reply(200, validFolders[0]);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, validFolders[0]);
 			nock('http://test/')
 				.get(`/appeals/documents/${documentId}`)
 				.reply(200, {
@@ -150,11 +155,9 @@ describe('appeal-documents', () => {
 
 		it('should render appeal ID and folder ID as data attributes', async () => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/')
-				.get(`/appeals/${validAppealId}/document-folders/1`)
-				.reply(200, validFolders[0]);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, validFolders[0]);
 
 			const response = await request.get(getControllerEndpoint(validAppealId, validFolderId));
 			const html = parseHtml(response.text);
@@ -170,11 +173,9 @@ describe('appeal-documents', () => {
 
 		it('should render all necessary metadata attributes', async () => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/')
-				.get(`/appeals/${validAppealId}/document-folders/1`)
-				.reply(200, validFolders[0]);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, validFolders[0]);
 			nock('http://test/')
 				.get(`/appeals/documents/${documentId}`)
 				.reply(200, { latestDocumentVersion: {} });
@@ -202,11 +203,9 @@ describe('appeal-documents', () => {
 
 		it('should render blob host and container', async () => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/')
-				.get(`/appeals/${validAppealId}/document-folders/1`)
-				.reply(200, validFolders[0]);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, validFolders[0]);
 
 			const response = await request.get(getControllerEndpoint(validAppealId, validFolderId));
 			const html = parseHtml(response.text);
@@ -241,9 +240,9 @@ describe('appeal-documents', () => {
 
 		beforeEach(() => {
 			nock('http://test/')
-				.get(`/appeals/${validAppealId}?include=all`)
-				.reply(200, { id: validAppealId });
-			nock('http://test/').get(`/appeals/${validAppealId}/document-folders/1`).reply(200, folder);
+				.get(`/appeals/${validAppealId}?include=appealType,appellantCase`)
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/').get(getFolderApiUrl(validAppealId, 1)).reply(200, folder);
 			nock('http://test/').get(`/appeals/documents/${documentId}`).reply(200, fileInfo);
 			nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
 			nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
@@ -6,13 +6,14 @@ import { permissionNames } from '#environment/permissions.js';
 import { getTodaysISOString } from '#lib/dates.js';
 import { folderIsAdditionalDocuments } from '#lib/documents.js';
 import logger from '#lib/logger.js';
-import { userHasPermission } from '#lib/mappers/index.js';
+import { mapPagination, userHasPermission } from '#lib/mappers/index.js';
 import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { isFileUploadInfoItemArray } from '#lib/ts-utilities.js';
-import { isInternalUrl, safeRedirect } from '#lib/url-utilities.js';
+import { isInternalUrl, safeRedirect, stripQueryString } from '#lib/url-utilities.js';
 import config from '@pins/appeals.web/environment/config.js';
+import { DOCUMENTS_PAGE_SIZE } from '@pins/appeals/constants/common.js';
 import { APPEAL_REDACTED_STATUS } from '@planning-inspectorate/data-model';
 import {
 	addDocumentDetailsFormDataToFileUploadInfo,
@@ -310,7 +311,7 @@ export const renderManageFolder = async ({
 	preHeadingTextOverride,
 	isCosts = false
 }) => {
-	const { currentFolder, errors } = request;
+	const { currentFolder, currentPageNumber, originalUrl, query, errors } = request;
 
 	if (!currentFolder) {
 		return response.status(404).render('app/404.njk');
@@ -326,11 +327,24 @@ export const renderManageFolder = async ({
 		addButtonTextOverride,
 		dateColumnLabelTextOverride,
 		preHeadingTextOverride,
+		editable: userHasPermission(permissionNames.updateCase, request.session),
+		currentPageNumber,
 		isCosts
 	});
 
+	const urlWithoutQuery = stripQueryString(originalUrl);
+	const pagination = mapPagination(
+		currentPageNumber,
+		currentFolder.pageCount,
+		DOCUMENTS_PAGE_SIZE,
+		urlWithoutQuery,
+		query,
+		false
+	);
+
 	return response.status(200).render('appeals/documents/manage-folder.njk', {
 		pageContent: mappedPageContent,
+		pagination,
 		errors
 	});
 };
@@ -974,7 +988,7 @@ export const renderDeleteDocument = async ({ request, response, backButtonUrl })
 		backButtonUrl,
 		redactionStatuses,
 		document,
-		currentFolder,
+		currentFolder.folderId,
 		versionId,
 		errors
 	);

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -18,7 +18,11 @@ import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-co
 import { surnameFirstToFullName } from '#lib/person-name-formatter.js';
 import { redactionStatusIdToName } from '#lib/redaction-statuses.js';
 import config from '@pins/appeals.web/environment/config.js';
-import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
+import {
+	APPEAL_TYPE,
+	DOCUMENTS_PAGE_SIZE,
+	FEATURE_FLAG_NAMES
+} from '@pins/appeals/constants/common.js';
 import {
 	APPEAL_DOCUMENT_TYPE,
 	APPEAL_REDACTED_STATUS,
@@ -29,8 +33,11 @@ import { capitalize } from 'lodash-es';
 /**
  * @typedef {import('../appeal-details/appeal-details.types.js').WebAppeal} Appeal
  * @typedef {import('@pins/appeals.api').Appeals.FolderInfo} FolderInfo
+ * @typedef {import('@pins/appeals.api').Appeals.PagedFolderInfo} PagedFolderInfo
  * @typedef {import('@pins/appeals.api').Appeals.DocumentInfo} DocumentInfo
+ * @typedef {import('@pins/appeals.api').Appeals.PagedDocumentInfo} PagedDocumentInfo
  * @typedef {import('@pins/appeals.api').Appeals.DocumentVersionInfo} DocumentVersionInfo
+ * @typedef {import('@pins/appeals.api').Appeals.PagedDocumentVersionInfo} PagedDocumentVersionInfo
  * @typedef {import('#lib/nunjucks-template-builders/tag-builders.js').HtmlLink} HtmlLink
  * @typedef {import('@pins/appeals.api').Schema.DocumentRedactionStatus} RedactionStatus
  * @typedef {import('@pins/appeals.api').Api.DocumentVersionAuditEntry} DocumentVersionAuditEntry
@@ -167,20 +174,6 @@ export const mapUncommittedDocumentDownloadUrl = (
 };
 
 /**
- * @param {string|null|undefined} fileName
- * @returns {string}
- */
-const mapDocumentFileNameToFileExtension = (fileName) => {
-	if (!fileName) {
-		return '';
-	}
-
-	const nameFragments = fileName.split('.');
-
-	return nameFragments[nameFragments.length - 1].toUpperCase();
-};
-
-/**
  * @param {number|null|undefined} fileSize
  * @returns {string}
  */
@@ -198,21 +191,6 @@ const mapDocumentSizeToFileSizeString = (fileSize) => {
 	} else {
 		return `${(fileSize / gigabyte).toFixed(2)} GB`;
 	}
-};
-
-/**
- *
- * @param {DocumentInfo|undefined} document
- * @returns {string}
- */
-const mapDocumentFileTypeAndSize = (document) => {
-	if (!document?.latestDocumentVersion) {
-		return '';
-	}
-
-	return `${mapDocumentFileNameToFileExtension(document.name)}, ${mapDocumentSizeToFileSizeString(
-		Number(document.latestDocumentVersion?.size)
-	)}`;
 };
 
 /**
@@ -256,7 +234,7 @@ export function mapVirusCheckStatus(virusCheckStatus) {
 }
 
 /**
- * @param {DocumentInfo} document
+ * @param {DocumentInfo|PagedDocumentInfo} document
  * @returns {DocumentVirusCheckStatus}
  */
 export function mapDocumentInfoVirusCheckStatus(document) {
@@ -267,7 +245,7 @@ export function mapDocumentInfoVirusCheckStatus(document) {
 }
 
 /**
- * @param {DocumentVersionInfo|undefined} document
+ * @param {DocumentVersionInfo|PagedDocumentVersionInfo|undefined} document
  * @returns {DocumentVirusCheckStatus}
  */
 export function mapDocumentVersionDetailsVirusCheckStatus(document) {
@@ -799,12 +777,20 @@ export function addDocumentsCheckAndConfirmPage({
 }
 
 /**
- * @param {FolderInfo} folder
- * @param {DocumentInfo} document
+ * @param {FolderInfo|PagedFolderInfo} folder
+ * @param {DocumentInfo|PagedDocumentInfo} document
+ * @param {number} index
+ * @param {number} totalDocuments
  * @param {boolean} [isCosts]
  * @returns {HtmlProperty & ClassesProperty}
  */
-export function mapFolderDocumentInformationHtmlProperty(folder, document, isCosts = false) {
+export function mapFolderDocumentInformationHtmlProperty(
+	folder,
+	document,
+	index,
+	totalDocuments,
+	isCosts = false
+) {
 	/** @type {HtmlProperty} */
 	const htmlProperty = {
 		html: '',
@@ -818,42 +804,30 @@ export function mapFolderDocumentInformationHtmlProperty(folder, document, isCos
 			: '';
 
 	if (document?.id) {
-		const linkWrapperHtml = {
-			opening: '<div class="govuk-!-margin-bottom-4">',
-			closing: '</div>'
-		};
 		const virusCheckStatus = mapDocumentInfoVirusCheckStatus(document);
-
+		const fileSizeString = document.latestDocumentVersion?.size
+			? `(${mapDocumentSizeToFileSizeString(Number(document.latestDocumentVersion?.size))})`
+			: '';
+		const indexString = totalDocuments > 1 ? `${index + 1}.` : '';
 		if (virusCheckStatus.checked && virusCheckStatus.safe) {
 			htmlProperty.pageComponents.push({
 				type: 'html',
-				wrapperHtml: linkWrapperHtml,
 				parameters: {
-					html: `${sharedTagHtml}<a class="govuk-link" href="${mapDocumentDownloadUrl(
+					html: `${indexString} ${sharedTagHtml}<a class="govuk-link" href="${mapDocumentDownloadUrl(
 						folder.caseId,
 						document.id,
 						document.name
-					)}" target="_blank">${document.name || ''}</a>`.trim()
+					)}" target="_blank">${document.name || ''}</a> ${fileSizeString}`.trim()
 				}
 			});
 		} else {
 			htmlProperty.pageComponents.push({
 				type: 'html',
-				wrapperHtml: linkWrapperHtml,
 				parameters: {
-					html: `${sharedTagHtml}<span class="govuk-body">${document.name || ''}</span>`.trim()
+					html: `${indexString} ${sharedTagHtml}<span class="govuk-body">${document.name || ''}</span> ${fileSizeString}`.trim()
 				}
 			});
 		}
-
-		htmlProperty.pageComponents.push({
-			type: 'html',
-			parameters: {
-				html: `<dl class="govuk-body govuk-!-font-size-16 pins-inline-definition-list"><dt>File type and size:&nbsp;</dt><dd>${mapDocumentFileTypeAndSize(
-					document
-				)}</dd></dl>`.trim()
-			}
-		});
 
 		if (!virusCheckStatus.safe) {
 			htmlProperty.pageComponents.push({
@@ -873,8 +847,8 @@ export function mapFolderDocumentInformationHtmlProperty(folder, document, isCos
 }
 
 /**
- * @param {FolderInfo} folder
- * @param {DocumentInfo} document
+ * @param {FolderInfo|PagedFolderInfo} folder
+ * @param {DocumentInfo|PagedDocumentInfo} document
  * @param {string} viewAndEditUrl
  * @param {boolean} [isCosts]
  * @returns {HtmlProperty & ClassesProperty}
@@ -918,13 +892,15 @@ export function mapFolderDocumentActionsHtmlProperty(
  * @param {string} params.backLinkUrl
  * @param {string} params.viewAndEditUrl
  * @param {string} params.addButtonUrl
- * @param {FolderInfo} params.folder - API type needs to be updated (should be Folder, but there are worse problems with that type)
+ * @param {PagedFolderInfo} params.folder - API type needs to be updated (should be Folder, but there are worse problems with that type)
  * @param {import('@pins/express/types/express.js').Request} params.request
  * @param {string} [params.pageHeadingTextOverride]
  * @param {string} [params.addButtonTextOverride]
  * @param {string} [params.dateColumnLabelTextOverride]
  * @param {string} [params.preHeadingTextOverride]
  * @param {boolean} [params.isCosts]
+ * @param {boolean} [params.editable]
+ * @param {number} params.currentPageNumber
  * @returns {PageContent}
  */
 export function manageFolderPage({
@@ -937,6 +913,8 @@ export function manageFolderPage({
 	addButtonTextOverride,
 	dateColumnLabelTextOverride,
 	preHeadingTextOverride,
+	editable = true,
+	currentPageNumber,
 	isCosts = false
 }) {
 	const appealType = request.currentAppeal?.appealType;
@@ -983,6 +961,26 @@ export function manageFolderPage({
 			classes: 'govuk-button--secondary'
 		}
 	};
+	const tableHead = [
+		{
+			text: 'Name'
+		},
+		{
+			text: dateColumnLabelTextOverride || 'Date received'
+		},
+		{
+			text: 'Redaction status'
+		},
+		...(editable
+			? [
+					{
+						text: 'Actions'
+					}
+				]
+			: [])
+	];
+
+	const docStartCount = (currentPageNumber - 1) * DOCUMENTS_PAGE_SIZE;
 
 	/** @type {PageContent} */
 	const pageContent = {
@@ -994,7 +992,7 @@ export function manageFolderPage({
 		pageComponents: [
 			...notificationBanners,
 			...errorSummaryPageComponents,
-			buttonComponent,
+			...(editable ? [buttonComponent] : []),
 			{
 				type: 'table',
 				wrapperHtml: {
@@ -1002,25 +1000,18 @@ export function manageFolderPage({
 					closing: '</div></div>'
 				},
 				parameters: {
-					head: [
-						{
-							text: 'Name'
-						},
-						{
-							text: dateColumnLabelTextOverride || 'Date received'
-						},
-						{
-							text: 'Redaction status'
-						},
-						{
-							text: 'Actions'
-						}
-					],
+					head: tableHead,
 					attributes: {
 						id: 'documents-table'
 					},
-					rows: (folder?.documents || []).map((document) => [
-						mapFolderDocumentInformationHtmlProperty(folder, document, isCosts),
+					rows: (folder?.documents || []).map((document, index) => [
+						mapFolderDocumentInformationHtmlProperty(
+							folder,
+							document,
+							docStartCount + index,
+							folder.totalFolderSize,
+							isCosts
+						),
 						folderIsAdditionalDocuments(folder.path) && document?.latestDocumentVersion?.isLateEntry
 							? {
 									html: '',
@@ -1055,7 +1046,9 @@ export function manageFolderPage({
 						{
 							text: document?.latestDocumentVersion?.redactionStatus
 						},
-						mapFolderDocumentActionsHtmlProperty(folder, document, viewAndEditUrl, isCosts)
+						...(editable
+							? [mapFolderDocumentActionsHtmlProperty(folder, document, viewAndEditUrl, isCosts)]
+							: [])
 					])
 				}
 			}
@@ -1603,7 +1596,7 @@ export async function manageDocumentPage({
  * @param {string} backLinkUrl
  * @param {RedactionStatus[]} redactionStatuses
  * @param {DocumentInfo} document
- * @param {FolderInfo} folder - API type needs to be updated here (should be Folder, but there are worse problems with that type)
+ * @param {number} folderId
  * @param {string} versionId
  * @param {import("@pins/express/types/express.js").ValidationErrors | undefined} errors
  * @returns {Promise<PageContent>}
@@ -1612,7 +1605,7 @@ export async function deleteDocumentPage(
 	backLinkUrl,
 	redactionStatuses,
 	document,
-	folder,
+	folderId,
 	versionId,
 	errors
 ) {
@@ -1644,7 +1637,7 @@ export async function deleteDocumentPage(
 		title: 'Remove document',
 		backLinkText: 'Back',
 		backLinkUrl: backLinkUrl
-			?.replace('{{folderId}}', folder.folderId.toString())
+			?.replace('{{folderId}}', folderId.toString())
 			.replace('{{documentId}}', document.id || ''),
 		preHeading: 'Manage versions',
 		heading: 'Are you sure you want to remove this version?',
@@ -2002,9 +1995,9 @@ export function changeDocumentDetailsPage(backLinkUrl, folder, file, redactionSt
 
 /**
  *
- * @param {FolderInfo} folder
+ * @param {FolderInfo|PagedFolderInfo} folder
  * @param {string} virusStatus
- * @returns {DocumentInfo[]}
+ * @returns {DocumentInfo[]|PagedDocumentInfo[]}
  */
 export function getDocumentsForVirusStatus(folder, virusStatus) {
 	let matchingDocuments = [];

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.middleware.js
@@ -1,3 +1,5 @@
+import { paginationDefaultSettings } from '#appeals/appeal.constants.js';
+import { DOCUMENTS_PAGE_SIZE } from '@pins/appeals/constants/common.js';
 import { getFileInfo, getFolder } from './appeal.documents.service.js';
 
 /**
@@ -6,14 +8,26 @@ import { getFileInfo, getFolder } from './appeal.documents.service.js';
  */
 export const validateCaseFolderId = async (req, res, next) => {
 	const { appealId, folderId } = req.params;
+	const { pageNumber = paginationDefaultSettings.firstPageNumber } = req.query;
+	if (Number.isNaN(Number(pageNumber)) || Number(pageNumber) < 1) {
+		return res.status(400).render('app/400.njk');
+	}
 	const repId = req.currentRepresentation?.id;
-	const folder = await getFolder(req.apiClient, appealId, folderId, repId);
+	const folder = await getFolder(
+		req.apiClient,
+		appealId,
+		folderId,
+		Number(pageNumber),
+		DOCUMENTS_PAGE_SIZE,
+		repId
+	);
 
 	if (!folder) {
 		return res.status(404).render('app/404.njk');
 	}
 
 	req.currentFolder = folder;
+	req.currentPageNumber = Number(pageNumber);
 	next();
 };
 

--- a/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
@@ -23,13 +23,19 @@ export const getAllCaseFolders = async (apiClient, appealId) => {
  * @param {import('got').Got} apiClient
  * @param {string|number} appealId
  * @param {string|number} folderId
+ * @param {string|number} pageNumber
+ * @param {string|number} pageSize
  * @param {string|number} [repId]
  * @returns {Promise<FolderInfo|undefined>}
  */
-export const getFolder = async (apiClient, appealId, folderId, repId) => {
+export const getFolder = async (apiClient, appealId, folderId, pageNumber, pageSize, repId) => {
 	try {
-		const query = repId ? `?repId=${repId}` : '';
-		const url = `appeals/${appealId}/document-folders/${folderId}${query}`;
+		const urlParams = new URLSearchParams();
+		urlParams.append('pageNumber', pageNumber.toString());
+		urlParams.append('pageSize', pageSize.toString());
+		if (repId) urlParams.append('repId', repId.toString());
+
+		const url = `appeals/${appealId}/document-folders/${folderId}?${urlParams.toString()}`;
 
 		const locationInfo = await apiClient.get(url).json();
 		return locationInfo;

--- a/appeals/web/src/server/appeals/appeals.types.d.ts
+++ b/appeals/web/src/server/appeals/appeals.types.d.ts
@@ -54,7 +54,8 @@ export interface AppealProcedureType {
 declare global {
 	namespace Express {
 		interface Request {
-			currentFolder: Schema.Folder;
+			currentFolder: Schema.Folder | Schema.PagedFolder;
+			currentPageNumber: number;
 			currentAppeal: Appeal;
 			currentRepresentation: Representation;
 			currentRule6Party: import('./appeal-details/appeal-details.types').AppealRule6Party;

--- a/appeals/web/src/server/lib/constants.js
+++ b/appeals/web/src/server/lib/constants.js
@@ -1,5 +1,4 @@
 export const SHOW_MORE_MAXIMUM_CHARACTERS_BEFORE_HIDING = 300;
-export const SHOW_MORE_MAXIMUM_ROWS_BEFORE_HIDING = 3;
 
 /**
  * @type {string[]}

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -1,7 +1,6 @@
 import { mapDocumentInfoVirusCheckStatus } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import config from '#environment/config.js';
 import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
-import { SHOW_MORE_MAXIMUM_ROWS_BEFORE_HIDING } from '#lib/constants.js';
 import logger from '#lib/logger.js';
 import { MAX_VISIBLE_DOCUMENTS_IN_SUMMARY } from '@pins/appeals/constants/common.js';
 import { appealSiteToMultilineAddressStringHtml } from './address-formatter.js';
@@ -189,7 +188,33 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 	if (documents.length > 0) {
 		const visibleDocs = documents.slice(0, MAX_VISIBLE_DOCUMENTS_IN_SUMMARY);
 		const hasMore = documents.length > MAX_VISIBLE_DOCUMENTS_IN_SUMMARY;
-		const moreCount = documents.length - MAX_VISIBLE_DOCUMENTS_IN_SUMMARY;
+
+		htmlProperty.wrapperHtml = {
+			opening: '<div class="full-width">',
+			closing: '</div>'
+		};
+
+		if (hasMore) {
+			htmlProperty.pageComponents.push({
+				type: 'html',
+				parameters: {
+					html: isAdditionalDocuments
+						? `<p class="govuk-body">Showing ${MAX_VISIBLE_DOCUMENTS_IN_SUMMARY} of ${documents.length} documents</p>`
+						: `<span class="govuk-body">Showing ${MAX_VISIBLE_DOCUMENTS_IN_SUMMARY} of ${documents.length} documents</span>`
+				}
+			});
+		}
+
+		htmlProperty.pageComponents.push({
+			type: 'html',
+			parameters: {
+				// hides list styling if only 1 doc
+				html:
+					documents.length > 1
+						? `<ul class="govuk-list govuk-list--bullet pins-file-list">`
+						: `<ul class="govuk-list pins-file-list">`
+			}
+		});
 
 		for (let i = 0; i < visibleDocs.length; i++) {
 			const document = visibleDocs[i];
@@ -264,30 +289,12 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 			});
 		}
 
-		if (hasMore) {
-			htmlProperty.pageComponents.push({
-				wrapperHtml: {
-					opening: `<li class="govuk-!-margin-top-1"><span>`,
-					closing: '</span></li>'
-				},
-				type: 'html',
-				parameters: {
-					html: `<span class="govuk-body govuk-!-font-weight-bold">... and ${moreCount} more document${moreCount === 1 ? '' : 's'}</span>`
-				}
-			});
-		}
-
-		if (htmlProperty.pageComponents.length > 1) {
-			htmlProperty.wrapperHtml = {
-				opening: '<ol class="govuk-list govuk-list--number pins-file-list">',
-				closing: '</ol>'
-			};
-		} else if (htmlProperty.pageComponents.length > 0) {
-			htmlProperty.wrapperHtml = {
-				opening: '<ul class="govuk-list pins-file-list">',
-				closing: '</ul>'
-			};
-		}
+		htmlProperty.pageComponents.push({
+			type: 'html',
+			parameters: {
+				html: `</ul>`
+			}
+		});
 	} else {
 		htmlProperty.pageComponents.push({
 			type: 'html',
@@ -296,32 +303,6 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 			}
 		});
 		logger.debug('No documents in this folder');
-	}
-
-	if (documents.length > SHOW_MORE_MAXIMUM_ROWS_BEFORE_HIDING && isAdditionalDocuments) {
-		htmlProperty.pageComponents = [
-			{
-				type: 'show-more',
-				parameters: {
-					labelText: 'additional documents',
-					html: '',
-					contentRowSelector: 'li',
-					toggleTextCollapsed: 'View all',
-					pageComponents: [
-						{
-							type: 'html',
-							wrapperHtml: htmlProperty.wrapperHtml,
-							parameters: {
-								html: '',
-								pageComponents: htmlProperty.pageComponents
-							}
-						}
-					]
-				}
-			}
-		];
-
-		delete htmlProperty.wrapperHtml;
 	}
 
 	return htmlProperty;

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -7,10 +7,8 @@ import {
 } from '#testing/app/fixtures/referencedata.js';
 import { areIdsDefinedAndUnique } from '#testing/lib/testMappers.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
-import { isEqual } from 'lodash-es';
 import { initialiseAndMapAppealData } from '../data/appeal/mapper.js';
 import { initialiseAndMapLPAQData } from '../data/lpa-questionnaire/mapper.js';
-import { mapPagination } from '../index.js';
 const isoDateInPast = '2011-10-05T14:48:00.000Z';
 
 /** @typedef {import('../../../app/auth/auth-session.service').SessionWithAuth} SessionWithAuth */
@@ -114,75 +112,6 @@ describe('lpaQuestionnaire-mapper', () => {
 		});
 		it('should have an id that is unique', async () => {
 			expect(areIdsDefinedAndUnique(validMappedData.lpaq)).toBe(true);
-		});
-	});
-});
-
-describe('pagination mapper', () => {
-	const testAdditionalQuery = { 'test-additional-query-string': true };
-
-	describe('mapPagination', () => {
-		it('should return an empty Pagination object if pageCount is less than 2', () => {
-			const result = mapPagination(1, 1, 10, 'test-base-url', testAdditionalQuery);
-
-			expect(result.previous).toEqual({});
-			expect(result.next).toEqual({});
-			expect(result.items).toEqual([]);
-		});
-		it('should return a Pagination object with the expected properties if pageCount is 2 or greater', () => {
-			const testBaseUrl = 'test-base-url';
-
-			const result = mapPagination(3, 5, 10, testBaseUrl, testAdditionalQuery);
-
-			const testAdditionalQueryString = '&test-additional-query-string=true';
-
-			expect(result.previous?.href).toEqual(
-				`${testBaseUrl}?pageSize=10&pageNumber=2${testAdditionalQueryString}`
-			);
-			expect(result.next?.href).toEqual(
-				`${testBaseUrl}?pageSize=10&pageNumber=4${testAdditionalQueryString}`
-			);
-			expect(result.items?.length).toBe(5);
-			expect(result.items?.[4]?.number).toEqual(5);
-			expect(result.items?.[4]?.href).toEqual(
-				`${testBaseUrl}?pageSize=10&pageNumber=5${testAdditionalQueryString}`
-			);
-		});
-
-		it('renders an ellipsis element before the final page marker and no ellipsis element after the first page marker when page count is greater than 10 and current page is 2', () => {
-			const testBaseUrl = 'test-base-url';
-			const result = mapPagination(2, 15, 30, testBaseUrl, testAdditionalQuery);
-
-			const containsEllipsisElementAfterFirstPageMarker = isEqual(result.items[1], {
-				ellipsis: true
-			});
-			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
-				ellipsis: true
-			});
-			const containsBlankEllipsisElement =
-				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
-
-			expect(containsEllipsisElementAfterFirstPageMarker).toBeFalsy();
-			expect(containsEllipsisElementBeforeLastPageMarker).toBeTruthy();
-			expect(containsBlankEllipsisElement).toBeFalsy();
-		});
-
-		it('renders an ellipsis element after the first page marker and no ellipsis element before the last page marker when page count is greater than 10 and current page is 17', () => {
-			const testBaseUrl = 'test-base-url';
-			const result = mapPagination(17, 15, 30, testBaseUrl, testAdditionalQuery);
-
-			const containsEllipsisElementAfterFirstPageMarker = isEqual(result.items[1], {
-				ellipsis: true
-			});
-			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
-				ellipsis: true
-			});
-			const containsBlankEllipsisElement =
-				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
-
-			expect(containsEllipsisElementAfterFirstPageMarker).toBeTruthy();
-			expect(containsEllipsisElementBeforeLastPageMarker).toBeFalsy();
-			expect(containsBlankEllipsisElement).toBeFalsy();
 		});
 	});
 });

--- a/appeals/web/src/server/lib/mappers/components/instructions/document.js
+++ b/appeals/web/src/server/lib/mappers/components/instructions/document.js
@@ -30,15 +30,17 @@ export function documentSummaryListItem({
 	const documents = (isFolderInfo(folderInfo) && folderInfo.documents) || [];
 	/** @type {ActionItemProperties[]} */
 	const actions = [];
+	if (documents.length) {
+		actions.push({
+			text: 'Manage',
+			visuallyHiddenText: text,
+			href: manageUrl,
+			attributes: { 'data-cy': `manage-${cypressDataName}` },
+			needsPermissions: false
+		});
+	}
+
 	if (editable) {
-		if (documents.length) {
-			actions.push({
-				text: 'Change',
-				visuallyHiddenText: text,
-				href: manageUrl,
-				attributes: { 'data-cy': `manage-${cypressDataName}` }
-			});
-		}
 		actions.push({
 			text: 'Add',
 			visuallyHiddenText: text,

--- a/appeals/web/src/server/lib/mappers/components/page-components/__tests__/pagination.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/__tests__/pagination.mapper.test.js
@@ -1,0 +1,100 @@
+// @ts-nocheck
+import { isEqual } from 'lodash-es';
+import { mapPagination } from '../pagination.mapper.js';
+
+describe('pagination mapper', () => {
+	const testAdditionalQuery = { 'test-additional-query-string': true };
+
+	describe('mapPagination', () => {
+		it('should return an empty Pagination object if pageCount is less than 2', () => {
+			const result = mapPagination(1, 1, 10, 'test-base-url', testAdditionalQuery);
+
+			expect(result.previous).toEqual({});
+			expect(result.next).toEqual({});
+			expect(result.items).toEqual([]);
+		});
+		it('should return a Pagination object with the expected properties if pageCount is 2 or greater', () => {
+			const testBaseUrl = 'test-base-url';
+
+			const result = mapPagination(3, 5, 10, testBaseUrl, testAdditionalQuery);
+
+			const testAdditionalQueryString = '&test-additional-query-string=true';
+
+			expect(result.previous?.href).toEqual(
+				`${testBaseUrl}?pageSize=10&pageNumber=2${testAdditionalQueryString}`
+			);
+			expect(result.next?.href).toEqual(
+				`${testBaseUrl}?pageSize=10&pageNumber=4${testAdditionalQueryString}`
+			);
+			expect(result.items?.length).toBe(5);
+			expect(result.items?.[4]?.number).toEqual(5);
+			expect(result.items?.[4]?.href).toEqual(
+				`${testBaseUrl}?pageSize=10&pageNumber=5${testAdditionalQueryString}`
+			);
+		});
+
+		it('renders an ellipsis element before the final page marker and no ellipsis element after the first page marker when page count is greater than 10 and current page is 2', () => {
+			const testBaseUrl = 'test-base-url';
+			const result = mapPagination(2, 15, 30, testBaseUrl, testAdditionalQuery);
+
+			const containsEllipsisElementAfterFirstPageMarker = isEqual(result.items[1], {
+				ellipsis: true
+			});
+			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
+				ellipsis: true
+			});
+			const containsBlankEllipsisElement =
+				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
+
+			expect(containsEllipsisElementAfterFirstPageMarker).toBeFalsy();
+			expect(containsEllipsisElementBeforeLastPageMarker).toBeTruthy();
+			expect(containsBlankEllipsisElement).toBeFalsy();
+		});
+
+		it('renders an ellipsis element after the first page marker and no ellipsis element before the last page marker when page count is greater than 10 and current page is 17', () => {
+			const testBaseUrl = 'test-base-url';
+			const result = mapPagination(17, 15, 30, testBaseUrl, testAdditionalQuery);
+
+			const containsEllipsisElementAfterFirstPageMarker = isEqual(result.items[1], {
+				ellipsis: true
+			});
+			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
+				ellipsis: true
+			});
+			const containsBlankEllipsisElement =
+				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
+
+			expect(containsEllipsisElementAfterFirstPageMarker).toBeTruthy();
+			expect(containsEllipsisElementBeforeLastPageMarker).toBeFalsy();
+			expect(containsBlankEllipsisElement).toBeFalsy();
+		});
+
+		it('removes pageSize from generated links when includePageSize is false', () => {
+			expect(mapPagination(2, 3, 25, '/appeals', { filter: 'open' }, false)).toEqual({
+				previous: {
+					href: '/appeals?pageNumber=1&filter=open'
+				},
+				next: {
+					href: '/appeals?pageNumber=3&filter=open'
+				},
+				items: [
+					{
+						number: 1,
+						href: '/appeals?pageNumber=1&filter=open',
+						current: false
+					},
+					{
+						number: 2,
+						href: '/appeals?pageNumber=2&filter=open',
+						current: true
+					},
+					{
+						number: 3,
+						href: '/appeals?pageNumber=3&filter=open',
+						current: false
+					}
+				]
+			});
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/components/page-components/pagination.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/pagination.mapper.js
@@ -9,9 +9,17 @@ import { paginationDefaultSettings } from '#appeals/appeal.constants.js';
  * @param {number} itemsPerPage
  * @param {string} baseUrl
  * @param {object} query
+ * @param {boolean} [includePageSize]
  * @returns {Pagination}
  */
-export function mapPagination(currentPage, pageCount, itemsPerPage, baseUrl, query) {
+export function mapPagination(
+	currentPage,
+	pageCount,
+	itemsPerPage,
+	baseUrl,
+	query,
+	includePageSize = true
+) {
 	// filter out pagination related query params
 	const paginationlessQueryParams = Object.entries(query).filter(
 		([prop]) => prop !== 'pageNumber' && prop !== 'pageSize'
@@ -128,6 +136,31 @@ export function mapPagination(currentPage, pageCount, itemsPerPage, baseUrl, que
 				});
 			}
 		}
+	}
+
+	if (!includePageSize) {
+		/** @param {string} href */
+		const removePageSizeFromQuery = (href) => {
+			const urlObj = new URL(href, 'http://localhost');
+			urlObj.searchParams.delete('pageSize');
+			return urlObj.pathname + urlObj.search;
+		};
+
+		if (pagination.previous?.href) {
+			pagination.previous.href = removePageSizeFromQuery(pagination.previous.href);
+		}
+		if (pagination.next?.href) {
+			pagination.next.href = removePageSizeFromQuery(pagination.next.href);
+		}
+		pagination.items = pagination.items.map((item) => {
+			if (item.href) {
+				return {
+					...item,
+					href: removePageSizeFromQuery(item.href)
+				};
+			}
+			return item;
+		});
 	}
 
 	return pagination;

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/remove-summary-list-actions.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/remove-summary-list-actions.test.js
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import { removeSummaryListActions } from '#lib/mappers/utils/remove-summary-list-actions.js';
+
+describe('removeSummaryListActions', () => {
+	it('returns undefined for nullish input', () => {
+		expect(removeSummaryListActions()).toBeUndefined();
+		expect(removeSummaryListActions(null)).toBeUndefined();
+	});
+
+	it('filters actions to only items that do not need permissions', () => {
+		const value = {
+			text: 'Example',
+			actions: {
+				items: [{ text: 'Manage', needsPermissions: false }, { text: 'Add' }]
+			}
+		};
+
+		expect(removeSummaryListActions(value)).toEqual({
+			text: 'Example',
+			actions: {
+				items: [{ text: 'Manage', needsPermissions: false }]
+			}
+		});
+	});
+
+	it('skips malformed action entries', () => {
+		const value = {
+			actions: {
+				items: [undefined, { text: 'Manage', needsPermissions: false }, null, { text: 'Add' }]
+			}
+		};
+
+		expect(removeSummaryListActions(value)).toEqual({
+			actions: {
+				items: [{ text: 'Manage', needsPermissions: false }]
+			}
+		});
+	});
+
+	it('does not throw when actions is missing or malformed', () => {
+		expect(() => removeSummaryListActions({ text: 'Example' })).not.toThrow();
+		expect(() => removeSummaryListActions({ actions: undefined })).not.toThrow();
+		expect(removeSummaryListActions({ actions: undefined })).toEqual({ actions: undefined });
+	});
+});

--- a/appeals/web/src/server/lib/mappers/utils/remove-summary-list-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/remove-summary-list-actions.js
@@ -1,5 +1,5 @@
 /**
- * Clone the object (shallow) and remove any 'actions' properties that are present
+ * Clone the object (shallow) and remove any 'actions' properties that are present, unless they have a 'needsPermissions' property set to false.
  * @param {Object|null|undefined} value
  * @returns {any|undefined}
  */
@@ -8,13 +8,20 @@ export function removeSummaryListActions(value) {
 		return;
 	}
 
-	const clonedObject = { ...value };
+	// @ts-expect-error
+	const actions = value.actions;
+	if (!actions || !Array.isArray(actions.items)) {
+		return { ...value };
+	}
 
-	Object.keys(clonedObject).forEach((key) => {
-		if (key === 'actions') {
-			Reflect.deleteProperty(clonedObject, key);
+	return {
+		...value,
+		actions: {
+			...actions,
+			items: actions.items.filter(
+				/**@param {{needsPermissions?: boolean}} action */ (action) =>
+					action?.needsPermissions === false
+			)
 		}
-	});
-
-	return clonedObject;
+	};
 }

--- a/appeals/web/src/server/views/appeals/documents/manage-folder.njk
+++ b/appeals/web/src/server/views/appeals/documents/manage-folder.njk
@@ -2,6 +2,7 @@
 {%- from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner -%}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {%- from "../../app/components/page-heading.njk" import pageHeading -%}
+{%- from "govuk/components/pagination/macro.njk" import govukPagination -%}
 
 {%- set backLinkUrl = pageContent.backLinkUrl -%}
 {%- set backLinkText = pageContent.backLinkText -%}
@@ -47,4 +48,15 @@
 			{%- include "../components/page-component.njk" -%}
 		{%- endif -%}
 	{%- endfor -%}
+	{% if pagination.items|length %}
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-full">
+				{{
+					govukPagination(
+						pagination
+					)
+				}}
+			</div>
+		</div>
+	{% endif %}
 {%- endblock -%}

--- a/appeals/web/src/styles/8-utilities/_layout.scss
+++ b/appeals/web/src/styles/8-utilities/_layout.scss
@@ -6,3 +6,8 @@
 .space-between {
 	justify-content: space-between;
 }
+
+.full-width {
+	display: block;
+	width: 100%;
+}

--- a/packages/appeals/constants/common.js
+++ b/packages/appeals/constants/common.js
@@ -202,4 +202,5 @@ export const FEEDBACK_FORM_LINKS = Object.freeze({
 
 export const REPRESENTATION_ADDED_AS_DOCUMENT = 'Added as a document';
 
-export const MAX_VISIBLE_DOCUMENTS_IN_SUMMARY = 30;
+export const MAX_VISIBLE_DOCUMENTS_IN_SUMMARY = 5;
+export const DOCUMENTS_PAGE_SIZE = 100;


### PR DESCRIPTION
## Describe your changes

- adds paging to manage folder pages
- changes how documents are displayed on details pages and displays only 5
- changes permissions to allow inspectors to view the full list
- changes some action link text from change to manage
- returned a larger data set from the exists endpoint so we can use more freely
- where possible reduces db lookups for document pages

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-8514
