### PR TITLE
fix(web): remove costs from BYS section in LDC, HAS and derivatives (…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-main.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case-main.test.js.snap
@@ -102,9 +102,6 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
@@ -408,9 +405,6 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
@@ -755,9 +749,6 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
@@ -1074,9 +1065,6 @@ exports[`appellant-case-main GET /appellant-case notification banners should ren
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
@@ -1527,9 +1515,6 @@ exports[`appellant-case-main GET /appellant-case should render review outcome fo
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/lpa-reference/change"
@@ -1846,9 +1831,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
@@ -2126,9 +2108,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/lpa-reference/change"
@@ -2390,9 +2369,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
@@ -3789,9 +3765,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/lpa-reference/change"
@@ -4162,9 +4135,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
@@ -4890,9 +4860,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/lpa-reference/change"
@@ -5249,9 +5216,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/lpa-reference/change"
@@ -5551,9 +5515,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/lpa-reference/change"
@@ -5842,9 +5803,6 @@ exports[`appellant-case-main GET /appellant-case should render the appellant cas
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
@@ -6149,9 +6107,6 @@ exports[`appellant-case-main POST /appellant-case should re-render the appellant
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
                                     data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
-                            <dd                             class="govuk-summary-list__value">No data</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
@@ -1,5 +1,4 @@
 import { isFeatureActive } from '#common/feature-flags.js';
-import { convertFromBooleanToYesNo } from '#lib/boolean-formatter.js';
 import * as displayPageFormatter from '#lib/display-page-formatter.js';
 import {
 	documentUploadUrlTemplate,
@@ -63,12 +62,6 @@ export function generateHASComponents(
 				removeSummaryListActions(mappedAppellantCaseData.applicationType.display.summaryListItem),
 				mappedAppellantCaseData.applicationDecision.display.summaryListItem,
 				mappedAppellantCaseData.applicationDecisionDate.display.summaryListItem,
-				{
-					key: { text: 'Are you claiming costs as part of your appeal?' },
-					value: {
-						text: convertFromBooleanToYesNo(appellantCaseData.appellantCostsAppliedFor, 'No data')
-					}
-				},
 				mappedAppellantCaseData.applicationReference.display.summaryListItem
 			]
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/ldc.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/ldc.mapper.js
@@ -1,4 +1,3 @@
-import { convertFromBooleanToYesNo } from '#lib/boolean-formatter.js';
 import { removeSummaryListActions } from '#lib/mappers/index.js';
 
 /**
@@ -48,12 +47,6 @@ export function generateLdcComponents(appealDetails, appellantCaseData, mappedAp
 				removeSummaryListActions(mappedAppellantCaseData.applicationType.display.summaryListItem),
 				mappedAppellantCaseData.applicationDecision.display.summaryListItem,
 				mappedAppellantCaseData.applicationDecisionDate.display.summaryListItem,
-				{
-					key: { text: 'Are you claiming costs as part of your appeal?' },
-					value: {
-						text: convertFromBooleanToYesNo(appellantCaseData.appellantCostsAppliedFor, 'No data')
-					}
-				},
 				mappedAppellantCaseData.applicationReference.display.summaryListItem
 			]
 		}


### PR DESCRIPTION
…A2-4732)

## Describe your changes

Removed costs currently showing in the BO for LDC, S78, S20, HAS, CAS Advert, CAS Planning and Full advert appeals in the BYS section.

Made sure theres no failing unit tests, updated existing snapshots and checked in the browser.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4732)