### PR TITLE
feat(appeals): create individual call for appeal details page to get only required data(A2-8260)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -128,7 +128,25 @@ const householdAppealDto = {
 	startedAt: householdAppeal.caseStartedDate?.toISOString(),
 	validAt: householdAppeal.caseValidDate?.toISOString(),
 	enforcementNotice: { appellantCase: {}, appealOutcome: {} },
-	appealRule6Parties: {}
+	appealRule6Parties: {},
+	appellantCase: {
+		numberOfResidencesNetChange: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		applicationMadeUnderActSection: null,
+		isEnforcementChild: false,
+		planningObligation: {
+			hasObligation: true,
+			status: 'not_started'
+		},
+		enforcementNotice: null
+	},
+	resubmitTypeId: null,
+	resubmitType: null,
+	caseNotes: [],
+	appealStatusHistory: householdAppeal.appealStatus.map((s) => ({
+		status: s.status,
+		createdAt: s.createdAt.toISOString()
+	}))
 };
 
 const s78AppealDto = {
@@ -279,7 +297,28 @@ const s78AppealDto = {
 	createdAt: fullPlanningAppeal.caseCreatedDate.toISOString(),
 	startedAt: fullPlanningAppeal.caseStartedDate?.toISOString(),
 	validAt: fullPlanningAppeal.caseValidDate?.toISOString(),
-	enforcementNotice: { appellantCase: {}, appealOutcome: {} }
+	enforcementNotice: { appellantCase: {}, appealOutcome: {} },
+	appellantCase: {
+		numberOfResidencesNetChange: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		applicationMadeUnderActSection: null,
+		isEnforcementChild: false,
+		planningObligation:
+			fullPlanningAppeal.appellantCase.planningObligation !== undefined
+				? {
+						hasObligation: fullPlanningAppeal.appellantCase.planningObligation,
+						status: fullPlanningAppeal.appellantCase.statusPlanningObligation
+					}
+				: null,
+		enforcementNotice: null
+	},
+	resubmitTypeId: null,
+	resubmitType: null,
+	caseNotes: [],
+	appealStatusHistory: fullPlanningAppeal.appealStatus.map((s) => ({
+		status: s.status,
+		createdAt: s.createdAt.toISOString()
+	}))
 };
 
 const folders = [

--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
@@ -1,7 +1,8 @@
 import {
 	checkAppealExistsByCaseReferenceAndAddToRequest,
 	checkAppealExistsById,
-	checkAppealExistsByIdAndAddPartialToRequest
+	checkAppealExistsByIdAndAddPartialToRequest,
+	checkAppealExistsByIdForPageDisplayAndAddToRequest
 } from '#middleware/check-appeal-exists-and-add-to-request.js';
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
@@ -64,6 +65,29 @@ router.get(
 	 */
 	getAppealValidator,
 	asyncHandler(checkAppealExistsByIdAndAddPartialToRequest([])),
+	asyncHandler(controller.getAppeal)
+);
+
+router.get(
+	'/:appealId/page-details',
+	/*
+		#swagger.tags = ['Appeal Details']
+		#swagger.path = '/appeals/{appealId}/page-details'
+		#swagger.description = Gets a single appeal by ID with optimized includes for the page display
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.responses[200] = {
+			description: 'Gets a single appeal by ID optimized for page display',
+			schema: { $ref: '#/components/schemas/Appeal' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	getAppealValidator,
+	asyncHandler(checkAppealExistsByIdForPageDisplayAndAddToRequest),
 	asyncHandler(controller.getAppeal)
 );
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -785,6 +785,7 @@ interface FolderInfo {
 	folderId: number;
 	caseId: string;
 	path: string;
+	documentCount?: number;
 	documents: DocumentInfo[];
 }
 

--- a/appeals/api/src/server/mappers/api/shared/map-folders-documents.js
+++ b/appeals/api/src/server/mappers/api/shared/map-folders-documents.js
@@ -99,6 +99,10 @@ export const mapAppealFolders = (data) => {
 				caseId: folder.caseId,
 				folderId: folder.id,
 				path: folder.path,
+				documentCount:
+					/** @type {Object<string, any>} */ (folder)._count?.documents ??
+					folder.documents?.length ??
+					0,
 				documents: mapDocuments(folder.documents)
 			};
 		});

--- a/appeals/api/src/server/mappers/mapper-factory.js
+++ b/appeals/api/src/server/mappers/mapper-factory.js
@@ -15,6 +15,7 @@ import { contextEnum } from './context-enum.js';
 import { integrationMappers } from './integration/index.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {Appeal & { caseNotes?: (import('@pins/appeals.api').Schema.CaseNote & { user: import('@pins/appeals.api').Schema.User })[], appealStatus?: import('@pins/appeals.api').Schema.AppealStatus[] }} AppealWithRelations */
 /** @typedef {import('@pins/appeals.api').Schema.AppealType} AppealType */
 /** @typedef {import('@pins/appeals.api').Api.Appeal} AppealDTO */
 /** @typedef {import('@pins/appeals.api').Api.AppellantCase} AppellantCaseDto */
@@ -24,7 +25,7 @@ import { integrationMappers } from './integration/index.js';
 /** @typedef {AppealDTO|AppellantCaseDto|LpaQuestionnaireDTO|AppealHASCase|AppealS78Case} MapResult */
 /** @typedef {import('@pins/appeals.api').Api.Folder} Folder */
 /** @typedef {import('@pins/appeals').CostsDecision} CostsDecision */
-/** @typedef {{ appeal: Appeal, appealTypes?: AppealType[]|undefined, linkedAppeals?: *[]|undefined, costsDecision?: CostsDecision|undefined, context?: keyof contextEnum }} MappingRequest */
+/** @typedef {{ appeal: AppealWithRelations, appealTypes?: AppealType[]|undefined, linkedAppeals?: *[]|undefined, costsDecision?: CostsDecision|undefined, context?: keyof contextEnum }} MappingRequest */
 
 /**
  *
@@ -217,7 +218,7 @@ const createMap = (mappers, mappingRequest) =>
  * @param {MappingRequest} mappingRequest
  */
 function createDataLayout(caseMap, mappingRequest) {
-	const { context, appeal } = mappingRequest;
+	const { context, appeal, appealTypes } = mappingRequest;
 
 	if (context === contextEnum.broadcast) {
 		return Array.from(caseMap.values()).reduce((acc, val) => ({ ...acc, ...val }), {});
@@ -273,6 +274,51 @@ function createDataLayout(caseMap, mappingRequest) {
 				...appealDetails,
 				appellantCaseId: appeal.appellantCase?.id,
 				lpaQuestionnaireId: appeal.lpaQuestionnaire?.id,
+				appellantCase: {
+					numberOfResidencesNetChange: appeal.appellantCase?.numberOfResidencesNetChange ?? null,
+					screeningOpinionIndicatesEiaRequired:
+						appeal.appellantCase?.screeningOpinionIndicatesEiaRequired ?? null,
+					applicationMadeUnderActSection:
+						appeal.appellantCase?.applicationMadeUnderActSection ?? null,
+					isEnforcementChild: appellantCase?.isEnforcementChild ?? false,
+					planningObligation:
+						appeal.appellantCase?.planningObligation !== undefined
+							? {
+									hasObligation: appeal.appellantCase.planningObligation,
+									status: appeal.appellantCase.statusPlanningObligation ?? null
+								}
+							: null,
+					enforcementNotice:
+						appeal.appellantCase?.enforcementNotice || appeal.appellantCase?.enforcementReference
+							? {
+									reference: appeal.appellantCase.enforcementReference ?? null
+								}
+							: null
+				},
+				resubmitTypeId: appeal.caseResubmittedTypeId,
+				resubmitType:
+					appeal.caseResubmittedTypeId && appealTypes
+						? (() => {
+								const found = appealTypes.find((t) => t.id === appeal.caseResubmittedTypeId);
+								return found ? { id: found.id, key: found.key, type: found.type } : null;
+							})()
+						: null,
+				caseNotes: appeal.caseNotes
+					? appeal.caseNotes
+							.filter((caseNote) => !caseNote.archived)
+							.map((caseNote) => ({
+								id: caseNote.id,
+								comment: caseNote.comment,
+								createdAt: caseNote.createdAt.toISOString(),
+								azureAdUserId: caseNote.user?.azureAdUserId
+							}))
+					: [],
+				appealStatusHistory: appeal.appealStatus
+					? appeal.appealStatus.map((s) => ({
+							status: s.status,
+							createdAt: s.createdAt.toISOString()
+						}))
+					: [],
 				healthAndSafety: {
 					appellantCase: { ...appellantCase?.healthAndSafety },
 					lpaQuestionnaire: { ...(lpaQuestionnaire?.healthAndSafety ?? null) }

--- a/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
+++ b/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
@@ -87,6 +87,24 @@ export const checkAppealExistsByIdAndAddPartialToRequest =
 /**
  * @type {import('express').Handler}
  */
+export const checkAppealExistsByIdForPageDisplayAndAddToRequest = async (req, res, next) => {
+	const {
+		params: { appealId }
+	} = req;
+
+	const appeal = await appealRepository.getAppealByIdForPageDisplay(Number(appealId));
+
+	if (!appeal || !isAppealTypeEnabled(appeal.appealType?.key || '')) {
+		return res.status(404).send({ errors: { appealId: ERROR_NOT_FOUND } });
+	}
+
+	req.appeal = appeal;
+	next();
+};
+
+/**
+ * @type {import('express').Handler}
+ */
 export const checkAppealExistsById = async (req, res, next) => {
 	const {
 		params: { appealId }

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -301,6 +301,54 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/page-details": {
+			"get": {
+				"tags": ["Appeal Details"],
+				"description": "Gets a single appeal by ID with optimized includes for the page display",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Gets a single appeal by ID optimized for page display",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Appeal"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Appeal"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
 		"/appeals/case-reference/{caseReference}": {
 			"get": {
 				"tags": ["Appeal Details"],

--- a/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
+++ b/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
@@ -3,7 +3,7 @@
 import { databaseConnector } from '#utils/database-connector.js';
 import { jest } from '@jest/globals';
 import appealRepository, {
-	appealDetailsInclude,
+	appealDetailsIncludeMap,
 	buildAppealInclude
 } from '../appeal.repository.js';
 
@@ -36,7 +36,7 @@ describe('buildAppealInclude', () => {
 
 		expect(result).not.toBeNull();
 		expect(Object.keys(result)).toEqual(['lpaQuestionnaire']);
-		expect(result.lpaQuestionnaire).toEqual(appealDetailsInclude.lpaQuestionnaire);
+		expect(result.lpaQuestionnaire).toEqual(appealDetailsIncludeMap.lpaQuestionnaire);
 	});
 
 	it('returns null when selectedKeys is not empty and includeDetails = false', () => {

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -1076,11 +1076,381 @@ const getAppealReference = async (appealId) => {
 	return appeal?.reference ?? '';
 };
 
+/**
+ * @type {import('#db-client/models.ts').AppealSelect}
+ **/
+export const appealDetailsPageDisplaySelect = /** @type {Object} */ {
+	id: true,
+	reference: true,
+	currentStatus: true,
+	applicationReference: true,
+	caseCreatedDate: true,
+	caseValidDate: true,
+	caseExtensionDate: true,
+	caseStartedDate: true,
+	withdrawalRequestDate: true,
+	caseResubmittedTypeId: true,
+	caseTransferredId: true,
+	eiaScreeningRequired: true,
+	padsInspectorUserId: true,
+	address: true,
+	procedureType: {
+		select: {
+			name: true
+		}
+	},
+	parentAppeals: {
+		select: {
+			type: true,
+			linkingDate: true,
+			parent: {
+				select: {
+					id: true,
+					reference: true
+				}
+			}
+		}
+	},
+	childAppeals: {
+		select: {
+			type: true,
+			linkingDate: true,
+			child: {
+				select: {
+					id: true,
+					reference: true
+				}
+			}
+		}
+	},
+	neighbouringSites: {
+		select: {
+			id: true,
+			source: true,
+			address: {
+				select: {
+					addressLine1: true,
+					addressLine2: true,
+					addressTown: true,
+					addressCounty: true,
+					postcode: true
+				}
+			}
+		}
+	},
+	allocation: {
+		select: {
+			level: true,
+			band: true
+		}
+	},
+	specialisms: {
+		select: {
+			specialism: {
+				select: {
+					name: true
+				}
+			}
+		}
+	},
+	appellantCase: {
+		select: {
+			id: true,
+			appellantCaseValidationOutcome: true,
+			knowsOtherOwners: true,
+			knowsAllOwners: true,
+			appellantCaseAdvertDetails: true,
+			contactAddress: true,
+			siteSafetyDetails: true,
+			numberOfResidencesNetChange: true,
+			screeningOpinionIndicatesEiaRequired: true,
+			applicationMadeUnderActSection: true,
+			planningObligation: true,
+			statusPlanningObligation: true,
+			enforcementReference: true
+		}
+	},
+	appellant: {
+		select: {
+			id: true,
+			firstName: true,
+			lastName: true,
+			organisationName: true,
+			email: true,
+			phoneNumber: true
+		}
+	},
+	agent: {
+		select: {
+			id: true,
+			firstName: true,
+			lastName: true,
+			organisationName: true,
+			email: true,
+			phoneNumber: true
+		}
+	},
+	lpa: {
+		select: {
+			name: true,
+			email: true
+		}
+	},
+	appealStatus: {
+		select: {
+			status: true,
+			valid: true,
+			createdAt: true
+		}
+	},
+	appealTimetable: {
+		select: {
+			id: true,
+			lpaQuestionnaireDueDate: true,
+			caseResubmissionDueDate: true,
+			ipCommentsDueDate: true,
+			lpaStatementDueDate: true,
+			finalCommentsDueDate: true,
+			s106ObligationDueDate: true,
+			issueDeterminationDate: true,
+			proofOfEvidenceAndWitnessesDueDate: true,
+			caseManagementConferenceDueDate: true,
+			planningObligationDueDate: true,
+			statementOfCommonGroundDueDate: true
+		}
+	},
+	appealType: {
+		select: {
+			id: true,
+			type: true,
+			key: true
+		}
+	},
+	assignedTeam: {
+		select: {
+			id: true,
+			name: true,
+			email: true
+		}
+	},
+	caseOfficer: {
+		select: {
+			azureAdUserId: true
+		}
+	},
+	inspector: {
+		select: {
+			azureAdUserId: true
+		}
+	},
+	inspectorDecision: {
+		select: {
+			outcome: true,
+			decisionLetterGuid: true,
+			caseDecisionOutcomeDate: true,
+			invalidDecisionReason: true
+		}
+	},
+	lpaQuestionnaire: {
+		select: {
+			id: true,
+			lpaqCreatedDate: true,
+			lpaQuestionnaireValidationOutcome: {
+				select: {
+					name: true
+				}
+			},
+			siteSafetyDetails: true
+		}
+	},
+	siteVisit: {
+		where: {
+			whoMissedSiteVisit: null
+		},
+		select: {
+			id: true,
+			visitDate: true,
+			visitStartTime: true,
+			visitEndTime: true,
+			siteVisitType: {
+				select: {
+					name: true
+				}
+			}
+		}
+	},
+	hearing: {
+		select: {
+			id: true,
+			hearingStartTime: true,
+			hearingEndTime: true,
+			estimatedDays: true,
+			addressId: true,
+			address: {
+				select: {
+					addressLine1: true,
+					addressLine2: true,
+					addressTown: true,
+					addressCounty: true,
+					postcode: true
+				}
+			}
+		}
+	},
+	inquiry: {
+		select: {
+			id: true,
+			inquiryStartTime: true,
+			inquiryEndTime: true,
+			addressId: true,
+			estimatedDays: true,
+			address: {
+				select: {
+					addressLine1: true,
+					addressLine2: true,
+					addressTown: true,
+					addressCounty: true,
+					postcode: true
+				}
+			}
+		}
+	},
+	representations: {
+		select: {
+			id: true,
+			representationType: true,
+			dateCreated: true,
+			isRedacted: true,
+			representedId: true,
+			status: true
+		}
+	},
+	hearingEstimate: {
+		select: {
+			id: true,
+			preparationTime: true,
+			sittingTime: true,
+			reportingTime: true
+		}
+	},
+	inquiryEstimate: {
+		select: {
+			id: true,
+			preparationTime: true,
+			sittingTime: true,
+			reportingTime: true
+		}
+	},
+	appealGrounds: {
+		where: {
+			isDeleted: false
+		},
+		select: {
+			factsForGround: true,
+			isDeleted: true,
+			ground: {
+				select: {
+					groundRef: true,
+					groundDescription: true
+				}
+			}
+		}
+	},
+	appealRule6Parties: {
+		select: {
+			id: true,
+			serviceUser: {
+				select: {
+					id: true,
+					organisationName: true,
+					email: true
+				}
+			}
+		}
+	},
+	enforcementNoticeAppealOutcome: {
+		select: {
+			id: true,
+			groundABarred: true,
+			otherInformation: true,
+			enforcementNoticeInvalid: true,
+			otherLiveAppeals: true,
+			groundAFeeReceiptDueDate: true
+		}
+	},
+	folders: {
+		select: {
+			id: true,
+			path: true,
+			caseId: true,
+			_count: {
+				select: {
+					documents: {
+						where: {
+							isDeleted: false
+						}
+					}
+				}
+			},
+			documents: {
+				where: {
+					isDeleted: false
+				},
+				orderBy: {
+					createdAt: 'desc'
+				},
+				take: 1,
+				select: {
+					guid: true,
+					name: true,
+					isDeleted: true,
+					latestDocumentVersion: {
+						select: {
+							documentGuid: true,
+							dateReceived: true,
+							isDeleted: true,
+							stage: true,
+							documentType: true
+						}
+					}
+				}
+			}
+		}
+	},
+	caseNotes: {
+		include: {
+			user: true
+		},
+		orderBy: {
+			createdAt: 'desc'
+		}
+	}
+};
+
+/**
+ * @param {number} id
+ * @returns {Promise<Appeal|undefined>}
+ */
+const getAppealByIdForPageDisplay = async (id) => {
+	const appeal = await databaseConnector.appeal.findUnique({
+		where: {
+			id
+		},
+		select: appealDetailsPageDisplaySelect
+	});
+
+	if (appeal) {
+		// @ts-ignore
+		return appeal;
+	}
+};
+
 export default {
 	checkAppealExistsById,
 	getLinkedAppeals,
 	getLinkedAppealsById,
 	getAppealById,
+	getAppealByIdForPageDisplay,
 	deprecatedGetAppealById,
 	getAppealTypeById,
 	deprecatedGetAppealByAppealReference,

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -112,7 +112,7 @@ describe('appeal-details', () => {
 			it('should render the case-team section for appeal with team name and email displayed"', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -132,7 +132,7 @@ describe('appeal-details', () => {
 			it('should render the case-team section for appeal with not assigned displayed when no team is assigned"', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -151,7 +151,7 @@ describe('appeal-details', () => {
 			it('should render the case-team section for appeal with not assigned displayed when only team name exists"', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -176,7 +176,7 @@ describe('appeal-details', () => {
 				it('should render a "Appeal ready to be assigned to case officer" important notification banner with a link to assign case officer when status is "Assign case officer"', async () => {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, { ...appealData, appealId, appealStatus: 'assign_case_officer' });
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 
@@ -221,7 +221,7 @@ describe('appeal-details', () => {
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
@@ -263,7 +263,7 @@ describe('appeal-details', () => {
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
-						.get(`/appeals/${appealData.appealId}?include=all`)
+						.get(`/appeals/${appealData.appealId}/page-details`)
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
@@ -303,7 +303,7 @@ describe('appeal-details', () => {
 						.get(`/appeals/${appealData.appealId}?include=neighbouringSites`)
 						.reply(200, appealData);
 					nock('http://test/')
-						.get(`/appeals/${appealData.appealId}?include=all`)
+						.get(`/appeals/${appealData.appealId}/page-details`)
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
@@ -332,10 +332,15 @@ describe('appeal-details', () => {
 
 					nock.cleanAll();
 					nock('http://test/')
+						.get(`/appeals/${appealData.appealId}`)
+						.query(true)
+						.reply(200, appealData)
+						.persist();
+					nock('http://test/')
 						.get(`/appeals/linkable-appeal/${appealReference}/linked`)
 						.reply(200, linkableAppealSummaryBackOffice);
 					nock('http://test/')
-						.get(`/appeals/${appealData.appealId}?include=all`)
+						.get(`/appeals/${appealData.appealId}/page-details`)
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/').post(`/appeals/${appealData.appealId}/link-appeal`).reply(200, {
@@ -375,10 +380,15 @@ describe('appeal-details', () => {
 
 					nock.cleanAll();
 					nock('http://test/')
+						.get(`/appeals/${appealData.appealId}`)
+						.query(true)
+						.reply(200, appealData)
+						.persist();
+					nock('http://test/')
 						.get(`/appeals/linkable-appeal/${appealReference}/linked`)
 						.reply(200, linkableAppealSummaryHorizon);
 					nock('http://test/')
-						.get(`/appeals/${appealData.appealId}?include=all`)
+						.get(`/appeals/${appealData.appealId}/page-details`)
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
@@ -420,7 +430,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a user was successfully assigned as case officer', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealData.appealId}?include=all`)
+						.get(`/appeals/${appealData.appealId}/page-details`)
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
@@ -461,7 +471,7 @@ describe('appeal-details', () => {
 
 				it('should render a success notification banner when a user was successfully assigned as inspector', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealData.appealId}?include=all`)
+						.get(`/appeals/${appealData.appealId}/page-details`)
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
@@ -815,7 +825,7 @@ describe('appeal-details', () => {
 				});
 
 				it('should render a success notification banner when a agent was updated', async () => {
-					nock('http://test/').get(`/appeals/1?include=all`).reply(200, appealData).persist();
+					nock('http://test/').get(`/appeals/1/page-details`).reply(200, appealData).persist();
 					nock('http://test/').patch(`/appeals/1/service-user`).reply(200, {
 						serviceUserId: 1
 					});
@@ -841,7 +851,7 @@ describe('appeal-details', () => {
 				});
 
 				it('should render a success notification banner when an appellant was updated', async () => {
-					nock('http://test/').get(`/appeals/1?include=all`).reply(200, appealData).persist();
+					nock('http://test/').get(`/appeals/1/page-details`).reply(200, appealData).persist();
 					nock('http://test/').patch(`/appeals/1/service-user`).reply(200, {
 						serviceUserId: 1
 					});
@@ -870,7 +880,12 @@ describe('appeal-details', () => {
 					const appealId = appealData.appealId.toString();
 					nock.cleanAll();
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}`)
+						.query(true)
+						.reply(200, { ...appealData, lpaQuestionnaireId: undefined })
+						.persist();
+					nock('http://test/')
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, { ...appealData, lpaQuestionnaireId: undefined })
 						.persist();
 					nock('http://test/')
@@ -1096,7 +1111,7 @@ describe('appeal-details', () => {
 							inspectorName: null
 						})
 						.reply(201, { hearingId: 1 });
-					nock('http://test/').get(`/appeals/1?include=all`).reply(200, appealData).persist();
+					nock('http://test/').get(`/appeals/1/page-details`).reply(200, appealData).persist();
 
 					// set session data with post requests to previous pages
 					await request.post(`${baseUrl}/${appealId}/hearing/setup/date`).send(dateValues);
@@ -1150,7 +1165,7 @@ describe('appeal-details', () => {
 							inspectorName: null
 						})
 						.reply(201, { hearingId: 1 });
-					nock('http://test/').get(`/appeals/1?include=all`).reply(200, appealData).persist();
+					nock('http://test/').get(`/appeals/1/page-details`).reply(200, appealData).persist();
 
 					// set session data with post requests to previous pages
 					await request.post(`${baseUrl}/${appealId}/hearing/change/date`).send(dateValues);
@@ -1187,7 +1202,7 @@ describe('appeal-details', () => {
 					const appealId = 2;
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, { ...appealData, appealId, appealStatus: 'awaiting_transfer' });
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 
@@ -1216,7 +1231,7 @@ describe('appeal-details', () => {
 							]
 						});
 					nock('http://test/')
-						.get('/appeals/2?include=all')
+						.get('/appeals/2/page-details')
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId: 2,
@@ -1280,7 +1295,7 @@ describe('appeal-details', () => {
 							]
 						});
 					nock('http://test/')
-						.get('/appeals/2?include=all')
+						.get('/appeals/2/page-details')
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId: 2,
@@ -1344,7 +1359,7 @@ describe('appeal-details', () => {
 							]
 						});
 					nock('http://test/')
-						.get('/appeals/2?include=all')
+						.get('/appeals/2/page-details')
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId: 2,
@@ -1402,7 +1417,7 @@ describe('appeal-details', () => {
 					const appealId = 2;
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -1440,7 +1455,7 @@ describe('appeal-details', () => {
 					const lpaQuestionnaireId = 123;
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -1480,7 +1495,7 @@ describe('appeal-details', () => {
 					const appealId = 2;
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -1499,7 +1514,7 @@ describe('appeal-details', () => {
 					const appealId = 2;
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -1528,7 +1543,7 @@ describe('appeal-details', () => {
 					const appealId = '2';
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealStatus: 'issue_determination',
@@ -1554,14 +1569,14 @@ describe('appeal-details', () => {
 					const appealId = 2;
 					const resetMocks = () => {
 						nock.cleanAll();
-						nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 						nock('http://test/')
 							.get(`/appeals/${appealId}/reps?type=appellant_final_comment,lpa_final_comment`)
-							.reply(200, {
-								itemCount: 2,
-								items: [...finalCommentsForReview.items, ...lpaFinalCommentsAwaitingReview.items]
-							})
+							.reply(200, { itemCount: 0, items: [] })
 							.persist();
+						nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+						nock('http://test/')
+							.get(/appeals\/\d+\/appellant-cases\/\d+/)
+							.reply(200, { planningObligation: { hasObligation: false } });
 					};
 
 					beforeEach(() => {
@@ -1572,7 +1587,7 @@ describe('appeal-details', () => {
 						'should render a "Add number of residential units" important notification banner a link to add residential units when numberOfResidencesNetChange has not been added for %s',
 						async (appealType) => {
 							nock('http://test/')
-								.get(`/appeals/${appealId}?include=all`)
+								.get(`/appeals/${appealId}/page-details`)
 								.reply(200, {
 									...appealData,
 									appealId,
@@ -1610,7 +1625,7 @@ describe('appeal-details', () => {
 						'should render a "Add number of residential units" important notification banner even when case is complete if numberOfResidencesNetChange has not been added for %s',
 						async (appealType) => {
 							nock('http://test/')
-								.get(`/appeals/${appealId}?include=all`)
+								.get(`/appeals/${appealId}/page-details`)
 								.reply(200, {
 									...appealData,
 									appealId,
@@ -1624,6 +1639,7 @@ describe('appeal-details', () => {
 									planningObligation: { hasObligation: false },
 									numberOfResidencesNetChange: null
 								});
+							nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 
 							const response = await request.get(`${baseUrl}/${appealId}`);
 
@@ -1648,7 +1664,7 @@ describe('appeal-details', () => {
 					it('should not render a "Add number of residential units" important notification banner when appeal type is not S78', async () => {
 						nock.cleanAll();
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -1677,7 +1693,7 @@ describe('appeal-details', () => {
 					it('should not render a "Add number of residential units" important notification banner if numberOfResidencesNetChange has been added', async () => {
 						nock.cleanAll();
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -1706,7 +1722,7 @@ describe('appeal-details', () => {
 					it('should not render a "Add number of residential units" important notification banner if numberOfResidencesNetChange has been added and set to 0', async () => {
 						nock.cleanAll();
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -1760,6 +1776,7 @@ describe('appeal-details', () => {
 
 				const resetMocks = () => {
 					nock.cleanAll();
+					nock('http://test/').get(`/appeals/${appealId}/exists`).reply(200, { id: appealId });
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 					nock('http://test/')
 						.get(/appeals\/\d+\/appellant-cases\/\d+/)
@@ -1780,7 +1797,7 @@ describe('appeal-details', () => {
 							})
 							.persist();
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealDataFullPlanning,
 								appealId,
@@ -1885,7 +1902,7 @@ describe('appeal-details', () => {
 							})
 							.persist();
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealDataFullPlanning,
 								appealId,
@@ -1948,6 +1965,9 @@ describe('appeal-details', () => {
 							caseOfficer: 'updatedCaseOfficerId'
 						});
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+					nock('http://test/')
+						.get(`/appeals/${appealId}/page-details`)
+						.reply(200, appealInValidationStatus);
 
 					await request
 						.post(`${baseUrl}/${appealId}/assign-case-officer/search-case-officer`)
@@ -1982,7 +2002,7 @@ describe('appeal-details', () => {
 		describe('Case notes', () => {
 			it('should render the case note details', async () => {
 				const appealId = appealData.appealId.toString();
-				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealData);
+				nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appealData);
 				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 				const response = await request.get(`${baseUrl}/${appealId}`);
 
@@ -1996,12 +2016,13 @@ describe('appeal-details', () => {
 			});
 			it('should submit a new case note and re-render case details', async () => {
 				nock.cleanAll();
+				nock('http://test/').get(`/appeals/${appealId}/exists`).reply(200, { id: appealId });
 				const appealId = appealData.appealId.toString();
 				const caseNotesResponse = [...caseNotes];
 				const comment = 'This is a new comment';
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
-					.reply(200, appealData)
+					.get(`/appeals/${appealId}/page-details`)
+					.reply(200, () => appealData)
 					.persist();
 				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotesResponse);
 				nock('http://test/')
@@ -2029,8 +2050,10 @@ describe('appeal-details', () => {
 					comment,
 					azureAdUserId: '923ac03b-9031-4cf4-8b17-348c274321f9'
 				});
+				appealData.caseNotes = caseNotesResponse;
 				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotesResponse);
 				const renderResponse = await request.get(`${baseUrl}/${appealId}?include=all`);
+				appealData.caseNotes = caseNotes;
 				expect(renderResponse.statusCode).toBe(200);
 				expect(submitRequest.isDone()).toBe(true);
 
@@ -2043,11 +2066,12 @@ describe('appeal-details', () => {
 			});
 			it('should not submit and  re-render case details with an error if the string is empty', async () => {
 				nock.cleanAll();
+				nock('http://test/').get(`/appeals/${appealId}/exists`).reply(200, { id: appealId });
 				const appealId = appealData.appealId.toString();
 				const caseNotesResponse = [...caseNotes];
 				const comment = '';
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, appealData)
 					.persist();
 				nock('http://test/')
@@ -2086,12 +2110,13 @@ describe('appeal-details', () => {
 			});
 			it('should not submit and re-render case details with an error if the comment exceeds the character limit', async () => {
 				nock.cleanAll();
+				nock('http://test/').get(`/appeals/${appealId}/exists`).reply(200, { id: appealId });
 				const appealId = appealData.appealId.toString();
 				const caseNotesResponse = [...caseNotes];
 				const comment = 'a'.repeat(501);
 
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, appealData)
 					.persist();
 				nock('http://test/')
@@ -2115,7 +2140,7 @@ describe('appeal-details', () => {
 					.post(`/appeals/${appealId}/case-notes`)
 					.reply(200, {});
 
-				await request.get(`${baseUrl}/${appealId}?include=all`);
+				await request.get(`${baseUrl}/${appealId}`);
 
 				const response = await request.post(`${baseUrl}/${appealId}`).send({ comment: comment });
 				expect(response.statusCode).toBe(200);
@@ -2138,7 +2163,7 @@ describe('appeal-details', () => {
 		describe('Case download', () => {
 			it('should render the case download link', async () => {
 				const appealId = appealData.appealId.toString();
-				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealData);
+				nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appealData);
 				const response = await request.get(`${baseUrl}/${appealId}`);
 
 				const element = parseHtml(response.text, {
@@ -2236,7 +2261,7 @@ describe('appeal-details', () => {
 					const appealId = 2;
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -2263,7 +2288,7 @@ describe('appeal-details', () => {
 			it('should render the received appeal details for a valid appealId with no linked/other appeals', async () => {
 				const appealId = appealData.appealId.toString();
 
-				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, undefined);
+				nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, undefined);
 				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 				const response = await request.get(`${baseUrl}/${appealId}`);
 				const element = parseHtml(response.text);
@@ -2294,7 +2319,7 @@ describe('appeal-details', () => {
 			it('should render an action link to the manage linked appeals page, if there are linked appeals, the status is not past LPA Questionnaire, all the linked appeals are children and internal', async () => {
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/${appealData.appealId}?include=all`)
+					.get(`/appeals/${appealData.appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealStatus: 'lpa_questionnaire',
@@ -2332,7 +2357,7 @@ describe('appeal-details', () => {
 			it('should render an action link to the add linked appeals page, if the appeal is a lead appeal in a state before STATEMENTS', async () => {
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/${appealData.appealId}?include=all`)
+					.get(`/appeals/${appealData.appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						isParentAppeal: true,
@@ -2371,7 +2396,7 @@ describe('appeal-details', () => {
 			it('should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal', async () => {
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/${appealData.appealId}?include=all`)
+					.get(`/appeals/${appealData.appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -2413,7 +2438,7 @@ describe('appeal-details', () => {
 			it('should render the case reference for each linked appeal in the linked appeals row, with each internal linked appeal item linking to the respective case details page, if there are linked appeals', async () => {
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/${appealData.appealId}?include=all`)
+					.get(`/appeals/${appealData.appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -2469,7 +2494,7 @@ describe('appeal-details', () => {
 				const appealId = '2';
 
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -2507,7 +2532,7 @@ describe('appeal-details', () => {
 				const appealId = '3';
 
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -2552,7 +2577,7 @@ describe('appeal-details', () => {
 			it('should render the lead or child status after the case reference link of each linked appeal in the linked appeals row, if there are linked appeals', async () => {
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/${appealData.appealId}?include=all`)
+					.get(`/appeals/${appealData.appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -2593,7 +2618,7 @@ describe('appeal-details', () => {
 			it('should render a lead tag next to the appeal status tag if the appeal is a parent', async () => {
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/${appealData.appealId}?include=all`)
+					.get(`/appeals/${appealData.appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -2626,7 +2651,7 @@ describe('appeal-details', () => {
 			it('should render a child tag next to the appeal status tag if the appeal is a child', async () => {
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/${appealData.appealId}?include=all`)
+					.get(`/appeals/${appealData.appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -2660,7 +2685,7 @@ describe('appeal-details', () => {
 			it('should not render a "Appeal valid" notification banner when status is "READY_TO_START" and appeal is a linked child appeal', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -2682,9 +2707,10 @@ describe('appeal-details', () => {
 			nock.cleanAll();
 			const appealId = appealData.appealId;
 			const comment = 'This is a new comment';
-			nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealData).persist();
-			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
-
+			nock('http://test/')
+				.get(`/appeals/${appealId}/page-details`)
+				.reply(200, appealData)
+				.persist();
 			nock('http://test/')
 				.get(`/appeals/${appealId}/reps?type=appellant_final_comment`)
 				.reply(200, appellantFinalCommentsAwaitingReview);
@@ -2693,7 +2719,7 @@ describe('appeal-details', () => {
 				.reply(200, lpaFinalCommentsAwaitingReview);
 
 			const submitRequest = nock('http://test/').post(`/appeals/${appealId}/case-notes`).reply(500);
-			await request.get(`${baseUrl}/${appealId}?include=all`);
+			await request.get(`${baseUrl}/${appealId}/page-details`);
 
 			const response = await request.post(`${baseUrl}/${appealId}`).send({ comment: comment });
 			expect(response.statusCode).toBe(500);
@@ -2703,8 +2729,7 @@ describe('appeal-details', () => {
 		it('should render the header with navigation containing links to the personal list, national list, and sign out route, without any active modifier classes', async () => {
 			const appealId = appealData.appealId.toString();
 
-			nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, undefined);
-			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+			nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appealData);
 			const response = await request.get(`${baseUrl}/${appealId}`);
 			const element = parseHtml(response.text, { rootElement: 'header' });
 
@@ -2724,7 +2749,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, { ...appealData, startedAt: null });
 			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 			const response = await request.get(`${baseUrl}/${appealId}`);
@@ -2742,7 +2767,7 @@ describe('appeal-details', () => {
 		it('should render a page not found when the appealId is not valid/does not exist', async () => {
 			const appealIdThatDoesNotExist = 999;
 
-			nock('http://test/').get(`/appeals/${appealIdThatDoesNotExist}?include=all`).reply(404);
+			nock('http://test/').get(`/appeals/${appealIdThatDoesNotExist}/page-details`).reply(404);
 			const response = await request.get(`${baseUrl}/${appealIdThatDoesNotExist}`);
 
 			expect(response.statusCode).toBe(404);
@@ -2757,7 +2782,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealStatus: 'complete',
@@ -2789,7 +2814,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealStatus: 'complete',
@@ -2821,7 +2846,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealType: APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING,
@@ -2850,7 +2875,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealType: APPEAL_TYPE.ENFORCEMENT_NOTICE,
@@ -2958,7 +2983,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealStatus: 'complete',
@@ -2988,7 +3013,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					decision: {
@@ -3021,7 +3046,7 @@ describe('appeal-details', () => {
 			const appealId = '2';
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealStatus: 'validation',
@@ -3054,7 +3079,7 @@ describe('appeal-details', () => {
 			const today = new Date();
 
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealStatus: 'validation',
@@ -3066,9 +3091,8 @@ describe('appeal-details', () => {
 					}
 				});
 			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
-			const response = await request.get(`${baseUrl}/${appealId}`);
-
 			jest.useRealTimers();
+			const response = await request.get(`${baseUrl}/${appealId}`);
 
 			expect(response.statusCode).toBe(200);
 			const element = parseHtml(response.text);
@@ -3083,7 +3107,7 @@ describe('appeal-details', () => {
 		it('should render a "Appeal valid" notification banner with a link to start case when status is "READY_TO_START"', async () => {
 			const appealId = 2;
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, { ...appealData, appealId, appealStatus: 'ready_to_start' });
 			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 			const response = await request.get(`${baseUrl}/${appealId}`);
@@ -3197,7 +3221,7 @@ describe('appeal-details', () => {
 			for (const testCase of testCases) {
 				it(`should render a "${testCase.bannerText}" important banner with the link to progress case from final comments with the expected content when Final Comments Due Date has passed and ${testCase.conditionName}.`, async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...testCase.appealData
 						})
@@ -3253,7 +3277,7 @@ describe('appeal-details', () => {
 				async (appealType) => {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3282,7 +3306,7 @@ describe('appeal-details', () => {
 
 			it('should not render a "Is there a net gain or loss of residential units?" row in the overview accordion if a S78 linked child appeal', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -3303,7 +3327,7 @@ describe('appeal-details', () => {
 
 			it('should not render a "Is there a net gain or loss of residential units?" row in the overview accordion if not S78 appeal', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -3327,11 +3351,14 @@ describe('appeal-details', () => {
 				async (appealType) => {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
-							appealType: appealType
+							appealType: appealType,
+							appellantCase: {
+								numberOfResidencesNetChange: 1
+							}
 						});
 					nock('http://test/')
 						.get(/appeals\/\d+\/appellant-cases\/\d+/)
@@ -3358,11 +3385,14 @@ describe('appeal-details', () => {
 				async (appealType) => {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
-							appealType: appealType
+							appealType: appealType,
+							appellantCase: {
+								numberOfResidencesNetChange: -1
+							}
 						});
 					nock('http://test/')
 						.get(/appeals\/\d+\/appellant-cases\/\d+/)
@@ -3389,11 +3419,14 @@ describe('appeal-details', () => {
 				async (appealType) => {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
-							appealType: appealType
+							appealType: appealType,
+							appellantCase: {
+								numberOfResidencesNetChange: 0
+							}
 						});
 					nock('http://test/')
 						.get(/appeals\/\d+\/appellant-cases\/\d+/)
@@ -3413,7 +3446,7 @@ describe('appeal-details', () => {
 				async (appealType) => {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3435,7 +3468,7 @@ describe('appeal-details', () => {
 			it('should not render net-residence-gain-or-loss row in the overview accordion if appeal type is not S78', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -3456,7 +3489,7 @@ describe('appeal-details', () => {
 			it('Should display procedure type change link because type is S78 and lpastatement status is not received', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -3495,7 +3528,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3541,7 +3574,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3587,7 +3620,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3633,7 +3666,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3682,7 +3715,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3731,7 +3764,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3780,7 +3813,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3829,7 +3862,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3878,7 +3911,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3927,7 +3960,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -3976,7 +4009,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -4025,7 +4058,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -4074,7 +4107,7 @@ describe('appeal-details', () => {
 				try {
 					const appealId = 2;
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -4106,7 +4139,7 @@ describe('appeal-details', () => {
 			it('Should not display procedure type change link because type is S78 and lpastatement status is received', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -4135,7 +4168,7 @@ describe('appeal-details', () => {
 			it('Should not display procedure type change link because type is S78 and lpastatement due date has elapsed', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -4167,7 +4200,7 @@ describe('appeal-details', () => {
 			it('Should not display case proceudre change link because appeal type is not S78', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -4196,10 +4229,15 @@ describe('appeal-details', () => {
 			it('Should display enforcement notice reference instead of LPA reference if appeal type is enforcement notice', async () => {
 				const appealId = 2;
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataEnforcementNotice,
-						appealId
+						appealId,
+						appellantCase: {
+							enforcementNotice: {
+								reference: 'ENF-123456789'
+							}
+						}
 					});
 				nock('http://test/')
 					.get(/appeals\/\d+\/appellant-cases\/\d+/)
@@ -4292,7 +4330,7 @@ describe('appeal-details', () => {
 
 				it('should render an "LPA Questionnaire" row with a status of "Incomplete" if the LPA questionnaire status is Incomplete and the due date has not yet passed', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -4323,7 +4361,7 @@ describe('appeal-details', () => {
 
 				it('should render an "LPA Questionnaire" row with a status of "Overdue" if the LPA questionnaire status is Incomplete and the due date has passed', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -4367,7 +4405,7 @@ describe('appeal-details', () => {
 							}
 						]
 					};
-					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appeal);
+					nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appeal);
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 					nock('http://test/')
 						.get(
@@ -4458,7 +4496,7 @@ describe('appeal-details', () => {
 							}
 						}
 					};
-					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appeal);
+					nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appeal);
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 					nock('http://test/')
 						.get(
@@ -4533,7 +4571,7 @@ describe('appeal-details', () => {
 						},
 						appealStatus: APPEAL_CASE_STATUS.STATEMENTS
 					};
-					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appeal);
+					nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appeal);
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 					nock('http://test/')
 						.get(
@@ -4585,7 +4623,7 @@ describe('appeal-details', () => {
 							}
 						}
 					};
-					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appeal);
+					nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appeal);
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 					nock('http://test/')
 						.get(
@@ -4641,7 +4679,7 @@ describe('appeal-details', () => {
 						}
 					};
 
-					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appeal);
+					nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appeal);
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 					nock('http://test/')
 						.get(
@@ -4710,7 +4748,7 @@ describe('appeal-details', () => {
 				for (const testCase of testCases) {
 					it(`should not render an "${testCase.rowLabel}" row, if the appeal type is "householder" (HAS)`, async () => {
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId
@@ -4728,7 +4766,7 @@ describe('appeal-details', () => {
 
 					it(`should not render an "${testCase.rowLabel}" row, if the appeal is a child linked appeal`, async () => {
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealDataFullPlanning,
 								isChildAppeal: true,
@@ -4747,7 +4785,7 @@ describe('appeal-details', () => {
 
 					it(`should render an "${testCase.rowLabel}" row with a status of "Not received" and nothing in the "Received" column, and no action link, if the appeal type is "planning appeal", and the appeal does not have ${testCase.name} final comments awaiting review`, async () => {
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealDataFullPlanning,
 								appealId,
@@ -4775,7 +4813,7 @@ describe('appeal-details', () => {
 
 					it(`should render an "${testCase.rowLabel}" row with a status of "Ready to review", and the expected date in the "Received" column, and a "Review" action link with the expected URL, if the appeal type is "planning appeal", and the appeal has ${testCase.name} final comments awaiting review`, async () => {
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealDataFullPlanning,
 								appealId,
@@ -4803,7 +4841,7 @@ describe('appeal-details', () => {
 
 					it(`should render an "${testCase.rowLabel}" row with a status of "Accepted", and the expected date in the "Received" column, and a "View" action link with the expected URL, if the appeal type is "planning appeal", and the appeal has valid/accepted ${testCase.name} final comments`, async () => {
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealDataFullPlanning,
 								appealId,
@@ -4831,7 +4869,7 @@ describe('appeal-details', () => {
 
 					it(`should render an "${testCase.rowLabel}" row with a status of "Rejected", and the expected date in the "Received" column, and a "Add | View" action link with the expected URL, if the appeal type is "planning appeal", and the appeal has invalid ${testCase.name} final comments`, async () => {
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealDataFullPlanning,
 								appealId,
@@ -4888,7 +4926,7 @@ describe('appeal-details', () => {
 
 				it('should not render an "Interested party comments" row if the appeal type is "Householder" (HAS)', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -4907,7 +4945,7 @@ describe('appeal-details', () => {
 
 				it('should render an "Interested party comments" row with a status of "No interested party comments received", and an "Add" action link to the first page of the add IP comment flow, if the appeal type is "planning appeal", and the appeal does not have IP comments awaiting review, and the statements due date has elapsed', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							appealId,
@@ -4978,7 +5016,7 @@ describe('appeal-details', () => {
 
 				it('should not render an "Environmental services team review" row if the review is not required', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5005,7 +5043,7 @@ describe('appeal-details', () => {
 
 				it('should render exactly one "Environmental services team review" row if the review is required', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5098,7 +5136,7 @@ describe('appeal-details', () => {
 
 				it('should render a "Timetable" with only a Valid date row with no date and no action link', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							validAt: null,
@@ -5130,7 +5168,7 @@ describe('appeal-details', () => {
 
 				it('should render a "Timetable" with only a Valid date row with no date and a validate action link', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							validAt: null,
@@ -5163,7 +5201,7 @@ describe('appeal-details', () => {
 
 				it('should render a "Timetable" with a Valid date row and a Start date row including no date and start action link', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							startedAt: null,
@@ -5204,7 +5242,7 @@ describe('appeal-details', () => {
 
 				it('should render a "Timetable" with all rows with the Start & IP comments due date rows, both including a date and change action link', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							caseOfficer: '2cb7735e-c4cf-410b-b773-5ec4cf110b87',
@@ -5269,7 +5307,7 @@ describe('appeal-details', () => {
 
 				it('should render a "Timetable" with all rows with the IP comments due date and change link displaying when published IP comments count equals zero', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							caseOfficer: '2cb7735e-c4cf-410b-b773-5ec4cf110b87',
@@ -5312,7 +5350,7 @@ describe('appeal-details', () => {
 					};
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							documentationSummary: testDocumentationSummary,
@@ -5389,7 +5427,7 @@ describe('appeal-details', () => {
 						});
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5477,7 +5515,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and has no planning obligation', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5531,7 +5569,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and has planning obligation', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5539,6 +5577,9 @@ describe('appeal-details', () => {
 							startedAt: '2025-01-01T00:00:00.000Z',
 							procedureType: APPEAL_CASE_PROCEDURE.HEARING,
 							hearing: null,
+							appellantCase: {
+								planningObligation: { hasObligation: true }
+							},
 							appealTimetable: {
 								validAt: '2025-01-01T00:00:00.000Z',
 								startedAt: '2025-01-01T00:00:00.000Z',
@@ -5590,7 +5631,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and planning obligation date has been set', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5598,6 +5639,9 @@ describe('appeal-details', () => {
 							startedAt: '2025-01-01T00:00:00.000Z',
 							procedureType: APPEAL_CASE_PROCEDURE.HEARING,
 							hearing: null,
+							appellantCase: {
+								planningObligation: { hasObligation: true }
+							},
 							appealTimetable: {
 								validAt: '2025-01-01T00:00:00.000Z',
 								startedAt: '2025-01-01T00:00:00.000Z',
@@ -5650,7 +5694,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and hearing has been set up', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5659,6 +5703,9 @@ describe('appeal-details', () => {
 							procedureType: APPEAL_CASE_PROCEDURE.HEARING,
 							hearing: {
 								hearingStartTime: '2025-01-08T10:00:00.000Z'
+							},
+							appellantCase: {
+								planningObligation: { hasObligation: true }
 							},
 							appealTimetable: {
 								validAt: '2025-01-01T00:00:00.000Z',
@@ -5721,7 +5768,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case started and has no planning obligation', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5778,7 +5825,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and has planning obligation', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -5787,6 +5834,9 @@ describe('appeal-details', () => {
 							procedureType: APPEAL_CASE_PROCEDURE.INQUIRY,
 							inquiry: {
 								inquiryStartTime: '2025-02-01T10:00:00.000Z'
+							},
+							appellantCase: {
+								planningObligation: { hasObligation: true }
 							},
 							appealTimetable: {
 								validAt: '2025-01-01T00:00:00.000Z',
@@ -5850,7 +5900,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and has no planning obligation', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataEnforcementNotice,
 							appealId,
@@ -5900,7 +5950,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and has planning obligation', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataEnforcementNotice,
 							appealId,
@@ -5908,6 +5958,9 @@ describe('appeal-details', () => {
 							startedAt: '2025-01-01T00:00:00.000Z',
 							procedureType: APPEAL_CASE_PROCEDURE.WRITTEN,
 							hearing: null,
+							appellantCase: {
+								planningObligation: { hasObligation: true }
+							},
 							appealTimetable: {
 								validAt: '2025-01-01T00:00:00.000Z',
 								startedAt: '2025-01-01T00:00:00.000Z',
@@ -5955,7 +6008,7 @@ describe('appeal-details', () => {
 
 				it('should render the correct rows when case has started and planning obligation date has been set', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataEnforcementNotice,
 							appealId,
@@ -5963,6 +6016,9 @@ describe('appeal-details', () => {
 							startedAt: '2025-01-01T00:00:00.000Z',
 							procedureType: APPEAL_CASE_PROCEDURE.WRITTEN,
 							hearing: null,
+							appellantCase: {
+								planningObligation: { hasObligation: true }
+							},
 							appealTimetable: {
 								validAt: '2025-01-01T00:00:00.000Z',
 								startedAt: '2025-01-01T00:00:00.000Z',
@@ -6022,7 +6078,7 @@ describe('appeal-details', () => {
 
 				it('should not contain any change action links', async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -6080,7 +6136,7 @@ describe('appeal-details', () => {
 
 			it('should not render the Hearing accordion for HAS cases', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId
@@ -6114,7 +6170,7 @@ describe('appeal-details', () => {
 					config.isChildAppeal ? 'not ' : ''
 				}render the site accordion for HAS cases when ${config.title}`, async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealData,
 							...config,
@@ -6151,7 +6207,7 @@ describe('appeal-details', () => {
 							});
 					}
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -6187,7 +6243,7 @@ describe('appeal-details', () => {
 					config.isChildAppeal ? 'not ' : ''
 				}render the site accordion for S78 Written cases when ${config.title}`, async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							...config,
@@ -6226,7 +6282,7 @@ describe('appeal-details', () => {
 					}
 
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -6247,7 +6303,7 @@ describe('appeal-details', () => {
 
 			it('should render the Hearing accordion with the expected content for s78 cases with a procedureType of "Hearing"', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -6292,7 +6348,7 @@ describe('appeal-details', () => {
 
 			it('should not render the Hearing accordion for enforcement notice child cases with a procedureType of "Hearing"', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataEnforcementNotice,
 						appealId,
@@ -6315,7 +6371,7 @@ describe('appeal-details', () => {
 
 			it('should render empty states for Hearing accordion when hearing is not set up and user is read only', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -6363,7 +6419,7 @@ describe('appeal-details', () => {
 
 			it('should render no change links for Hearing accordion when hearing is set up and user is read only', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -6497,13 +6553,13 @@ describe('appeal-details', () => {
 
 			it('should render the hearing details summary list when hearing is present with address', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
 						procedureType: APPEAL_CASE_PROCEDURE.HEARING,
 						hearing: {
-							hearingId: '123',
+							hearingId: 123,
 							hearingStartTime: '2025-05-15T12:00:00.000Z',
 							estimatedDays: 6,
 							address: {
@@ -6608,7 +6664,7 @@ describe('appeal-details', () => {
 
 			it('should render the hearing details summary list when hearing is present with no address', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -6667,7 +6723,7 @@ describe('appeal-details', () => {
 
 			it('should render the cancel hearing link when hearing is present and in the future', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -6706,7 +6762,7 @@ describe('appeal-details', () => {
 
 			it('should render the Hearing estimates summary list when estimates are present', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -6759,7 +6815,7 @@ describe('appeal-details', () => {
 				const appealId = '123';
 				const appealDetails = { ...appealData, appealId, procedureType: 'hearing' };
 
-				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealDetails);
+				nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appealDetails);
 				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 
 				const response = await request.get(`/appeals-service/appeal-details/${appealId}`);
@@ -6779,7 +6835,7 @@ describe('appeal-details', () => {
 					const appealId = '123';
 					const appealDetails = { ...ldcEnfDiscAppealTypeData, appealId, procedureType: 'hearing' };
 
-					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealDetails);
+					nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appealDetails);
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 
 					const response = await request.get(`/appeals-service/appeal-details/${appealId}`);
@@ -6795,7 +6851,7 @@ describe('appeal-details', () => {
 			it('should render a "Appellant application" row in the costs accordion', async () => {
 				const appealId = 2;
 
-				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealData);
+				nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appealData);
 				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 
 				const response = await request.get(`${baseUrl}/${appealId}`);
@@ -6834,7 +6890,7 @@ describe('appeal-details', () => {
 							}
 						]
 					};
-					nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appeal);
+					nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appeal);
 					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 					nock('http://test/')
 						.get(
@@ -6889,7 +6945,7 @@ describe('appeal-details', () => {
 				const appealId = 2;
 
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -6922,7 +6978,7 @@ describe('appeal-details', () => {
 						const appealId = 2;
 
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -6949,7 +7005,7 @@ describe('appeal-details', () => {
 						const appealId = 2;
 
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -6990,7 +7046,7 @@ describe('appeal-details', () => {
 						const appealId = 2;
 
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -7021,7 +7077,7 @@ describe('appeal-details', () => {
 						const appealId = 2;
 
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -7062,7 +7118,7 @@ describe('appeal-details', () => {
 						const appealId = 2;
 
 						nock('http://test/')
-							.get(`/appeals/${appealId}?include=all`)
+							.get(`/appeals/${appealId}/page-details`)
 							.reply(200, {
 								...appealData,
 								appealId,
@@ -7107,7 +7163,7 @@ describe('appeal-details', () => {
 
 			it('should not render the Inquiry accordion for HAS cases', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						appealId,
@@ -7129,7 +7185,7 @@ describe('appeal-details', () => {
 				const appealId = '123';
 				const appealDetails = { ...appealData, appealId, procedureType: 'inquiry' };
 
-				nock('http://test/').get(`/appeals/${appealId}?include=all`).reply(200, appealDetails);
+				nock('http://test/').get(`/appeals/${appealId}/page-details`).reply(200, appealDetails);
 				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 
 				const response = await request.get(`/appeals-service/appeal-details/${appealId}`);
@@ -7141,7 +7197,7 @@ describe('appeal-details', () => {
 
 			it('should render the Site accordion for HAS cases', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealData,
 						completedStateList: ['ready_to_start'],
@@ -7162,7 +7218,7 @@ describe('appeal-details', () => {
 			for (const procedureType of [APPEAL_CASE_PROCEDURE.WRITTEN, APPEAL_CASE_PROCEDURE.HEARING]) {
 				it(`should not render the Inquiry accordion for s78 cases with a procedureType of ${procedureType}`, async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -7194,7 +7250,7 @@ describe('appeal-details', () => {
 			for (const procedureType of [APPEAL_CASE_PROCEDURE.HEARING, APPEAL_CASE_PROCEDURE.INQUIRY]) {
 				it(`should not render the site accordion for s78 cases with a procedureType of ${procedureType}`, async () => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...appealDataFullPlanning,
 							appealId,
@@ -7225,7 +7281,7 @@ describe('appeal-details', () => {
 
 			it('should render the Inquiry accordion with the expected content for s78 cases with a procedureType of "Inquiry"', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -7261,7 +7317,7 @@ describe('appeal-details', () => {
 
 			it('should not render the Inquiry accordion for enforcement notice child cases with a procedureType of "Inquiry"', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataEnforcementNotice,
 						appealId,
@@ -7282,6 +7338,7 @@ describe('appeal-details', () => {
 			});
 
 			it('should render the inquiry details summary list when inquiry is present with address', async () => {
+				const appealId = 3;
 				nock('http://test/')
 					.get(
 						`/appeals/${appealId}/reps?type=appellant_final_comment,lpa_final_comment,appellant_proofs_evidence,lpa_proofs_evidence`
@@ -7295,7 +7352,7 @@ describe('appeal-details', () => {
 					});
 
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -7418,7 +7475,7 @@ describe('appeal-details', () => {
 					});
 
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -7495,7 +7552,7 @@ describe('appeal-details', () => {
 					});
 
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -7546,7 +7603,7 @@ describe('appeal-details', () => {
 
 			it('should render the inquiry details summary list with cancel inquiry when inquiry date is in the future', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -7584,7 +7641,7 @@ describe('appeal-details', () => {
 			});
 			it('should render the inquiry details summary list with setup inquiry when there is no inquiry', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, {
 						...appealDataFullPlanning,
 						appealId,
@@ -7624,7 +7681,7 @@ describe('appeal-details', () => {
 
 			it('should render the cancel appeal section if appeal status is not withdrawn or invalid', async () => {
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, { ...appealData, appealStatus: APPEAL_CASE_STATUS.VALIDATION });
 				const response = await request.get(`${baseUrl}/${appealId}?backUrl=/some-back-link`);
 
@@ -7641,7 +7698,7 @@ describe('appeal-details', () => {
 			it('should not render the cancel appeal section if appeal status is withdrawn', async () => {
 				const appealId = appealData.appealId.toString();
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, { ...appealData, appealStatus: APPEAL_CASE_STATUS.WITHDRAWN });
 				const response = await request.get(`${baseUrl}/${appealId}`);
 
@@ -7654,7 +7711,7 @@ describe('appeal-details', () => {
 			it('should not render the cancel appeal section if appeal status is invalid', async () => {
 				const appealId = appealData.appealId.toString();
 				nock('http://test/')
-					.get(`/appeals/${appealId}?include=all`)
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, { ...appealData, appealStatus: APPEAL_CASE_STATUS.INVALID });
 				const response = await request.get(`${baseUrl}/${appealId}`);
 
@@ -7680,7 +7737,7 @@ describe('appeal-details', () => {
 
 		it('should render the site visit section with correct link after site visit data has passed and decision has not been issued', async () => {
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, { ...appealData, completedStateList: [APPEAL_CASE_STATUS.READY_TO_START] });
 			const response = await request.get(`${baseUrl}/${appealId}`);
 
@@ -7693,7 +7750,7 @@ describe('appeal-details', () => {
 		});
 		it('should render the site visit section with no links after site visit data has passed and decision has been issued', async () => {
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					completedStateList: ['ready_to_start', 'issue_determination']
@@ -7711,7 +7768,7 @@ describe('appeal-details', () => {
 
 		it('should render the site visit section with correct link before site visit', async () => {
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					completedStateList: ['ready_to_start'],
@@ -7741,7 +7798,7 @@ describe('appeal-details', () => {
 			const siteVisitStartTime = new Date('2025-06-04T07:00:00Z');
 			const siteVisitEndTime = new Date('2025-06-04T09:00:00Z');
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					completedStateList: ['ready_to_start'],
@@ -7773,7 +7830,7 @@ describe('appeal-details', () => {
 			const siteVisitStartTime = new Date('2025-12-04T08:00:00Z');
 			const siteVisitEndTime = new Date('2025-12-04T10:00:00Z');
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					completedStateList: ['ready_to_start'],
@@ -7799,7 +7856,7 @@ describe('appeal-details', () => {
 
 		it('should render no links when site visit is not set up', async () => {
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					completedStateList: ['ready_to_start'],
@@ -7827,7 +7884,7 @@ describe('appeal-details', () => {
 				`should not render the site visit section for %s cases with a procedureType of ${procedureType}`,
 				async (_, specificAppealTypeData) => {
 					nock('http://test/')
-						.get(`/appeals/${appealId}?include=all`)
+						.get(`/appeals/${appealId}/page-details`)
 						.reply(200, {
 							...specificAppealTypeData,
 							procedureType: procedureType,
@@ -7870,7 +7927,7 @@ describe('appeal-details', () => {
 
 		it('should render the site visit section when the appeal has procedure type: undefined (and so is written)', async () => {
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					procedureType: undefined,
@@ -7890,7 +7947,7 @@ describe('appeal-details', () => {
 		it('should render the correct rows', async () => {
 			const appealId = 2;
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealData,
 					appealId
@@ -7961,7 +8018,7 @@ describe('appeal-details', () => {
 		it('should render the correct rows for an inquiry appeal', async () => {
 			const appealId = 2;
 			nock('http://test/')
-				.get(`/appeals/${appealId}?include=all`)
+				.get(`/appeals/${appealId}/page-details`)
 				.reply(200, {
 					...appealDataFullPlanning,
 					appealId,
@@ -8064,7 +8121,7 @@ describe('appeal-details', () => {
 		const appealId = '2';
 
 		nock('http://test/')
-			.get(`/appeals/${appealId}?include=all`)
+			.get(`/appeals/${appealId}/page-details`)
 			.reply(200, {
 				...appealData,
 				appealId

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
@@ -1,11 +1,7 @@
 import { getSavedBackUrl } from '#lib/middleware/save-back-url.js';
 import { stripQueryString } from '#lib/url-utilities.js';
-import { APPEAL_REPRESENTATION_TYPE, APPEAL_TYPE } from '@pins/appeals/constants/common.js';
-import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+
 import { appealDetailsPage } from './appeal-details.mapper.js';
-import { getAppellantCaseFromAppealId } from './appellant-case/appellant-case.service.js';
-import { getAppealCaseNotes } from './case-notes/case-notes.service.js';
-import { getRepresentationsByTypes } from './representations/representations.service.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
@@ -20,44 +16,22 @@ export const viewAppealDetails = async (request, response) => {
 	delete session.reviewOutcome;
 	delete session.changeAppealType;
 
-	const appealCaseNotes = await getAppealCaseNotes(
-		request.apiClient,
-		currentAppeal.appealId.toString()
-	);
-
-	let appellantFinalComments, lpaFinalComments, appellantProofOfEvidence, lpaProofOfEvidence;
-
-	if (currentAppeal.appealType === APPEAL_TYPE.S78) {
-		let types = `${APPEAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT},${APPEAL_REPRESENTATION_TYPE.LPA_FINAL_COMMENT}`;
-		if (currentAppeal.procedureType.toLowerCase() === APPEAL_CASE_PROCEDURE.INQUIRY) {
-			types = `${types},${APPEAL_REPRESENTATION_TYPE.APPELLANT_PROOFS_EVIDENCE},${APPEAL_REPRESENTATION_TYPE.LPA_PROOFS_EVIDENCE}`;
-		}
-
-		const representations = await getRepresentationsByTypes(
-			request.apiClient,
-			currentAppeal.appealId.toString(),
-			types
-		);
-		appellantFinalComments =
-			representations[APPEAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT] ?? undefined;
-		lpaFinalComments = representations[APPEAL_REPRESENTATION_TYPE.LPA_FINAL_COMMENT] ?? undefined;
-		appellantProofOfEvidence =
-			representations[APPEAL_REPRESENTATION_TYPE.APPELLANT_PROOFS_EVIDENCE] ?? undefined;
-		lpaProofOfEvidence =
-			representations[APPEAL_REPRESENTATION_TYPE.LPA_PROOFS_EVIDENCE] ?? undefined;
-	}
-
-	const appellantCase = await getAppellantCaseFromAppealId(
-		request.apiClient,
-		currentAppeal.appealId,
-		currentAppeal.appellantCaseId
-	);
+	const appealCaseNotes = currentAppeal.caseNotes || [];
+	const appellantCase = currentAppeal.appellantCase || null;
 	const backLinkUrl = getSavedBackUrl(request, 'appeals-detail') || '';
 
 	// Remove redundant slash at the end of the url if it exists to prevent a double slash when creating links
 	const currentUrl = request.originalUrl.endsWith('/')
 		? request.originalUrl.slice(0, -1)
 		: request.originalUrl;
+	const documentationSummary = currentAppeal?.documentationSummary || {};
+
+	let appellantFinalComments, lpaFinalComments, appellantProofOfEvidence, lpaProofOfEvidence;
+
+	appellantFinalComments = documentationSummary.appellantFinalComments;
+	lpaFinalComments = documentationSummary.lpaFinalComments;
+	appellantProofOfEvidence = documentationSummary.appellantProofOfEvidence;
+	lpaProofOfEvidence = documentationSummary.lpaProofOfEvidence;
 
 	const mappedPageContent = await appealDetailsPage(
 		currentAppeal,

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.middleware.js
@@ -2,7 +2,8 @@ import { areIdParamsValid } from '#lib/validators/id-param.validator.js';
 import {
 	checkAppealExists,
 	deprecatedGetAppealDetailsFromId,
-	getAppealDetailsFromId
+	getAppealDetailsFromId,
+	getAppealDetailsPageFromId
 } from './appeal-details.service.js';
 
 /**
@@ -77,6 +78,37 @@ export const validateAppealWithInclude =
 			}
 		}
 	};
+
+/**
+ * @type {import("express").RequestHandler}
+ */
+export const validateAppealForAppealDetailsPage = async (req, res, next) => {
+	const { appealId, caseId } = req.params;
+
+	if (!areIdParamsValid(appealId || caseId)) {
+		return res.status(400).render('app/400.njk');
+	}
+
+	if (req.currentAppeal) {
+		throw new Error('validateAppealForAppealDetailsPage should only be called once per request');
+	}
+
+	try {
+		const appeal = await getAppealDetailsPageFromId(req.apiClient, appealId || caseId);
+		if (!appeal) {
+			return res.status(404).render('app/404.njk');
+		}
+		req.currentAppeal = appeal;
+		next();
+	} catch (/** @type {any} */ error) {
+		switch (error?.response?.statusCode) {
+			case 404:
+				return res.status(404).render('app/404.njk');
+			default:
+				return res.status(500).render('app/500.njk');
+		}
+	}
+};
 
 /**
  * @type {import("express").RequestHandler}

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
@@ -9,7 +9,11 @@ import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
 import allocationDetailsRouter from './allocation-details/allocation-details.router.js';
 import * as controller from './appeal-details.controller.js';
-import { validateAppeal, validateAppealWithInclude } from './appeal-details.middleware.js';
+import {
+	validateAppeal,
+	validateAppealForAppealDetailsPage,
+	validateAppealWithInclude
+} from './appeal-details.middleware.js';
 import siteAddressRouter from './appellant-case/address/address.router.js';
 import appellantCaseRouter from './appellant-case/appellant-case.router.js';
 import assignUserRouter from './assign-user/assign-user.router.js';
@@ -51,7 +55,7 @@ router
 	.route('/:appealId')
 	.get(
 		saveBackUrl('appeals-detail'),
-		validateAppeal,
+		validateAppealForAppealDetailsPage,
 		clearSessionData,
 		assertUserHasPermission(
 			permissionNames.viewCaseDetails,
@@ -59,7 +63,7 @@ router
 		),
 		asyncHandler(controller.viewAppealDetails)
 	)
-	.post(validateAppeal, validateCaseNoteTextArea, asyncHandler(postCaseNote));
+	.post(validateAppealForAppealDetailsPage, validateCaseNoteTextArea, asyncHandler(postCaseNote));
 
 router.use(
 	'/:appealId/start-case',

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
@@ -19,6 +19,18 @@ export function getAppealDetailsFromId(apiClient, appealId, include) {
 }
 
 /**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @returns {Promise<import('./appeal-details.types.js').WebAppeal>}
+ */
+export function getAppealDetailsPageFromId(apiClient, appealId) {
+	const encodedAppealId = encodeURIComponent(appealId);
+	const url = `appeals/${encodedAppealId}/page-details`;
+
+	return apiClient.get(url).json();
+}
+
+/**
  * @deprecated Inefficient use getAppealDetailsFromId and select only the data needed
  * @param {import('got').Got} apiClient
  * @param {string} appealId
@@ -35,7 +47,7 @@ export function deprecatedGetAppealDetailsFromId(apiClient, appealId) {
  *
  * @param {import('got').Got} apiClient
  * @param {string} appealId
- * @returns {Promise<{appealId: number}>}
+ * @returns {Promise<{id: number}>}
  */
 export function checkAppealExists(apiClient, appealId) {
 	const encodedAppealId = encodeURIComponent(appealId);

--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
@@ -718,6 +718,10 @@ describe('representations', () => {
 							.get(`/appeals/${appealId}?include=all`)
 							.reply(200, appealAtStatements)
 							.persist();
+						nock('http://test/')
+							.get(`/appeals/${appealId}/page-details`)
+							.reply(200, appealAtStatements)
+							.persist();
 						nock('http://test/').post(`/appeals/${appealId}/reps/publish`).reply(200, []);
 
 						const sharePostResponse = await request.post(`${baseUrl}/${appealId}/share`).send({});
@@ -771,6 +775,10 @@ describe('representations', () => {
 							.get(`/appeals/${appealId}?include=all`)
 							.reply(200, appealAtStatements)
 							.persist();
+						nock('http://test/')
+							.get(`/appeals/${appealId}/page-details`)
+							.reply(200, appealAtStatements)
+							.persist();
 						nock('http://test/').post(`/appeals/${appealId}/reps/publish`).reply(200, []);
 
 						const sharePostResponse = await request.post(`${baseUrl}/${appealId}/share`).send({});
@@ -808,6 +816,10 @@ describe('representations', () => {
 				};
 				nock('http://test/')
 					.get(`/appeals/${appealId}?include=all`)
+					.reply(200, appealAtStatements)
+					.persist();
+				nock('http://test/')
+					.get(`/appeals/${appealId}/page-details`)
 					.reply(200, appealAtStatements)
 					.persist();
 				nock('http://test/')
@@ -877,26 +889,31 @@ describe('representations', () => {
 
 			for (const testCase of testCases) {
 				it(`should call the publish representations API endpoint, redirect to the case details page, and render a "Final comments shared" success banner, if ${testCase.name} final comments were shared`, async () => {
+					const appealDetailsResponse = {
+						...appealData,
+						appealType: 'Planning appeal',
+						appealId,
+						appealStatus: 'final_comments',
+						documentationSummary: {
+							appellantFinalComments: {
+								receivedAt: '2025-01-29T10:19:47.259Z',
+								representationStatus: 'valid',
+								status: 'received'
+							},
+							lpaFinalComments: {
+								receivedAt: '2025-01-29T10:19:47.259Z',
+								representationStatus: 'valid',
+								status: 'received'
+							}
+						}
+					};
 					nock('http://test/')
 						.get(`/appeals/${appealId}?include=all`)
-						.reply(200, {
-							...appealData,
-							appealType: 'Planning appeal',
-							appealId,
-							appealStatus: 'final_comments',
-							documentationSummary: {
-								appellantFinalComments: {
-									receivedAt: '2025-01-29T10:19:47.259Z',
-									representationStatus: 'valid',
-									status: 'received'
-								},
-								lpaFinalComments: {
-									receivedAt: '2025-01-29T10:19:47.259Z',
-									representationStatus: 'valid',
-									status: 'received'
-								}
-							}
-						})
+						.reply(200, appealDetailsResponse)
+						.persist();
+					nock('http://test/')
+						.get(`/appeals/${appealId}/page-details`)
+						.reply(200, appealDetailsResponse)
 						.persist();
 					const mockShareRepsEndpoint = nock('http://test/')
 						.post(`/appeals/${appealId}/reps/publish`)
@@ -930,26 +947,31 @@ describe('representations', () => {
 			}
 
 			it('should call the publish representations API endpoint, redirect to the case details page, and render a "Case progressed" success banner, if no final comments were shared', async () => {
+				const appealDetailsResponse = {
+					...appealData,
+					appealType: 'Planning appeal',
+					appealId,
+					appealStatus: 'final_comments',
+					documentationSummary: {
+						appellantFinalComments: {
+							receivedAt: null,
+							representationStatus: null,
+							status: 'not_received'
+						},
+						lpaFinalComments: {
+							receivedAt: null,
+							representationStatus: null,
+							status: 'not_received'
+						}
+					}
+				};
 				nock('http://test/')
 					.get(`/appeals/${appealId}?include=all`)
-					.reply(200, {
-						...appealData,
-						appealType: 'Planning appeal',
-						appealId,
-						appealStatus: 'final_comments',
-						documentationSummary: {
-							appellantFinalComments: {
-								receivedAt: null,
-								representationStatus: null,
-								status: 'not_received'
-							},
-							lpaFinalComments: {
-								receivedAt: null,
-								representationStatus: null,
-								status: 'not_received'
-							}
-						}
-					})
+					.reply(200, appealDetailsResponse)
+					.persist();
+				nock('http://test/')
+					.get(`/appeals/${appealId}/page-details`)
+					.reply(200, appealDetailsResponse)
 					.persist();
 				const mockShareRepsEndpoint = nock('http://test/')
 					.post(`/appeals/${appealId}/reps/publish`)

--- a/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/accept/__tests__/accept-proof-of-evidence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/accept/__tests__/accept-proof-of-evidence.test.js
@@ -36,20 +36,27 @@ describe('proof-of-evidence', () => {
 			})
 			.persist();
 
-		nock('http://test/').get('/appeals/2/case-notes').reply(200, []).persist();
-
-		nock('http://test/').get('/appeals/2/appellant-cases/0').reply(200, {}).persist();
-
 		nock('http://test/')
-			.get('/appeals/2/reps?type=appellant_final_comment,lpa_final_comment')
-			.reply(200, { items: [], itemCount: 0 })
-			.persist();
-
-		nock('http://test/')
-			.get(
-				'/appeals/2/reps?type=appellant_final_comment,lpa_final_comment,appellant_proofs_evidence,lpa_proofs_evidence'
-			)
-			.reply(200, { items: [], itemCount: 0 })
+			.get('/appeals/2/page-details')
+			.reply(200, {
+				...appealDataFullPlanning,
+				appealId: 2,
+				appealStatus: 'appellant_proofs_evidence',
+				procedureType: 'inquiry',
+				inquiry: {},
+				caseNotes: [],
+				appealRule6Parties: [
+					{
+						id: 3670,
+						serviceUserId: 3838,
+						partyName: 'Test Rule 6 Party',
+						serviceUser: {
+							organisationName: 'Test Rule 6 Party'
+						}
+					}
+				],
+				rule6PartyId: 3670
+			})
 			.persist();
 	});
 
@@ -148,7 +155,11 @@ describe('proof-of-evidence', () => {
 				items: [
 					{
 						...proofOfEvidenceForReviewWithAttachments.items[0],
-						representationType: 'rule_6_party_proofs_evidence'
+						representationType: 'rule_6_party_proofs_evidence',
+						represented: {
+							id: 3838,
+							name: 'Test Rule 6 Party'
+						}
 					}
 				]
 			};

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.validators.js
@@ -9,8 +9,8 @@ export function validateReadyToShare(request, response, next) {
 	const { currentAppeal } = request;
 
 	switch (currentAppeal.appealStatus) {
-		case APPEAL_REPRESENTATION_STATUS.STATEMENTS: {
-			const { representationStatus, status } =
+		case APPEAL_CASE_STATUS.STATEMENTS: {
+			const { representationStatus, status = 'not_received' } =
 				currentAppeal.documentationSummary?.lpaStatement || {};
 			const isValid =
 				representationStatus === APPEAL_REPRESENTATION_STATUS.VALID || status === 'not_received';

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
@@ -817,6 +817,14 @@ describe('start case hearing flow', () => {
 					procedureType: 'Hearing'
 				});
 			nock('http://test/')
+				.get('/appeals/1/page-details')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Planning appeal',
+					completedStateList: ['lpa_questionnaire'],
+					procedureType: 'Hearing'
+				});
+			nock('http://test/')
 				.post('/appeals/1/appeal-timetables', {
 					startDate: '2025-09-18T23:00:00.000Z',
 					procedureType: 'hearing',

--- a/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
@@ -6,8 +6,6 @@ import { renderPageComponentsToHtml } from '#lib/nunjucks-template-builders/page
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 import { decisionOutcomeToDisplayText } from '@pins/appeals/utils/decision-outcome-display-text.js';
 import { APPEAL_CASE_STATUS, APPEAL_VIRUS_CHECK_STATUS } from '@planning-inspectorate/data-model';
-import { getAppealTypesFromId } from '../change-appeal-type/change-appeal-type.service.js';
-import { getInvalidStatusCreatedDate } from '../invalid-appeal/invalid-appeal.service.js';
 
 /**
  * @param {{ appeal: MappedInstructions }} mappedData
@@ -84,13 +82,14 @@ export const generateStatusTags = async (mappedData, appealDetails, request) => 
 					: `Decision issued on ${letterDateObject.latestLetterDate}`
 			);
 		} else if (isAppealInvalid) {
-			const invalidDate = await getInvalidStatusCreatedDate(
-				request.apiClient,
-				appealDetails.appealId
+			// @ts-ignore
+			const invalidStatusObj = appealDetails.appealStatusHistory?.find(
+				(/** @type {any} */ s) => s.status === 'invalid'
 			);
-			insetTextRows.push(
-				`Marked as invalid on ${dateISOStringToDisplayDate(invalidDate.createdDate)}`
-			);
+			const invalidDate = invalidStatusObj?.createdAt;
+			if (invalidDate) {
+				insetTextRows.push(`Marked as invalid on ${dateISOStringToDisplayDate(invalidDate)}`);
+			}
 			insetTextRows.push(getViewInvalidAppealLink(appealDetails.appealId));
 		}
 
@@ -155,14 +154,10 @@ export const generateStatusTags = async (mappedData, appealDetails, request) => 
 		appealDetails.resubmitTypeId &&
 		appealDetails.appealTimetable?.caseResubmissionDueDate
 	) {
-		const appealTypesFromId = await getAppealTypesFromId(request.apiClient, appealDetails.appealId);
-		const appealTypeById = appealTypesFromId?.find(
-			(appealType) => appealType.id === appealDetails.resubmitTypeId
-		);
+		// @ts-ignore
+		const resubmitType = appealDetails.resubmitType;
 		const appealTypeText =
-			appealTypeById?.key && appealTypeById?.type
-				? `${appealTypeById.type} (${appealTypeById.key})`
-				: '';
+			resubmitType?.key && resubmitType?.type ? `${resubmitType.type} (${resubmitType.key})` : '';
 		const caseResubmissionDueDate = dateISOStringToDisplayDate(
 			appealDetails.appealTimetable.caseResubmissionDueDate
 		);

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -157,19 +157,39 @@ export const formatListOfListedBuildingNumbers = (listOfListedBuildingNumbers) =
  * @param {import('@pins/appeals.api/src/server/endpoints/appeals.js').DocumentInfo[]} options.documents
  * @param {import('#appeals/appeals.types.js').DocumentRowDisplayMode} [options.displayMode]
  * @param {boolean} [options.isAdditionalDocuments]
+ * @param {number} [options.documentCount]
  * @returns {TextProperty & ClassesProperty | HtmlProperty & ClassesProperty}
  */
-export function formatDocumentValues({ appealId, documents, displayMode, isAdditionalDocuments }) {
+export function formatDocumentValues({
+	appealId,
+	documents,
+	displayMode,
+	isAdditionalDocuments,
+	documentCount
+}) {
 	switch (displayMode) {
 		case 'none':
 			return { text: '' };
 		case 'number':
-			return formatDocumentValuesAsNumber({ documents });
+			return formatDocumentValuesAsNumber({ documents, documentCount });
 		case 'list':
 		default:
 			return formatDocumentValuesAsList({ appealId, documents, isAdditionalDocuments });
 	}
 }
+
+/**
+ * @param {Object} options
+ * @param {import('@pins/appeals.api/src/server/endpoints/appeals.js').DocumentInfo[]} options.documents
+ * @param {number} [options.documentCount]
+ * @returns {TextProperty & ClassesProperty}
+ */
+const formatDocumentValuesAsNumber = ({ documents, documentCount }) => {
+	const count = typeof documentCount === 'number' ? documentCount : documents.length;
+	return {
+		html: `${count > 0 ? count : 'No'} document${count === 1 ? '' : 's'}`
+	};
+};
 
 /**
  * @param {Object} options
@@ -306,19 +326,6 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 	}
 
 	return htmlProperty;
-};
-
-/**
- * @param {Object} options
- * @param {import('@pins/appeals.api/src/server/endpoints/appeals.js').DocumentInfo[]} options.documents
- * @returns {TextProperty & ClassesProperty}
- */
-const formatDocumentValuesAsNumber = ({ documents }) => {
-	return {
-		html: `${documents.length > 0 ? documents.length : 'No'} document${
-			documents.length === 1 ? '' : 's'
-		}`
-	};
 };
 
 /**

--- a/appeals/web/src/server/lib/mappers/components/instructions/document.js
+++ b/appeals/web/src/server/lib/mappers/components/instructions/document.js
@@ -53,7 +53,12 @@ export function documentSummaryListItem({
 		display: {
 			summaryListItem: {
 				key: { text },
-				value: formatDocumentValues({ appealId, documents, displayMode }),
+				value: formatDocumentValues({
+					appealId,
+					documents,
+					displayMode,
+					documentCount: isFolderInfo(folderInfo) ? folderInfo.documentCount : undefined
+				}),
 				actions: { items: actions }
 			}
 		}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/environmental-assessment.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/environmental-assessment.mapper.test.js
@@ -55,6 +55,7 @@ describe('environmental-assessment.mapper', () => {
 	});
 
 	it('should contain tableItem with one documents', () => {
+		data.appealDetails.environmentalAssessment.documentCount = 1;
 		data.appealDetails.environmentalAssessment.documents = [
 			{
 				latestDocumentVersion: { dateReceived: new Date('2025-02-01') }
@@ -84,6 +85,7 @@ describe('environmental-assessment.mapper', () => {
 	});
 
 	it('should contain tableItem with three documents', () => {
+		data.appealDetails.environmentalAssessment.documentCount = 3;
 		data.appealDetails.environmentalAssessment.documents = [
 			{
 				latestDocumentVersion: { dateReceived: new Date('2025-02-01') }

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/environmental-assessment.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/environmental-assessment.mapper.js
@@ -40,12 +40,13 @@ export const mapEnvironmentalAssessment = (data) => {
 	return documentationFolderTableItem({
 		id,
 		text,
-		statusText: documents?.length
-			? `${documents?.length} document${documents.length === 1 ? '' : 's'}`
+		statusText: environmentalAssessment.documentCount
+			? `${environmentalAssessment.documentCount} document${environmentalAssessment.documentCount === 1 ? '' : 's'}`
 			: 'No documents',
-		receivedText: documents?.length
-			? dateISOStringToDisplayDate(latestReceivedDocument?.latestDocumentVersion.dateReceived)
-			: 'Not applicable',
+		receivedText:
+			documents?.length && latestReceivedDocument?.latestDocumentVersion?.dateReceived
+				? dateISOStringToDisplayDate(latestReceivedDocument.latestDocumentVersion.dateReceived)
+				: 'Not applicable',
 		actionHtml: actionsHtml({
 			id,
 			text,

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -3,7 +3,6 @@ import {
 	DOCUMENT_STATUS_NOT_RECEIVED,
 	DOCUMENT_STATUS_RECEIVED,
 	VALIDATION_OUTCOME_INCOMPLETE
-	// @ts-ignore
 } from '@pins/appeals/constants/support.js';
 import {
 	APPEAL_CASE_PROCEDURE,
@@ -209,7 +208,7 @@ export const appealsNationalList = {
 };
 
 /**
- * @type {import('../../../src/server/appeals/appeal-details/appeal-details.types.d').WebAppeal}
+ * @type {import('../../../src/server/appeals/appeal-details/appeal-details.types.d').WebAppeal & { caseNotes?: any, appellantCase?: any }}
  */
 export const appealData = {
 	allocationDetails: {
@@ -5447,3 +5446,26 @@ export const enforcementGroundsMismatchFacts = [
 	{ name: 'j', id: 10, hasText: true },
 	{ name: 'k', id: 11, hasText: true }
 ];
+
+appealData.caseNotes = caseNotes;
+appealDataEnforcementListedBuilding.caseNotes = caseNotes;
+appealDataEnforcementNotice.caseNotes = caseNotes;
+appealDataFullPlanning.caseNotes = caseNotes;
+appealDataLdc.caseNotes = caseNotes;
+appealDataListedBuilding.caseNotes = caseNotes;
+
+appealData.appellantCase = {
+	numberOfResidencesNetChange: null,
+	screeningOpinionIndicatesEiaRequired: null,
+	applicationMadeUnderActSection: null,
+	isEnforcementChild: false,
+	planningObligation: {
+		hasObligation: false,
+		status: null
+	}
+};
+appealDataEnforcementListedBuilding.appellantCase = { ...appealData.appellantCase };
+appealDataEnforcementNotice.appellantCase = { ...appealData.appellantCase };
+appealDataFullPlanning.appellantCase = { ...appealData.appellantCase };
+appealDataLdc.appellantCase = { ...appealData.appellantCase };
+appealDataListedBuilding.appellantCase = { ...appealData.appellantCase };

--- a/appeals/web/testing/appeals/mocks/api.js
+++ b/appeals/web/testing/appeals/mocks/api.js
@@ -8,28 +8,27 @@ export function installMockAppealsService() {
 	// national list
 	nock('http://test/').get('/appeals/').reply(200, appealsNationalList).persist();
 
-	// appeal details
+	// appeal details (matches any query params including include=all, include=specific, or none)
 	nock('http://test/')
 		.get(`/appeals/${appealData.appealId}`)
-		.query((actualQueryObject) => {
-			return Object.prototype.hasOwnProperty.call(actualQueryObject, 'include');
-		})
+		.query(true)
 		.reply(200, appealData)
 		.persist();
 
-	// appeal details with appellant case
+	// appeal details page (optimized endpoint for the main appeal details page)
 	nock('http://test/')
-		.get(`/appeals/${appealData.appealId}?include=appellantCase`)
+		.get(`/appeals/${appealData.appealId}/page-details`)
 		.reply(200, appealData)
 		.persist();
 
-	// appeal details with appellant case and appeal grounds
+	// appeal exists check (for checkAppealExists / validateAppealExists middleware)
 	nock('http://test/')
-		.get(`/appeals/${appealData.appealId}?include=appellantCase,appealGrounds`)
-		.reply(200, appealData)
+		.get(`/appeals/${appealData.appealId}/exists`)
+		.reply(200, { id: appealData.appealId })
 		.persist();
 
 	nock('http://test/').get('/appeals/0').reply(500).persist();
+	nock('http://test/').get('/appeals/0/exists').reply(404).persist();
 
 	nock('http://test/')
 		.get(`/appeals/${appealData.appealId}/case-notes`)


### PR DESCRIPTION
## Describe your changes

Updates:
Dedicated API Endpoint: Added new route GET /appeals/:appealId/page-details specifically tailored to the appeal details page.
This query gets the specific data required for the appeal details page to load. Reducing document retrieval to 1 document and getting the document count for the page. Getting only the latest document for when the data is required.
Added document count for the document page on the appeal-details page.

Removed additional round trip Queries and document payload and made into one single response/


WEB updates:
Updated appeal-details.middleware.js and appeal-details.service.js to call getAppealDetailsPageFromId.
Updated associated mappers (status-tags.mapper.js, display-page-formatter.js, environmental-assessment.mapper.js) to handle document count metadata.

Testing:
Updated unit test suites across API and Web packages to align with new setup


Metrics:

Metric | Legacy Endpoint (/appeals/:appealId) | Optimized Endpoint (/appeals/:appealId/page-details) | Improvement / Impact
-- | -- | -- | --
Response Latency | ~9.49 ms | ~1.84 ms | ~80% faster (~5x latency reduction)




## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8260)
