### PR TITLE
fix(web): defining visit type when going through change date flow. (A2-8780)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/site-visit/schedule/schedule.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/schedule/schedule.controller.js
@@ -315,6 +315,14 @@ const renderKnowDateTimePage = async (request, response, apiErrors) => {
  */
 const renderScheduleVisitDatePage = async (request, response, apiErrors) => {
 	const { session, currentAppeal, body } = request;
+
+	if (!session.visitType) {
+		const visitType = currentAppeal?.siteVisit?.visitType;
+		if (visitType) {
+			session.visitType = visitType;
+		}
+	}
+
 	const errors = request.errors || apiErrors;
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		pageContent: scheduleVisitDateTimePage(


### PR DESCRIPTION
## Describe your changes

On Case Details page when only editing Date and Time for "Unaccompanied" site visit types, checks would fail as session.visitType was undefined as it had never been set like it does in the normal flow (Select visit type -> know visit date(yes) -> date and time).

Added a check that looks to see if session.visitType isn't there and sets it if not.

Tests relating to site-visit pass, doesn't affect function of other site visit types.

## Issue ticket number and link

[Changing the date for Unaccompanied site visit date returns the error "Enter the start time" where time is optional](https://pins-ds.atlassian.net.mcas.ms/browse/A2-8780)
