### PR TITLE
chore(web): remove unused setting of currentAppeal on session (A2-7812)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
@@ -17,7 +17,6 @@ export const viewAppealDetails = async (request, response) => {
 	if (!currentAppeal) {
 		return response.status(404).render('app/404.njk');
 	}
-	session.currentAppeal = currentAppeal;
 	delete session.reviewOutcome;
 	delete session.changeAppealType;
 


### PR DESCRIPTION
## Describe your changes

Removes an instance where current appeal was being attached to session, but then not used.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7812)
