### PR TITLE
feat(web): show final comments in documentation for ldcEnfDisc hearin…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -6751,6 +6751,41 @@ describe('appeal-details', () => {
 					`<dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/hearing/estimates/change"`
 				);
 			});
+
+			it('should not render appellantFinalComments and lpaFinalComments rows in documentation table when procedureType is "hearing" - non ldcEnfDisc appeal types', async () => {
+				const appealId = '123';
+				const appealDetails = { ...appealData, appealId, procedureType: 'hearing' };
+
+				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealDetails);
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+
+				const response = await request.get(`/appeals-service/appeal-details/${appealId}`);
+				const unprettifiedHTML = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
+
+				expect(unprettifiedHTML).not.toContain('Appellant final comments');
+				expect(unprettifiedHTML).not.toContain('LPA final comments');
+			});
+
+			test.each([
+				[APPEAL_TYPE.ENFORCEMENT_NOTICE, appealDataEnforcementNotice],
+				[APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING, appealDataEnforcementListedBuilding],
+				[APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE, appealDataLdc]
+			])(
+				`should render appellantFinalComments and lpaFinalComments rows in documentation table when procedureType is "hearing" - %s appeal type`,
+				async (_, ldcEnfDiscAppealTypeData) => {
+					const appealId = '123';
+					const appealDetails = { ...ldcEnfDiscAppealTypeData, appealId, procedureType: 'hearing' };
+
+					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealDetails);
+					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+
+					const response = await request.get(`/appeals-service/appeal-details/${appealId}`);
+					const unprettifiedHTML = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
+
+					expect(unprettifiedHTML).toContain('Appellant final comments');
+					expect(unprettifiedHTML).toContain('LPA final comments');
+				}
+			);
 		});
 
 		describe('Costs', () => {

--- a/appeals/web/src/server/lib/mappers/data/appeal/common.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/common.js
@@ -11,8 +11,11 @@ import {
 	APPEAL_PROOF_OF_EVIDENCE_STATUS,
 	APPEAL_REPRESENTATION_STATUS
 } from '@pins/appeals/constants/common.js';
-import { APPEAL_VIRUS_CHECK_STATUS } from '@planning-inspectorate/data-model';
-
+import { isLdcOrDiscontinuanceOrEnforcementAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
+import {
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_VIRUS_CHECK_STATUS
+} from '@planning-inspectorate/data-model';
 /**
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal
  */
@@ -157,3 +160,11 @@ export const proofsReceivedText = (statusText, receivedAt) => {
 		receivedAt instanceof Date ? receivedAt.toDateString() : receivedAt
 	);
 };
+
+/**
+ * @param {WebAppeal} appealDetails
+ * @returns {boolean}
+ */
+export const doNotDisplayFinalComments = (appealDetails) =>
+	appealDetails?.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING &&
+	!isLdcOrDiscontinuanceOrEnforcementAppealType(appealDetails?.appealType);

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/appellant-final-comments.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/appellant-final-comments.mapper.test.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { mapAppellantFinalComments } from '#lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
 describe('appellant-final-comments.mapper', () => {
 	const mockRequest = {
@@ -53,9 +54,39 @@ describe('appellant-final-comments.mapper', () => {
 		);
 	});
 
-	it('should not display appellant final comments row if the procedure type is hearing', () => {
+	it('should not display appellant final comments row if the procedure type is hearing - non ldcEnfDisc', () => {
 		data.appealDetails.procedureType = 'Hearing';
 		const result = mapAppellantFinalComments(data);
 		expect(result).toEqual({ id: 'start-case-date', display: {} });
 	});
+
+	test.each([
+		[APPEAL_TYPE.ENFORCEMENT_NOTICE],
+		[APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING],
+		[APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE],
+		[APPEAL_TYPE.DISCONTINUANCE_NOTICE]
+	])(
+		`should display appellant final comments row if the procedure type is hearing - %s`,
+		(appealType) => {
+			data.appealDetails.procedureType = 'Hearing';
+			data.appealDetails.appealType = appealType;
+			const result = mapAppellantFinalComments(data);
+			expect(result).toEqual(
+				expect.objectContaining({
+					display: {
+						tableItem: [
+							{ text: 'Appellant final comments' },
+							{ text: 'Awaiting final comments' },
+							{ text: 'Due by ' },
+							expect.objectContaining({
+								classes: 'govuk-!-text-align-right',
+								html: ''
+							})
+						]
+					},
+					id: 'appellant-final-comments'
+				})
+			);
+		}
+	);
 });

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-final-comments.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-final-comments.mapper.test.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { mapLPAFinalComments } from '#lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
 describe('lpa-final-comments.mapper', () => {
 	const mockRequest = {
@@ -51,9 +52,37 @@ describe('lpa-final-comments.mapper', () => {
 		});
 	});
 
-	it('should not display lpa final comments row if the procedure type is hearing', () => {
+	it('should not display lpa final comments row if the procedure type is hearing - non ldcEnfDisc', () => {
 		data.appealDetails.procedureType = 'Hearing';
 		const result = mapLPAFinalComments(data);
 		expect(result).toEqual({ id: 'start-case-date', display: {} });
 	});
+
+	test.each([
+		[APPEAL_TYPE.ENFORCEMENT_NOTICE],
+		[APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING],
+		[APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE],
+		[APPEAL_TYPE.DISCONTINUANCE_NOTICE]
+	])(
+		`should display appellant final comments row if the procedure type is hearing - %s`,
+		(appealType) => {
+			data.appealDetails.procedureType = 'Hearing';
+			data.appealDetails.appealType = appealType;
+			const result = mapLPAFinalComments(data);
+			expect(result).toEqual({
+				display: {
+					tableItem: [
+						{ text: 'LPA final comments' },
+						{ text: 'Awaiting final comments' },
+						{ text: 'Due by ' },
+						{
+							classes: 'govuk-!-text-align-right',
+							html: ''
+						}
+					]
+				},
+				id: 'lpa-final-comments'
+			});
+		}
+	);
 });

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
@@ -9,7 +9,11 @@ import {
 	mapRepresentationDocumentSummaryActionLink
 } from '#lib/representation-utilities.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
-import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { doNotDisplayFinalComments } from '../common.js';
+
+/**
+ * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal
+ */
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapAppellantFinalComments = ({ appealDetails, currentRoute, request }) => {
@@ -55,7 +59,7 @@ export const mapAppellantFinalComments = ({ appealDetails, currentRoute, request
 		return dateISOStringToDisplayDate(receivedAt);
 	})();
 
-	if (appealDetails?.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING) {
+	if (doNotDisplayFinalComments(appealDetails)) {
 		const id = 'start-case-date';
 		return { id, display: {} };
 	} else {

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
@@ -9,7 +9,7 @@ import {
 	mapRepresentationDocumentSummaryActionLink
 } from '#lib/representation-utilities.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
-import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { doNotDisplayFinalComments } from '../common.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapLPAFinalComments = ({ appealDetails, currentRoute, request }) => {
@@ -55,7 +55,7 @@ export const mapLPAFinalComments = ({ appealDetails, currentRoute, request }) =>
 		return dateISOStringToDisplayDate(receivedAt);
 	})();
 
-	if (appealDetails?.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING) {
+	if (doNotDisplayFinalComments(appealDetails)) {
 		const id = 'start-case-date';
 		return { id, display: {} };
 	} else {

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -118,6 +118,16 @@ export const isAnyEnforcementAppealType = (appealType) =>
 
 /**
  *
+ * @param {string|undefined} appealType
+ * @returns {boolean}
+ */
+export const isLdcOrDiscontinuanceOrEnforcementAppealType = (appealType) =>
+	appealType === APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE ||
+	appealType === APPEAL_TYPE.DISCONTINUANCE_NOTICE ||
+	isAnyEnforcementAppealType(appealType);
+
+/**
+ *
  * @param {string|undefined} caseType
  * @returns {boolean}
  */


### PR DESCRIPTION
…g (A2-8534)

Amends mapping to include final comments rows in documentation section of Appeal Details page for ldcEnfDisc hearings (maintains position where rows don't show for non ldcEnfDisc hearings).

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8534)
