### PR TITLE
fix(web): removed "due" from name tag (A2-7890)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/__snapshots__/set-up-inquiry.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/__snapshots__/set-up-inquiry.test.js.snap
@@ -726,7 +726,7 @@ exports[`set up inquiry GET /inquiry/setup/timetable-due-dates should match the 
                         </div>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="case-management-conference-due-date-hint">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Case management conference due date</legend>
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Case management conference date</legend>
                                 <div id="case-management-conference-due-date-hint"
                                 class="govuk-hint">
                                     <div class="govuk-hint">For example, 31 3 2025</div>

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.mapper.js
@@ -326,7 +326,7 @@ export const getDueDateFieldNameAndID = (dateField) => {
 		case 'caseManagementConferenceDueDate':
 			return {
 				id: 'case-management-conference-due-date',
-				name: 'Case management conference due date'
+				name: 'Case management conference date'
 			};
 		default:
 			return undefined;


### PR DESCRIPTION
## Describe your changes

Small changes to wording in timetable section of S78 inquiry cases.

## Issue ticket number and link

[Inquiry timetable - should be "Case management conference date" rather than "Case management conference due date"](https://pins-ds.atlassian.net.mcas.ms/browse/A2-7890)
