### PR TITLE
fix(api): add front office link for appeal confirmed LPA email (A2-8741)

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-confirmed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-confirmed-lpa.test.js
@@ -26,7 +26,7 @@ describe('appeal-confirmed-lpa.md', () => {
 		const expectedContent = [
 			`You have a new ${notifySendData.personalisation.appeal_type.toLowerCase()} against the application ${notifySendData.personalisation.lpa_reference}`,
 			'',
-			'You can view the appeal in the appeals service.',
+			`[You can view the appeal in the appeals service](/mock-front-office-url/manage-appeals/${notifySendData.personalisation.appeal_reference_number}).`,
 			'',
 			'# Appeal details',
 			'',

--- a/appeals/api/src/server/notify/templates/appeal-confirmed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-confirmed-lpa.content.md
@@ -1,6 +1,6 @@
 You have a new {{appeal_type | lower}} against the application {{lpa_reference}}
 
-You can view the appeal in the appeals service.
+[You can view the appeal in the appeals service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}).
 
 # Appeal details
 


### PR DESCRIPTION
## Describe your changes

Add link to the FO for LPAs in the appeal confirmed notify.

Updated unit test for notify template

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8741)
