### PR TITLE
fix(appeals): site visit transition fixes (A2-8796)

### DIFF
--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits-update.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits-update.test.js
@@ -2,6 +2,8 @@
 import { jest } from '@jest/globals';
 import {
 	AUDIT_TRAIL_SITE_VISIT_TYPE_SELECTED,
+	CASE_RELATIONSHIP_LINKED,
+	CASE_RELATIONSHIP_RELATED,
 	ERROR_INVALID_SITE_VISIT_TYPE,
 	ERROR_MUST_BE_CORRECT_UTC_DATE_FORMAT,
 	ERROR_MUST_BE_NUMBER,
@@ -12,6 +14,7 @@ import {
 	SITE_VISIT_TYPE_ACCOMPANIED,
 	SITE_VISIT_TYPE_UNACCOMPANIED
 } from '@pins/appeals/constants/support.js';
+import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 import { request } from '../../../app-test.js';
 
 import {
@@ -1105,6 +1108,118 @@ describe('PATCH /:appealId/site-visits/:siteVisitId', () => {
 			});
 		});
 
+		test('updates a site visit and transitions appeal status to awaiting_event when in event status', async () => {
+			const appeal = getAppeal();
+			const { siteVisit } = appeal;
+
+			appeal.appealStatus[0].status = 'event';
+			appeal.procedureType = { key: 'written' };
+			addStatusesToLinkedAppeals(appeal, appeal.appealStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({
+				id: 1,
+				azureAdUserId
+			});
+			databaseConnector.appealStatus.create.mockResolvedValue({});
+			databaseConnector.appealStatus.updateMany.mockResolvedValue({});
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: 'Accompanied'
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						appealId: appeal.id,
+						status: 'awaiting_event',
+						valid: true
+					})
+				})
+			);
+		});
+
+		test('updates a site visit and does not transition appeal status when not in event status', async () => {
+			const appeal = getAppeal();
+			const { siteVisit } = appeal;
+
+			appeal.appealStatus[0].status = 'final_comments';
+			appeal.procedureType = { key: 'written' };
+			addStatusesToLinkedAppeals(appeal, appeal.appealStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({
+				id: 1,
+				azureAdUserId
+			});
+			databaseConnector.appealStatus.create.mockResolvedValue({});
+			databaseConnector.appealStatus.updateMany.mockResolvedValue({});
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: 'Accompanied'
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+		});
+
+		test('updates a site visit and does not transition appeal status when visitDate is not provided', async () => {
+			const appeal = getAppeal();
+			const { siteVisit } = appeal;
+
+			appeal.appealStatus[0].status = 'event';
+			appeal.procedureType = { key: 'written' };
+			addStatusesToLinkedAppeals(appeal, appeal.appealStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({
+				id: 1,
+				azureAdUserId
+			});
+			databaseConnector.appealStatus.create.mockResolvedValue({});
+			databaseConnector.appealStatus.updateMany.mockResolvedValue({});
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: 'Accompanied'
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+		});
+
 		test('updates an Unaccompanied site visit without time fields', async () => {
 			const appeal = getAppeal();
 			const { siteVisit } = appeal;
@@ -1614,6 +1729,240 @@ describe('PATCH /:appealId/site-visits/:siteVisitId', () => {
 			});
 
 			expect(mockNotifySend).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('linked appeal site visit updates', () => {
+		const getLinkedLeadAppeal = () =>
+			JSON.parse(
+				JSON.stringify({ ...enforcementNoticeAppeal, childAppeals: childAppealsEnforcementBase })
+			);
+
+		test('transitions status for both lead and linked child appeals when lead is in event status', async () => {
+			const appeal = getLinkedLeadAppeal();
+			const { siteVisit } = appeal;
+
+			appeal.appealStatus[0].status = APPEAL_CASE_STATUS.EVENT;
+			appeal.procedureType = { key: 'written' };
+			addStatusesToLinkedAppeals(appeal, appeal.appealStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({ id: 1, azureAdUserId });
+			databaseConnector.appealStatus.create.mockResolvedValue({});
+			databaseConnector.appealStatus.updateMany.mockResolvedValue({});
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: SITE_VISIT_TYPE_ACCOMPANIED
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+
+			// Lead appeal should be transitioned
+			expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						appealId: appeal.id,
+						status: APPEAL_CASE_STATUS.AWAITING_EVENT,
+						valid: true
+					})
+				})
+			);
+
+			// Linked child appeals (type === 'linked') should also be transitioned
+			const linkedChildren = appeal.childAppeals.filter((c) => c.type === CASE_RELATIONSHIP_LINKED);
+			for (const child of linkedChildren) {
+				expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith(
+					expect.objectContaining({
+						data: expect.objectContaining({
+							appealId: child.childId,
+							status: APPEAL_CASE_STATUS.AWAITING_EVENT,
+							valid: true
+						})
+					})
+				);
+			}
+		});
+
+		test('does not transition child appeal status when child appeal is in a different status to lead', async () => {
+			const appeal = getLinkedLeadAppeal();
+			const { siteVisit } = appeal;
+
+			appeal.appealStatus[0].status = APPEAL_CASE_STATUS.EVENT;
+			appeal.procedureType = { key: 'written' };
+			// Give the child appeals a different status to the lead
+			const childStatus = [
+				{ ...appeal.appealStatus[0], status: APPEAL_CASE_STATUS.FINAL_COMMENTS }
+			];
+			addStatusesToLinkedAppeals(appeal, childStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({ id: 1, azureAdUserId });
+			databaseConnector.appealStatus.create.mockResolvedValue({});
+			databaseConnector.appealStatus.updateMany.mockResolvedValue({});
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: SITE_VISIT_TYPE_ACCOMPANIED
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+
+			// Lead should still transition
+			expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						appealId: appeal.id,
+						status: APPEAL_CASE_STATUS.AWAITING_EVENT,
+						valid: true
+					})
+				})
+			);
+
+			// Child appeals should NOT be transitioned (they are in a different status)
+			const linkedChildren = appeal.childAppeals.filter((c) => c.type === CASE_RELATIONSHIP_LINKED);
+			for (const child of linkedChildren) {
+				expect(databaseConnector.appealStatus.create).not.toHaveBeenCalledWith(
+					expect.objectContaining({
+						data: expect.objectContaining({
+							appealId: child.childId,
+							status: APPEAL_CASE_STATUS.AWAITING_EVENT
+						})
+					})
+				);
+			}
+		});
+
+		test('does not transition any status when lead linked appeal is not in event status', async () => {
+			const appeal = getLinkedLeadAppeal();
+			const { siteVisit } = appeal;
+
+			appeal.appealStatus[0].status = APPEAL_CASE_STATUS.FINAL_COMMENTS;
+			appeal.procedureType = { key: 'written' };
+			addStatusesToLinkedAppeals(appeal, appeal.appealStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({ id: 1, azureAdUserId });
+			databaseConnector.appealStatus.create.mockResolvedValue({});
+			databaseConnector.appealStatus.updateMany.mockResolvedValue({});
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: SITE_VISIT_TYPE_ACCOMPANIED
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+		});
+
+		test('updates site visit for all linked appeals in group (lead + linked children)', async () => {
+			const appeal = getLinkedLeadAppeal();
+			const { siteVisit } = appeal;
+			const idsOfLinkedGroup = getIdsOfLinkedGroup(appeal);
+
+			appeal.appealStatus[0].status = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
+			addStatusesToLinkedAppeals(appeal, appeal.appealStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({ id: 1, azureAdUserId });
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: SITE_VISIT_TYPE_ACCOMPANIED
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			// The updateMany should include all linked appeal IDs (lead + linked children)
+			expect(databaseConnector.siteVisit.updateMany).toHaveBeenCalledWith({
+				where: { appealId: { in: idsOfLinkedGroup } },
+				data: {
+					visitDate: new Date(siteVisit.visitDate),
+					visitEndTime: new Date(siteVisit.visitEndTime),
+					visitStartTime: new Date(siteVisit.visitStartTime),
+					siteVisitTypeId: siteVisit.siteVisitType.id
+				}
+			});
+		});
+
+		test('does not update related (non-linked) child appeal site visits', async () => {
+			const appeal = getLinkedLeadAppeal();
+			const { siteVisit } = appeal;
+
+			appeal.appealStatus[0].status = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
+			addStatusesToLinkedAppeals(appeal, appeal.appealStatus);
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockImplementation(mockAppealFindUnique(appeal));
+			// @ts-ignore
+			databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({ id: 1, azureAdUserId });
+
+			const response = await request
+				.patch(`/appeals/${appeal.id}/site-visits/${siteVisit.id}`)
+				.send({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name,
+					previousVisitType: SITE_VISIT_TYPE_ACCOMPANIED
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+
+			// The 'related' child (childAppealsEnforcementBase[1], id 102) should NOT be in the updateMany
+			const relatedChildId = appeal.childAppeals.find(
+				(c) => c.type === CASE_RELATIONSHIP_RELATED
+			)?.childId;
+			expect(relatedChildId).toBeDefined();
+			expect(databaseConnector.siteVisit.updateMany).not.toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: expect.objectContaining({
+						appealId: expect.objectContaining({ in: expect.arrayContaining([relatedChildId]) })
+					})
+				})
+			);
 		});
 	});
 });

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
@@ -182,6 +182,13 @@ const rearrangeSiteVisit = async (req, res) => {
 		// @ts-ignore
 		await updateSiteVisit(azureAdUserId, updateSiteVisitData, notifyClient, appealsToUpdate);
 
+		if (visitDate && arrayOfStatusesContainsString(appeal.appealStatus, APPEAL_CASE_STATUS.EVENT)) {
+			if (isLinkedAppealsActive(appeal)) {
+				await transitionLinkedChildAppealsState(appeal, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
+			}
+			await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
+		}
+
 		return res.send({
 			visitDate,
 			visitEndTime,

--- a/appeals/api/src/server/state/__tests__/transition-state.test.js
+++ b/appeals/api/src/server/state/__tests__/transition-state.test.js
@@ -2,12 +2,20 @@
 import appealRepository from '#repositories/appeal.repository.js';
 import { jest } from '@jest/globals';
 import {
+	APPEAL_REPRESENTATION_STATUS,
+	APPEAL_REPRESENTATION_TYPE
+} from '@pins/appeals/constants/common.js';
+import {
 	CASE_RELATIONSHIP_LINKED,
 	VALIDATION_OUTCOME_COMPLETE,
 	VALIDATION_OUTCOME_INCOMPLETE,
 	VALIDATION_OUTCOME_VALID
 } from '@pins/appeals/constants/support.js';
-import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+import {
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_TYPE
+} from '@planning-inspectorate/data-model';
 import transitionState, {
 	getEventElapsed,
 	transitionLinkedChildAppealsState
@@ -19,6 +27,10 @@ const representationRepository = (await import('#repositories/representation.rep
 const oneDayinMS = 90000000; // 25 hours
 
 describe('transitionState', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	const stateList = [
 		{
 			status: 'validation',
@@ -96,7 +108,7 @@ describe('transitionState', () => {
 					appealStatus: [{ status, valid: true }]
 				};
 
-				representationRepository.getRepresentations = jest.fn();
+				jest.spyOn(representationRepository, 'getRepresentations').mockImplementation(jest.fn());
 				databaseConnector.appeal.findUnique.mockResolvedValue(dynamicFixture);
 
 				const result = await transitionState(11, 'user-123', VALIDATION_OUTCOME_VALID);
@@ -132,12 +144,11 @@ describe('transitionState', () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue(
 				appealFixtureIncompleteDoesNotTransition
 			);
-			// @ts-ignore
-			appealStatusRepository.updateAppealStatusByAppealId = jest.fn();
-			// @ts-ignore
-			appealStatusRepository.rollBackAppealStatusTo = jest.fn();
-			// @ts-ignore
-			databaseConnector.personalList.upsert = jest.fn().mockResolvedValue({});
+			jest
+				.spyOn(appealStatusRepository, 'updateAppealStatusByAppealId')
+				.mockImplementation(jest.fn());
+			jest.spyOn(appealStatusRepository, 'rollBackAppealStatusTo').mockImplementation(jest.fn());
+			databaseConnector.personalList.upsert.mockResolvedValue({});
 		});
 		test('does not update status but updates personal list', async () => {
 			const result = await transitionState(22, 'user-xyz', VALIDATION_OUTCOME_INCOMPLETE);
@@ -487,6 +498,271 @@ describe('transitionState', () => {
 			]);
 			expect(result).toEqual(true);
 		});
+	});
+
+	describe('Transition to EVENT / AWAITING_EVENT / ISSUE_DETERMINATION from preceding states', () => {
+		const runTransitionTest = async (mockAppeal, mockRepresentations) => {
+			const currentAppeal = { ...mockAppeal };
+			currentAppeal.appealStatus = mockAppeal.appealStatus.map((s) => ({ ...s }));
+
+			jest.spyOn(appealRepository, 'getAppealById').mockImplementation(() => {
+				return Promise.resolve(currentAppeal);
+			});
+
+			const appealStatusCreateMock = jest.fn().mockImplementation(({ data }) => {
+				currentAppeal.appealStatus = currentAppeal.appealStatus.map((s) => ({
+					...s,
+					valid: false
+				}));
+				currentAppeal.appealStatus.push({ status: data.status, valid: true });
+				return Promise.resolve({});
+			});
+
+			Object.defineProperty(databaseConnector, 'appealStatus', {
+				get: () => ({
+					updateMany: jest.fn().mockResolvedValue({}),
+					create: appealStatusCreateMock
+				}),
+				configurable: true
+			});
+
+			if (mockRepresentations) {
+				jest
+					.spyOn(representationRepository, 'getRepresentations')
+					.mockResolvedValue(mockRepresentations);
+			}
+
+			await transitionState(mockAppeal.id, 'user-123', VALIDATION_OUTCOME_COMPLETE);
+			return appealStatusCreateMock;
+		};
+
+		afterEach(() => {
+			// @ts-ignore
+			delete databaseConnector.appealStatus;
+		});
+
+		const futureDate = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000);
+		const pastDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+		const standardRepresentations = {
+			comments: [
+				{
+					representationType: APPEAL_REPRESENTATION_TYPE.APPELLANT_PROOFS_EVIDENCE,
+					status: APPEAL_REPRESENTATION_STATUS.VALID
+				},
+				{
+					representationType: APPEAL_REPRESENTATION_TYPE.LPA_PROOFS_EVIDENCE,
+					status: APPEAL_REPRESENTATION_STATUS.VALID
+				}
+			]
+		};
+
+		const testCases = [
+			{
+				description: 'transitions from final_comments to event when no site visit exists (written)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				appeal: {
+					id: 100,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.FINAL_COMMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: null
+				}
+			},
+			{
+				description:
+					'transitions from final_comments to event when site visit exists with null date (written)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				appeal: {
+					id: 101,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.FINAL_COMMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: { visitDate: null }
+				}
+			},
+			{
+				description:
+					'transitions from final_comments to awaiting_event when site visit exists with future date (written)',
+				expectedStatus: APPEAL_CASE_STATUS.AWAITING_EVENT,
+				appeal: {
+					id: 102,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.FINAL_COMMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: { visitDate: futureDate }
+				}
+			},
+			{
+				description:
+					'transitions from final_comments directly to issue_determination when site visit is in the past (written)',
+				expectedStatus: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				appeal: {
+					id: 103,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.FINAL_COMMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: { visitDate: pastDate }
+				}
+			},
+			{
+				description: 'transitions from statements to event when no hearing exists (hearing)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				appeal: {
+					id: 200,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.STATEMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.HEARING },
+					hearing: null
+				}
+			},
+			{
+				description:
+					'transitions from statements to awaiting_event when hearing has address and future date',
+				expectedStatus: APPEAL_CASE_STATUS.AWAITING_EVENT,
+				appeal: {
+					id: 201,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.STATEMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.HEARING },
+					hearing: { addressId: 1, hearingStartTime: futureDate }
+				}
+			},
+			{
+				description: 'transitions from statements to awaiting_event when hearing is in the past',
+				expectedStatus: APPEAL_CASE_STATUS.AWAITING_EVENT,
+				appeal: {
+					id: 202,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.STATEMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.HEARING },
+					hearing: { addressId: 1, hearingStartTime: pastDate }
+				}
+			},
+			{
+				description:
+					'transitions from lpa_questionnaire to event when no site visit exists (HAS / written)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				appeal: {
+					id: 300,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.D },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: null
+				}
+			},
+			{
+				description:
+					'transitions from lpa_questionnaire to event when site visit exists with null date (HAS / written)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				appeal: {
+					id: 301,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.D },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: { visitDate: null }
+				}
+			},
+			{
+				description:
+					'transitions from lpa_questionnaire to awaiting_event when site visit exists with future date (HAS / written)',
+				expectedStatus: APPEAL_CASE_STATUS.AWAITING_EVENT,
+				appeal: {
+					id: 302,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.D },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: { visitDate: futureDate }
+				}
+			},
+			{
+				description:
+					'transitions from lpa_questionnaire directly to issue_determination when site visit is in the past (HAS / written)',
+				expectedStatus: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				appeal: {
+					id: 303,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.D },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.WRITTEN },
+					siteVisit: { visitDate: pastDate }
+				}
+			},
+			{
+				description: 'transitions from evidence to event when no inquiry exists (inquiry)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				mockRepresentations: standardRepresentations,
+				appeal: {
+					id: 400,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.EVIDENCE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.INQUIRY },
+					inquiry: null
+				}
+			},
+			{
+				description:
+					'transitions from evidence to awaiting_event when inquiry has address and future date',
+				expectedStatus: APPEAL_CASE_STATUS.AWAITING_EVENT,
+				mockRepresentations: standardRepresentations,
+				appeal: {
+					id: 401,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.EVIDENCE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.INQUIRY },
+					inquiry: { addressId: 1, inquiryStartTime: futureDate }
+				}
+			},
+			{
+				description: 'transitions from evidence to awaiting_event when inquiry is in the past',
+				expectedStatus: APPEAL_CASE_STATUS.AWAITING_EVENT,
+				mockRepresentations: standardRepresentations,
+				appeal: {
+					id: 402,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.EVIDENCE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.INQUIRY },
+					inquiry: { addressId: 1, inquiryStartTime: pastDate }
+				}
+			},
+			{
+				description:
+					'transitions from statements to event when hearing exists but has no addressId (hearing)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				appeal: {
+					id: 203,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.STATEMENTS, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.HEARING },
+					hearing: { addressId: null, hearingStartTime: futureDate }
+				}
+			},
+			{
+				description:
+					'transitions from evidence to event when inquiry exists but has no addressId (inquiry)',
+				expectedStatus: APPEAL_CASE_STATUS.EVENT,
+				mockRepresentations: standardRepresentations,
+				appeal: {
+					id: 403,
+					appealStatus: [{ status: APPEAL_CASE_STATUS.EVIDENCE, valid: true }],
+					appealType: { key: APPEAL_CASE_TYPE.W },
+					procedureType: { key: APPEAL_CASE_PROCEDURE.INQUIRY },
+					inquiry: { addressId: null, inquiryStartTime: futureDate }
+				}
+			}
+		];
+
+		test.each(testCases)(
+			'$description',
+			async ({ appeal, expectedStatus, mockRepresentations }) => {
+				const createMock = await runTransitionTest(appeal, mockRepresentations);
+				expect(createMock).toHaveBeenCalledWith({
+					data: expect.objectContaining({
+						appealId: appeal.id,
+						status: expectedStatus,
+						valid: true
+					})
+				});
+			}
+		);
 	});
 });
 

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -123,7 +123,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 	if (
 		newState === APPEAL_CASE_STATUS.EVENT &&
 		[APPEAL_CASE_TYPE.D, APPEAL_CASE_TYPE.W].includes(normalizedAppealTypeKey) &&
-		((normalizedProcedureKey === APPEAL_CASE_PROCEDURE.WRITTEN && appeal.siteVisit) ||
+		((normalizedProcedureKey === APPEAL_CASE_PROCEDURE.WRITTEN && appeal.siteVisit?.visitDate) ||
 			(normalizedProcedureKey === APPEAL_CASE_PROCEDURE.HEARING &&
 				appeal.hearing &&
 				appeal.hearing?.addressId) ||

--- a/appeals/api/src/server/utils/__tests__/calculate-due-date.test.js
+++ b/appeals/api/src/server/utils/__tests__/calculate-due-date.test.js
@@ -115,6 +115,16 @@ describe('calculateDueDate Tests', () => {
 		expect(dueDate).toEqual(createdAtPlusFortyBusinessDays);
 	});
 
+	test('maps STATE_TARGET_ISSUE_DETERMINATION to caseCreatedDate fallback when site visit exists but has no visitDate', async () => {
+		mockAppeal.appealStatus[0].status = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
+		mockAppeal.siteVisit = { visitDate: null };
+		mockAppeal.caseCreatedDate = new Date('2023-01-01T00:00:00.000Z');
+		const expectedCreatedAtPlusThirtyBusinessDays = new Date('2023-02-10T00:00:00.000Z');
+		// @ts-ignore
+		const dueDate = await calculateDueDate(mockAppeal, '');
+		expect(dueDate).toEqual(expectedCreatedAtPlusThirtyBusinessDays);
+	});
+
 	test('maps STATE_TARGET_ISSUE_DETERMINATION when site visit not available', async () => {
 		mockAppeal.appealStatus[0].status = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
 
@@ -192,6 +202,18 @@ describe('calculateDueDate Tests', () => {
 		// @ts-ignore
 		const dueDate = await calculateDueDate(mockAppeal, '');
 		expect(dueDate).toEqual(mockAppeal.siteVisit.visitDate);
+	});
+
+	test('handles STATE_TARGET_AWAITING_SITE_VISIT when site visit exists but has no visitDate', async () => {
+		mockAppeal.appealStatus[0].status = APPEAL_CASE_STATUS.AWAITING_EVENT;
+		mockAppeal.siteVisit = { visitDate: null };
+		mockAppeal.procedureType = {
+			key: APPEAL_CASE_PROCEDURE.WRITTEN
+		};
+
+		// @ts-ignore
+		const dueDate = await calculateDueDate(mockAppeal, '');
+		expect(dueDate).toBeUndefined();
 	});
 
 	test('handles STATE_TARGET_AWAITING_HEARING', async () => {

--- a/appeals/api/src/server/utils/calculate-due-date.js
+++ b/appeals/api/src/server/utils/calculate-due-date.js
@@ -89,9 +89,9 @@ export const calculateDueDate = async (appeal, costsDecision) => {
 			}
 			return new Date(appeal.caseExtensionDate ? appeal.caseExtensionDate : appeal.caseCreatedDate);
 		case APPEAL_CASE_STATUS.ISSUE_DETERMINATION: {
-			if (appeal.siteVisit) {
+			if (appeal.siteVisit?.visitDate) {
 				return await calculateIssueDecisionDeadline(
-					new Date(appeal.siteVisit.visitEndTime || appeal.siteVisit.visitDate || 0),
+					new Date(appeal.siteVisit.visitEndTime || appeal.siteVisit.visitDate),
 					approxStageCompletion.STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT
 				);
 			}
@@ -167,7 +167,7 @@ export const calculateDueDate = async (appeal, costsDecision) => {
 				}
 				return date;
 			}
-			return appeal.siteVisit ? new Date(appeal.siteVisit?.visitDate || 0) : undefined;
+			return appeal.siteVisit?.visitDate ? new Date(appeal.siteVisit.visitDate) : undefined;
 		}
 		case APPEAL_CASE_STATUS.EVENT: {
 			return new Date(

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
@@ -1585,6 +1585,7 @@ describe('required actions', () => {
 					getRequiredActionsForAppeal(
 						{
 							...appealData,
+							siteVisit: undefined,
 							appealStatus: APPEAL_CASE_STATUS.EVENT
 						},
 						'detail'

--- a/appeals/web/src/server/lib/mappers/utils/required-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/required-actions.js
@@ -95,7 +95,10 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 				!procedureType ||
 				procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN.toLowerCase()
 			) {
-				actions.push('arrangeSiteVisit');
+				// @ts-ignore
+				if (!appealDetails.siteVisit?.visitType) {
+					actions.push('arrangeSiteVisit');
+				}
 				break;
 			}
 


### PR DESCRIPTION
## Describe your changes

Site Visit Transitions: Restricted the site visit scheduling/updating state transition so that appeals (and their linked child appeals) only transition to Awaiting Site Visit (i.e. awaiting_event) if their current status is event. Updating a site visit on an appeal in any other state (e.g. final_comments) will no longer trigger an automatic status transition.

Linked Appeal Support: Updated the state transition logic match these status changes to linked child appeals if they match the parent's status.

Tests:
Added new tests transition-state.test.js to test transition logic from final comments to event, awaiting event and issue decision.
Added unit tests in site-visits-update.test.js covering linked appeal status transitions during site visit updates (verifying correct behavior for matching statuses, differing child statuses, non-event statuses, and ensuring related non-linked appeals are not updated).

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8796)
