### PR TITLE
feat(api): database updates and seeding changes for enforcement team …

### DIFF
--- a/appeals/api/src/database/migrations/20260715140656_add_enforcement_team_to_lpa/migration.sql
+++ b/appeals/api/src/database/migrations/20260715140656_add_enforcement_team_to_lpa/migration.sql
@@ -1,0 +1,28 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropForeignKey
+ALTER TABLE [dbo].[LPA] DROP CONSTRAINT [LPA_teamId_fkey];
+
+-- AlterTable
+ALTER TABLE [dbo].[LPA] ADD [enforcementTeamId] INT;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[LPA] ADD CONSTRAINT [LPA_teamId_fkey] FOREIGN KEY ([teamId]) REFERENCES [dbo].[Team]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[LPA] ADD CONSTRAINT [LPA_enforcementTeamId_fkey] FOREIGN KEY ([enforcementTeamId]) REFERENCES [dbo].[Team]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -204,14 +204,16 @@ model ProcedureType {
 /// LPA model
 /// Contains information about the Local Planning Authority in the appeal site.
 model LPA {
-  id              Int              @id @default(autoincrement())
-  name            String
-  lpaCode         String           @unique
-  email           String?
-  appeals         Appeal[]
-  representations Representation[] @relation("lpaRepresentation")
-  team            Team?            @relation("team", fields: [teamId], references: [id])
-  teamId          Int?
+  id                Int              @id @default(autoincrement())
+  name              String
+  lpaCode           String           @unique
+  email             String?
+  appeals           Appeal[]
+  representations   Representation[] @relation("lpaRepresentation")
+  team              Team?            @relation("team", fields: [teamId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  teamId            Int?
+  enforcementTeam   Team?            @relation("enforcementTeam", fields: [enforcementTeamId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  enforcementTeamId Int?
 }
 
 /// ServiceUser model
@@ -1112,8 +1114,9 @@ model Team {
   name  String  @unique
   email String?
 
-  lpas   LPA[]    @relation("team")
-  Appeal Appeal[]
+  lpas            LPA[]    @relation("team")
+  enforcementLpas LPA[]    @relation("enforcementTeam")
+  Appeal          Appeal[]
 }
 
 /// PersonalList model

--- a/appeals/api/src/database/seed/LPAs/dev.js
+++ b/appeals/api/src/database/seed/LPAs/dev.js
@@ -14,43 +14,50 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'Q1111',
 		name: 'System Test Borough Council 2',
 		email: 'appealplanningdecisiontest@planninginspectorate.gov.uk',
-		teamId: 1 // Ops Test
+		teamId: 1, // Ops Test
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'MAID',
 		name: 'Maidstone Borough Council',
 		email: 'maid@lpa-email.gov.uk',
-		teamId: 2 // Ops Test
+		teamId: 2, // Ops Test
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'BARN',
 		name: 'Barnsley Metropolitan Borough Council',
 		email: 'barn@lpa-email.gov.uk',
-		teamId: 2 // Ops Test
+		teamId: 2, // Ops Test
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'WORT',
 		name: 'Worthing Borough Council',
 		email: 'wort@lpa-email.gov.uk',
-		teamId: 2 // Ops Test
+		teamId: 2, // Ops Test
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'DORS',
 		name: 'Dorset Council',
 		email: 'dors@lpa-email.gov.uk',
-		teamId: 2 // Ops Test
+		teamId: 2, // Ops Test
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'BASI',
 		name: 'Basingstoke and Deane Borough Council',
 		email: 'basi@lpa-email.gov.uk',
-		teamId: 3 // Ops Test
+		teamId: 3, // Ops Test
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'WILT',
 		name: 'Wiltshire Council',
 		email: 'wilt@lpa-email.gov.uk',
-		teamId: 3 // Ops Test
+		teamId: 3, // Ops Test
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'WAVE',
@@ -62,6 +69,7 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'BRIS',
 		name: 'Bristol City Council',
 		email: 'bris@lpa-email.gov.uk',
-		teamId: 3 // Ops Test
+		teamId: 3, // Ops Test
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	}
 ];

--- a/appeals/api/src/database/seed/LPAs/prod.js
+++ b/appeals/api/src/database/seed/LPAs/prod.js
@@ -18,636 +18,742 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'N5090',
 		name: 'Barnet',
 		email: 'planning.appeals@barnet.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H1705',
 		name: 'Basingstoke and Deane Borough Council',
 		email: 'appeals@basingstoke.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F0114',
 		name: 'Bath and North East Somerset Council',
 		email: 'Planning_appeals@bathnes.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'V1260',
 		name: 'Bournemouth, Christchurch and Poole',
 		email: 'planning.appeals@bcpcouncil.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G5180',
 		name: 'Bromley',
 		email: 'planningappeals@bromley.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K0425',
 		name: 'Buckinghamshire Council - Wycombe Area',
 		email: 'planning.wyc@buckinghamshire.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X3405',
 		name: 'Cannock Chase District Council',
 		email: 'developmentcontrol@cannockchasedc.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D0840',
 		name: 'Cornwall Council',
 		email: 'planningappeals@cornwall.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F1610',
 		name: 'Cotswold District Council',
 		email: 'planning.appeals@cotswold.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U4610',
 		name: 'Coventry City Council',
 		email: 'planning@coventry.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J9497',
 		name: 'Dartmoor National Park Authority',
 		email: 'planning@dartmoor.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D1265',
 		name: 'Dorset',
 		email: 'Appeals@dorsetcouncil.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C4615',
 		name: 'Dudley Metropolitan Borough Council',
 		email: 'development.control@dudley.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'U1105',
 		name: 'East Devon District Council',
 		email: 'planningappeals@eastdevon.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B3410',
 		name: 'East Staffordshire Borough Council',
 		email: 'dcsupport@eaststaffsbc.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W1715',
 		name: 'Eastleigh Borough Council',
 		email: 'ebcplanningsupport@eastleigh.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y1110',
 		name: 'Exeter City Council',
 		email: 'planning@exeter.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F9498',
 		name: 'Exmoor National Park Authority',
-		email: 'plan@exmoor-nationalpark.gov.uk'
+		email: 'plan@exmoor-nationalpark.gov.uk',
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'A1720',
 		name: 'Fareham Borough Council',
 		email: 'devcontrol@fareham.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'P1615',
 		name: 'Forest of Dean District Council',
 		email: 'planning.appeals@fdean.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U1620',
 		name: 'Gloucester City Council',
 		email: 'business.support@gloucester.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'T1600',
 		name: 'Gloucestershire',
 		email: 'planningdc@gloucestershire.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'J1725',
 		name: 'Gosport',
 		email: 'planning@gosport.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E5330',
 		name: 'Greenwich',
 		email: 'planning-enforcement@royalgreenwich.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'N1730',
 		name: 'Hart District Council',
 		email: 'appeals@hart.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'X1735',
 		name: 'Havant Borough Council',
 		email: 'planning.development@havant.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B5480',
 		name: 'Havering',
 		email: 'planning_appeals@havering.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'W1850',
 		name: 'Herefordshire Council',
 		email: 'planning_enquiries@herefordshire.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P2114',
 		name: 'Isle of Wight Council',
 		email: 'planning.appeals@iow.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'K3415',
 		name: 'Lichfield District Council',
 		email: 'appeals@lichfielddc.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J1860',
 		name: 'Malvern Hills District Council',
 		email: 'planningappeals@malvernhills.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Y1138',
 		name: 'Mid Devon District Council',
 		email: 'appeals@middevon.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B1740',
 		name: 'New Forest District Council',
 		email: 'planning.appeals@nfdc.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B9506',
 		name: 'New Forest National Park Authority',
 		email: 'appeals@newforestnpa.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'P3420',
 		name: 'Newcastle-under-Lyme Borough Council',
 		email: 'planningapplications@newcastle-staffs.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X1118',
 		name: 'North Devon District Council',
 		email: 'planningappeals@northdevon.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'R3705',
 		name: 'North Warwickshire Borough Council',
 		email: 'planningcontrol@northwarks.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W3710',
 		name: 'Nuneaton and Bedworth Borough Council',
 		email: 'planning@nuneatonandbedworth.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1160',
 		name: 'Plymouth City Council',
 		email: 'planningconsents@plymouth.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L5810',
 		name: 'Richmond',
 		email: 'richmondplanningappeals@richmondandwandsworth.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E3715',
 		name: 'Rugby Borough Council',
 		email: 'planningappeals@rugby.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P1750',
 		name: 'Rushmoor Borough Council',
 		email: 'plan@rushmoor.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L3245',
 		name: 'Shropshire Council',
 		email: 'appeals@shropshire.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J0350',
 		name: 'Slough Borough Council',
 		email: 'planning@slough.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Q4625',
 		name: 'Solihull Metropolitan Borough Council',
 		email: 'planningenforcement@solihull.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Y9507',
 		name: 'South Downs National Park Authority',
 		email: 'planning@southdowns.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'K1128',
 		name: 'South Hams District Council',
 		email: 'Dm.appeals@swdevon.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Q3115',
 		name: 'South Oxfordshire District Council',
 		email: 'planning.admin@southoxon.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D1780',
 		name: 'Southampton City Council',
 		email: 'planning.appeal@southampton.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y3425',
 		name: 'Stafford Borough Council',
 		email: 'planning@staffordbc.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'B3438',
 		name: 'Staffordshire Moorlands District Council',
 		email: 'planning@staffsmoorlands.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J3720',
 		name: 'Stratford-on-Avon District Council',
 		email: 'planning.appeals@stratford-dc.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C1625',
 		name: 'Stroud District Council',
 		email: 'planning.appeals@stroud.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U3935',
 		name: 'Swindon Borough Council',
 		email: 'appeals@swindon.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z3445',
 		name: 'Tamworth Borough Council',
 		email: 'planningadmin@tamworth.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P1133',
 		name: 'Teignbridge District Council',
 		email: 'planningappeals@teignbridge.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C3240',
 		name: 'Telford and Wrekin Council',
 		email: 'planningappeals@telford.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C1760',
 		name: 'Test Valley Borough Council',
 		email: 'planning@testvalley.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G1630',
 		name: 'Tewkesbury Borough Council',
 		email: 'appealsadmin@tewkesbury.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z0835',
 		name: 'The Isles of Scilly Council',
 		email: 'planning@scilly.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'X1165',
 		name: 'Torbay Council',
 		email: 'planning@torbay.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'W1145',
 		name: 'Torridge District Council',
 		email: 'planningsupport@torridge.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'V3120',
 		name: 'Vale of White Horse District Council',
 		email: 'planning.admin@whitehorsedc.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'V4630',
 		name: 'Walsall Metropolitan Borough Council',
 		email: 'planningservices@walsall.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T3725',
 		name: 'Warwick District Council',
 		email: 'planning_appeals@warwickdc.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W0340',
 		name: 'West Berkshire District Council',
 		email: 'appeals@westberks.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Q1153',
 		name: 'West Devon Borough Council',
 		email: 'dc@westdevon.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D3125',
 		name: 'West Oxfordshire District Council',
 		email: 'Planning.Appeals@westoxon.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Y3940',
 		name: 'Wiltshire Council',
 		email: 'planningappeals@wiltshire.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L1765',
 		name: 'Winchester City Council',
 		email: 'appeals@winchester.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D4635',
 		name: 'Wolverhampton City Council',
 		email: 'planning.appeals@wolverhampton.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M3835',
 		name: 'Worthing Borough Council',
 		email: 'planning-worthing@adur-worthing.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H1840',
 		name: 'Wychavon District Council',
 		email: 'Planning.Appeals@wychavon.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'R1845',
 		name: 'Wyre Forest District Council',
 		email: 'planning.admin@wyreforestdc.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M1005',
 		name: 'Amber Valley Borough Council',
 		email: 'planningappeals@ambervalley.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W3005',
 		name: 'Ashfield District Council',
 		email: 'planning.admin@ashfield-dc.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D3505',
 		name: 'Babergh District Council',
 		email: 'planning@baberghmidsuffolk.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R4408',
 		name: 'Barnsley Borough Council',
 		email: 'developmentcontrol@barnsley.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A3010',
 		name: 'Bassetlaw District Council',
 		email: 'planningappeals@bassetlaw.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T2405',
 		name: 'Blaby District Council',
 		email: 'planning@blaby.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M2372',
 		name: 'Blackburn with Darwen Borough Council',
 		email: 'planning@blackburn.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'R1010',
 		name: 'Bolsover District Council',
 		email: 'dev.control@bolsover.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N4205',
 		name: 'Bolton Metropolitan Borough Council',
 		email: 'planning.control@bolton.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z2505',
 		name: 'Boston Borough Council',
 		email: 'Planning@boston.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H1515',
 		name: 'Brentwood Borough Council',
 		email: 'planning@brentwood.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'K2610',
 		name: 'Broadland District Council',
 		email: 'appealbdc@southnorfolkandbroadland.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E9505',
 		name: 'Broads Authority',
 		email: 'planning@broads-authority.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W1905',
 		name: 'Borough of Broxbourne',
 		email: 'planning@broxbourne.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J3015',
 		name: 'Broxtowe Borough Council',
 		email: 'planningappeals@broxtowe.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z2315',
 		name: 'Burnley Borough Council',
 		email: 'planning@burnley.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A4710',
 		name: 'Calderdale Metropolitan Borough Council',
 		email: 'planningappeals@calderdale.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q0505',
 		name: 'Cambridge City Council',
 		email: 'appeals@greatercambridgeplanning.org',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E0535',
 		name: 'Cambridgeshire County Council',
 		email: 'planningdc@cambridgeshire.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M1520',
 		name: 'Castle Point Borough Council',
 		email: 'planning@castlepoint.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X2410',
 		name: 'Charnwood Borough Council',
 		email: 'development.control@charnwood.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A1015',
 		name: 'Chesterfield Borough Council',
 		email: 'planning@chesterfield.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'L3815',
 		name: 'Chichester District Council',
 		email: 'planningappeals@chichester.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M2515',
 		name: 'City of Lincoln Council',
 		email: 'developmentteam@lincoln.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'F0935',
 		name: 'Cumberland Council',
 		email: 'planning.appeals@cumberland.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A1910',
 		name: 'Dacorum Borough Council',
 		email: 'planning@dacorum.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1350',
 		name: 'Darlington Borough Council',
 		email: 'planning.enquiries@darlington.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U1050',
 		name: 'Derbyshire County Council',
 		email: 'development.management@derbyshire.gov.uk',
-		teamId: null
+		teamId: null,
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P1045',
 		name: 'Derbyshire Dales District Council',
 		email: 'planning@derbyshiredales.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'F4410',
 		name: 'Doncaster Metropolitan Borough Council',
 		email: 'tsi@doncaster.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'V0510',
 		name: 'East Cambridgeshire District Council',
 		email: 'appeals@eastcambs.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'D2510',
 		name: 'East Lindsey District Council',
 		email: 'planning.appeals@e-lindsey.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J2285',
@@ -659,151 +765,176 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'N1025',
 		name: 'Erewash Borough Council',
 		email: 'planning@erewash.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z1585',
 		name: 'Essex County Council',
 		email: 'mineralsandwastedm@essex.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'D0515',
 		name: 'Fenland District Council',
 		email: 'planningappeals@fenland.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M2325',
 		name: 'Fylde Borough Council',
 		email: 'planning@fylde.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H4505',
 		name: 'Gateshead Metropolitan Borough Council',
 		email: 'planning@gateshead.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'N3020',
 		name: 'Gedling Borough Council',
 		email: 'PandEServiceSupport@gedling.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'K2230',
 		name: 'Gravesham Borough Council',
 		email: 'planning.appeals@gravesham.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'U2615',
 		name: 'Great Yarmouth Borough Council',
 		email: 'plan@great-yarmouth.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'D0650',
 		name: 'Halton Borough Council',
 		email: 'dev.control@halton.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q1770',
 		name: 'Hampshire County Council',
 		email: 'planning@hants.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F2415',
 		name: 'Harborough District Council',
 		email: 'planning@harborough.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1540',
 		name: 'Harlow District Council',
 		email: 'planning.services@harlow.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H0724',
 		name: 'Hartlepool Borough Council',
 		email: 'developmentcontrol@hartlepool.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B1415',
 		name: 'Hastings Borough Council',
 		email: 'planning@hastings.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M1900',
 		name: 'Hertfordshire County Council',
 		email: 'spatialplanning@hertfordshire.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1920',
 		name: 'Hertsmere Borough Council',
 		email: 'appeals.planning@Hertsmere.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H1033',
 		name: 'High Peak Borough Council',
 		email: 'planning@highpeak.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'K2420',
 		name: 'Hinckley and Bosworth Borough Council',
 		email: 'planningappeal@hinckley-bosworth.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H0520',
 		name: 'Huntingdonshire District Council',
 		email: 'planning.appeals@huntingdonshire.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R2330',
 		name: 'Hyndburn Borough Council',
 		email: 'planning@hyndburnbc.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'R3515',
 		name: 'Ipswich Borough Council',
 		email: 'development.management@ipswich.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W2275',
 		name: 'Kent County Council',
 		email: 'planning.applications@kent.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V2004',
 		name: 'Kingston-Upon-Hull City Council',
 		email: 'dev.control@hullcc.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z4718',
 		name: 'Kirklees Metropolitan Council',
 		email: 'dc.admin@kirklees.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'V4305',
 		name: 'Knowsley Metropolitan Borough Council',
 		email: 'dcconsultations@knowsley.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q9495',
@@ -815,769 +946,897 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'Q2371',
 		name: 'Lancashire County Council',
 		email: 'devcon@lancashire.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W2465',
 		name: 'Leicester City Council',
 		email: 'planning@leicester.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z5060',
 		name: 'London Borough of Barking and Dagenham Council',
 		email: 'Planning@lbbd.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R5510',
 		name: 'London Borough of Hillingdon',
 		email: 'PlanningAppeals@Hillingdon.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'N5660',
 		name: 'London Borough of Lambeth',
 		email: 'planningappeals@lambeth.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W5780',
 		name: 'London Borough of Redbridge',
 		email: 'planning.appeals@redbridge.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X1545',
 		name: 'Maldon District Council',
 		email: 'dc.planning@maldon.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X3025',
 		name: 'Mansfield District Council',
 		email: 'pbc@mansfield.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A2280',
 		name: 'Medway Council',
 		email: 'planningappeals@medway.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Y2430',
 		name: 'Melton Borough Council',
 		email: 'externaldevelopmentcontrol@melton.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D3830',
 		name: 'Mid Sussex District Council',
 		email: 'planningappeals@midsussex.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W0734',
 		name: 'Middlesbrough Council',
 		email: 'developmentcontrol@middlesbrough.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B3030',
 		name: 'Newark & Sherwood District Council',
 		email: 'planningappeals@newark-sherwooddc.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X2600',
 		name: 'Norfolk County Council',
 		email: 'mawp@norfolk.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R1038',
 		name: 'North East Derbyshire District Council',
 		email: 'developmentcontrol@ne-derbyshire.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'B2002',
 		name: 'North East Lincolnshire Council',
 		email: 'Planning@nelincs.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'X1925',
 		name: 'North Hertfordshire District Council',
 		email: 'planning.appeals@north-herts.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'R2520',
 		name: 'North Kesteven District Council',
 		email: 'planning@n-kesteven.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Y2620',
 		name: 'North Norfolk District Council',
 		email: 'planning-appeals@north-norfolk.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W4515',
 		name: 'North Tyneside Council',
 		email: 'development.control@northtyneside.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'G2435',
 		name: 'North West Leicestershire District Council',
 		email: 'development.control@nwleicestershire.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W9500',
 		name: 'North York Moors National Park Authority',
 		email: 'planning@northyorkmoors.org.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'T9501',
 		name: 'Northumberland National Park Authority',
 		email: 'planning@nnpa.org.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q3060',
 		name: 'Nottingham City Council',
 		email: 'PlanningAppeals@nottinghamcity.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'L2440',
 		name: 'Oadby and Wigston Borough Council',
 		email: 'planning@oadby-wigston.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'F5730',
 		name: 'Old Oak and Park Royal Development Corporation',
 		email: 'planningapplications@opdc.london.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U3100',
 		name: 'Oxfordshire County Council',
 		email: 'planning@oxfordshire.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M9496',
 		name: 'Peak District National Park Authority',
 		email: 'planningappeals@peakdistrict.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'E2340',
 		name: 'Pendle Borough Council',
 		email: 'planning@pendle.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J0540',
 		name: 'Peterborough City Council',
 		email: 'planningappeals@peterborough.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'N2345',
 		name: 'Preston City Council',
 		email: 'devcon@preston.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'V0728',
 		name: 'Redcar and Cleveland Borough Council',
 		email: 'planning_admin@redcar-cleveland.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'T2350',
 		name: 'Ribble Valley Borough Council',
 		email: 'planningappeals@ribblevalley.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B1550',
 		name: 'Rochford District Council',
 		email: 'planning.appeals@rochford.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'B2355',
 		name: 'Rossendale Borough Council',
 		email: 'planningappeals@rossendalebc.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U1430',
 		name: 'Rother District Council',
 		email: 'Planning-Appeals@rother.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P4415',
 		name: 'Rotherham Metropolitan Borough Council',
 		email: 'development.control@rotherham.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K5600',
 		name: 'Royal Borough of Kensington and Chelsea',
 		email: 'planningappeals@rbkc.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'P3040',
 		name: 'Rushcliffe Borough Council',
 		email: 'planningappealsadmin@rushcliffe.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A2470',
 		name: 'Rutland County Council',
 		email: 'planningappeals@rutland.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M4320',
 		name: 'Sefton Metropolitan Borough Council',
 		email: 'planning.appeals@sefton.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'G2245',
 		name: 'Sevenoaks District Council',
 		email: 'appeals@sevenoaks.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W0530',
 		name: 'South Cambridgeshire District Council',
 		email: 'DSAppeals@scambs.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'F1040',
 		name: 'South Derbyshire District Council',
 		email: 'Planning@southderbyshire.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A2525',
 		name: 'South Holland District Council',
 		email: 'planningadvice@sholland.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'E2530',
 		name: 'South Kesteven District Council',
 		email: 'Planning@southkesteven.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'L2630',
 		name: 'South Norfolk District Council',
 		email: 'appealsnc@southnorfolkandbroadland.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'F2360',
 		name: 'South Ribble Borough Council',
 		email: 'planning@southribble.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A4520',
 		name: 'South Tyneside Council',
 		email: 'planningapplications@southtyneside.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K1935',
 		name: 'Stevenage Borough Council',
 		email: 'planning@stevenage.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'V3500',
 		name: 'Suffolk County Council',
 		email: 'planning@suffolk.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'J4525',
 		name: 'Sunderland City Council',
 		email: 'dc@sunderland.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B3600',
 		name: 'Surrey County Council',
 		email: 'mwcd@surreycc.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V2255',
 		name: 'Swale Borough Council',
 		email: 'planningappeals@midkent.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1560',
 		name: 'Tendring District Council',
 		email: 'appeals.planningservices@tendringdc.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Z2260',
 		name: 'Thanet District Council',
 		email: 'planning.services@thanet.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1940',
 		name: 'Three Rivers District Council',
 		email: 'trdc.appeals@threerivers.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M1595',
 		name: 'Thurrock Borough Council',
 		email: 'plan.appeals@thurrock.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H2265',
 		name: 'Tonbridge and Malling Borough Council',
 		email: 'planning.appeals@tmbc.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M2270',
 		name: 'Tunbridge Wells Borough Council',
 		email: 'planningappeals@tunbridgewells.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Y1945',
 		name: 'Watford Borough Council',
 		email: 'developmentcontrol@watford.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C1950',
 		name: 'Welwyn Hatfield Council',
 		email: 'planningappeals@welhat.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'K0940',
 		name: 'Westmorland and Furness Council',
 		email: 'appeals4@westmorlandandfurness.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'N2535',
 		name: 'West Lindsey District Council',
 		email: 'Planning.Customer.Care@west-lindsey.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'F3545',
 		name: 'West Suffolk',
 		email: 'planning.technical@westsuffolk.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V4250',
 		name: 'Wigan Metropolitan Borough Council',
 		email: 'planning@wigan.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W4325',
 		name: 'Wirral Metropolitan Borough Council',
 		email: 'appeals@wirral.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U2370',
 		name: 'Wyre Borough Council',
 		email: 'planning@wyre.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'C9499',
 		name: 'Yorkshire Dales National Park Authority',
 		email: 'planning@yorkshiredales.org.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Y3805',
 		name: 'Adur District Council',
 		email: 'planning-Adur@adur-worthing.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P4605',
 		name: 'Birmingham City Council',
 		email: 'planning.appeals@birmingham.gov.uk',
-		teamId: 10 //west4
+		teamId: 10, //west4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'R0335',
 		name: 'Bracknell Forest Borough Council',
 		email: 'planning.appeals@bracknell-forest.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z0116',
 		name: 'Bristol City Council',
 		email: 'development.management@bristol.gov.uk',
-		teamId: 10 //west4
+		teamId: 10, //west4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B1605',
 		name: 'Cheltenham Borough Council',
 		email: 'planning.appeals@cheltenham.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C3105',
 		name: 'Cherwell District Council',
 		email: 'submit.appeal@cherwell-dc.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T1410',
 		name: 'Eastbourne Borough Council',
 		email: 'customerfirst@lewes-eastbourne.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M1710',
 		name: 'East Hampshire District Council',
 		email: 'planning.appeals@easthants.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L2250',
 		name: 'Folkestone and Hythe District Council',
 		email: 'Planning@folkestone-hythe.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1425',
 		name: 'Lewes District Council',
 		email: 'planningfirst@lewes-eastbourne.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X5210',
 		name: 'London Borough of Camden',
 		email: 'planningappeals@camden.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F5540',
 		name: 'London Borough of Hounslow',
 		email: 'planningappeals@hounslow.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T5720',
 		name: 'London Borough of Merton',
 		email: 'planning.appeals@merton.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A5840',
 		name: 'London Borough of Southwark',
 		email: 'planning.appeals@southwark.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P5870',
 		name: 'London Borough of Sutton',
 		email: 'developmentcontrol@sutton.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H5960',
 		name: 'London Borough of Wandsworth',
 		email: 'WandsworthPlanningAppeals@richmondandwandsworth.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y0435',
 		name: 'Milton Keynes Council',
 		email: 'dcappeals@milton-keynes.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D0121',
 		name: 'North Somerset Council',
 		email: 'DMAppeals@n-somerset.gov.uk',
-		teamId: 10 //west4
+		teamId: 10, //west4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G3110',
 		name: 'Oxford City Council',
 		email: 'planningappeals@oxford.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z1775',
 		name: 'Portsmouth City Council',
 		email: 'planningapps@portsmouthcc.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E0345',
 		name: 'Reading Borough Council',
 		email: 'plgadmin@reading.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z5630',
 		name: 'Royal Borough of Kingston Upon Thames',
 		email: 'planning.appeals@kingston.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'T0355',
 		name: 'Royal Borough of Windsor and Maidenhead',
 		email: 'planning.appeals@rbwm.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G4620',
 		name: 'Sandwell Metropolitan Borough Council',
 		email: 'planning@sandwell.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P0119',
 		name: 'South Gloucestershire Council',
 		email: 'planningsupport@southglos.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C3430',
 		name: 'South Staffordshire District Council',
 		email: 'Appeals@sstaffs.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M3455',
 		name: 'Stoke-on-Trent City Council',
 		email: 'planning@stoke.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X0360',
 		name: 'Wokingham Borough Council',
 		email: 'planning.appeals@wokingham.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D1835',
 		name: 'Worcester City Council',
 		email: 'planning@worcester.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C3810',
 		name: 'Arun District Council',
 		email: 'planning@arun.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E2205',
 		name: 'Ashford Borough Council',
 		email: 'planning.appeals@ashford.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V1505',
 		name: 'Basildon Borough Council',
 		email: 'appeals@basildon.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'K0235',
 		name: 'Bedford Borough Council',
 		email: 'planningappeals@bedford.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J2373',
 		name: 'Blackpool Council',
 		email: 'planning@blackpool.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z1510',
 		name: 'Braintree District Council',
 		email: 'appeals@braintree.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'F2605',
 		name: 'Breckland District Council',
 		email: 'planningappeals@breckland.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Q1445',
 		name: 'Brighton and Hove City Council',
 		email: 'planning.appeals@brighton-hove.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1805',
 		name: 'Bromsgrove District Council',
 		email: 'newplan@bromsgroveandredditch.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C0440',
 		name: 'Buckinghamshire Council',
 		email: 'planning.appeals@buckinghamshire.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T4210',
 		name: 'Bury Metropolitan Borough Council',
 		email: 'development.control@bury.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J2210',
 		name: 'Canterbury City Council',
 		email: 'planning@canterbury.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P0240',
 		name: 'Central Bedfordshire Council',
 		email: 'planning.appeals@centralbedfordshire.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W1525',
 		name: 'Chelmsford City Council',
 		email: 'appeals.planning@chelmsford.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R0660',
 		name: 'Cheshire East Council',
 		email: 'planningappeals@cheshireeast.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A0665',
 		name: 'Cheshire West and Chester Council',
 		email: 'planning.appeals@cheshirewestandchester.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D2320',
 		name: 'Chorley Borough Council',
 		email: 'dcon@chorley.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W4705',
 		name: 'City of Bradford Metropolitan District Council',
 		email: 'appealsplanning@bradford.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K5030',
 		name: 'City of London Council',
 		email: 'plncomments@cityoflondon.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'X5990',
 		name: 'City of Westminster Council',
 		email: 'planningappeals@westminster.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C2741',
 		name: 'City of York Council',
 		email: 'planning.appeals@york.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A1530',
 		name: 'Colchester City Council',
 		email: 'planning.services@colchester.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Q3820',
 		name: 'Crawley Borough Council',
 		email: 'planningappeals@crawley.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'T2215',
 		name: 'Dartford Borough Council',
 		email: 'dc.appeals@dartford.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'C1055',
 		name: 'Derby City Council',
 		email: 'pins.correspondence@derby.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X2220',
 		name: 'Dover District Council',
 		email: 'planningappeals@dover.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X1355',
 		name: 'Durham County Council',
 		email: 'planning@durham.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J1915',
 		name: 'East Hertfordshire District Council',
 		email: 'planning.tech@eastherts.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'E2001',
 		name: 'East Riding of Yorkshire Council',
 		email: 'planning.appeals@eastriding.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'X3540',
 		name: 'East Suffolk Council',
 		email: 'appeals@eastsuffolk.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'G1440',
@@ -1589,355 +1848,414 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'K3605',
 		name: 'Elmbridge Borough Council',
 		email: 'tpappeals@elmbridge.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'J1535',
 		name: 'Epping Forest District Council',
 		email: 'appealsadmin@eppingforestdc.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P3610',
 		name: 'Epsom and Ewell Borough Council',
 		email: 'PlanningAppeals@epsom-ewell.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Y3615',
 		name: 'Guildford Borough Council',
 		email: 'planningappeals@guildford.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Z3825',
 		name: 'Horsham District Council',
 		email: 'planning@horsham.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V2635',
 		name: "King's Lynn and West Norfolk Borough Council",
 		email: 'borough.planning@west-norfolk.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'A2335',
 		name: 'Lancaster City Council',
 		email: 'dm@lancaster.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'N4720',
 		name: 'Leeds City Council',
 		email: 'planning.appeals@leeds.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'M2460',
 		name: 'Leicestershire County Council',
 		email: 'planningcontrol@leics.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Q2500',
 		name: 'Lincolnshire County Council',
 		email: 'Dev_planningenquiries@lincolnshire.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z4310',
 		name: 'Liverpool City Council',
 		email: 'planningappeals@liverpool.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D5120',
 		name: 'London Borough of Bexley',
 		email: 'planningappeals@bexley.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'T5150',
 		name: 'London Borough of Brent',
 		email: 'appeals@brent.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'L5240',
 		name: 'London Borough of Croydon',
 		email: 'planning.appeals@croydon.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A5270',
 		name: 'London Borough of Ealing',
 		email: 'planningappeals@ealing.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Q5300',
 		name: 'London Borough of Enfield',
 		email: 'planning.appeals@enfield.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'U5360',
 		name: 'London Borough of Hackney',
 		email: 'planningappeals@hackney.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'H5390',
 		name: 'London Borough of Hammersmith and Fulham',
 		email: 'planningappeals@lbhf.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y5420',
 		name: 'London Borough of Haringey',
 		email: 'planning.appeals@haringey.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M5450',
 		name: 'London Borough of Harrow',
 		email: 'planningappeals@harrow.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'V5570',
 		name: 'London Borough of Islington',
 		email: 'planningappeals@islington.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'C5690',
 		name: 'London Borough of Lewisham',
 		email: 'planningappeals@lewisham.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'G5750',
 		name: 'London Borough of Newham',
 		email: 'planning.appeals@newham.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E5900',
 		name: 'London Borough of Tower Hamlets',
 		email: 'development.control@towerhamlets.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B0230',
 		name: 'Luton Borough Council',
 		email: 'dcappeals@luton.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'U2235',
 		name: 'Maidstone Borough Council',
 		email: 'planningappeals@midkent.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'B4215',
 		name: 'Manchester City Council',
 		email: 'planning@manchester.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W3520',
 		name: 'Mid Suffolk District Council',
 		email: 'planning@baberghmidsuffolk.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'C3620',
 		name: 'Mole Valley District Council',
 		email: 'appeals@molevalley.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M4510',
 		name: 'Newcastle Upon Tyne City Council',
 		email: 'planning.appeals@newcastle.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Y2003',
 		name: 'North Lincolnshire Council',
 		email: 'planning@northlincs.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'M2840',
 		name: 'North Northamptonshire Council',
 		email: 'planningappeals@northnorthants.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'U2750',
 		name: 'North Yorkshire Council',
 		email: 'NYCplanningappeals@northyorks.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'P2935',
 		name: 'Northumberland County Council',
 		email: 'planning@northumberland.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'G2625',
 		name: 'Norwich City Council',
 		email: 'planning@norwich.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'L3055',
 		name: 'Nottinghamshire County Council',
 		email: 'development.management@nottscc.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W4223',
 		name: 'Oldham Metropolitan Borough Council',
 		email: 'planning@oldham.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q1825',
 		name: 'Redditch Borough Council',
 		email: 'developmentcontrol@redditchbc.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'L3625',
 		name: 'Reigate and Banstead Borough Council',
 		email: 'planning.appeals@reigate-banstead.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P4225',
 		name: 'Rochdale Metropolitan Borough Council',
 		email: 'development.management@rochdale.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q3630',
 		name: 'Runnymede Borough Council',
 		email: 'planning@runnymede.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'U4230',
 		name: 'Salford City Council',
 		email: 'planning.contact@salford.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J4423',
 		name: 'Sheffield City Council',
 		email: 'InspectoratePlanningAppeals@sheffield.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'E3335',
 		name: 'Somerset Council',
 		email: 'planningappeals@somerset.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D1590',
 		name: 'Southend-on-Sea Borough Council',
 		email: 'planningappeal@southend.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Z3635',
 		name: 'Spelthorne Borough Council',
 		email: 'planningdm.appeals@spelthorne.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'B1930',
 		name: 'St Albans City Council',
 		email: 'pins.appeals@stalbans.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H4315',
 		name: 'St Helens Metropolitan Borough Council',
 		email: 'planning@sthelens.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D3450',
 		name: 'Staffordshire County Council',
 		email: 'planning@staffordshire.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C4235',
 		name: 'Stockport Metropolitan Borough Council',
 		email: 'planningappeals@stockport.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H0738',
 		name: 'Stockton-on-Tees Borough Council',
 		email: 'planningdevelopmentservices@stockton.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D3640',
 		name: 'Surrey Heath Borough Council',
 		email: 'planning.appeals@surreyheath.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'G4240',
 		name: 'Tameside Metropolitan Borough Council',
 		email: 'planningmail@tameside.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'M3645',
 		name: 'Tandridge District Council',
 		email: 'PlanningAppealsLegal@tandridge.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Q4245',
 		name: 'Trafford Metropolitan Borough Council',
 		email: 'appeals.planning@trafford.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'C1570',
 		name: 'Uttlesford District Council',
 		email: 'planning@uttlesford.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X4725',
 		name: 'Wakefield Metropolitan District Council',
 		email: 'appeals@wakefield.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U5930',
 		name: 'Waltham Forest London Borough Council',
 		email: 'planningappeals@walthamforest.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'M0655',
 		name: 'Warrington Borough Council',
 		email: 'devcontrol@warrington.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H3700',
@@ -1949,37 +2267,43 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'R3650',
 		name: 'Waverley Borough Council',
 		email: 'consultation.planning@waverley.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'C1435',
 		name: 'Wealden District Council',
 		email: 'planning.appeals@wealden.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P2365',
 		name: 'West Lancashire District Council',
 		email: 'plan.appeals@westlancs.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W2845',
 		name: 'West Northamptonshire Council',
 		email: 'planningappeals@westnorthants.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P3800',
 		name: 'West Sussex County Council',
 		email: 'planning.applications@westsussex.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'A3655',
 		name: 'Woking Borough Council',
 		email: 'developmentcontrol@woking.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E1855',
@@ -1991,13 +2315,15 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'F0745',
 		name: 'Hartlepool Development Corporation',
 		email: 'HDCplanning@teesvalley-ca.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K0750',
 		name: 'Middlesbrough Development Corporation',
 		email: 'MDCplanning@teesvalley-ca.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J1155',

--- a/appeals/api/src/database/seed/LPAs/training.js
+++ b/appeals/api/src/database/seed/LPAs/training.js
@@ -20,635 +20,741 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'N5090',
 		name: 'Barnet',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H1705',
 		name: 'Basingstoke and Deane Borough Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F0114',
 		name: 'Bath and North East Somerset Council',
 		email: 'Planning_appeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'V1260',
 		name: 'Bournemouth, Christchurch and Poole',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G5180',
 		name: 'Bromley',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K0425',
 		name: 'Buckinghamshire Council - Wycombe Area',
-		email: 'planning.wyc@example.gov.uk'
+		email: 'planning.wyc@example.gov.uk',
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X3405',
 		name: 'Cannock Chase District Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D0840',
 		name: 'Cornwall Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F1610',
 		name: 'Cotswold District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U4610',
 		name: 'Coventry City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J9497',
 		name: 'Dartmoor National Park Authority',
 		email: 'planning@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D1265',
 		name: 'Dorset',
 		email: 'Appeals@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C4615',
 		name: 'Dudley Metropolitan Borough Council',
 		email: 'development.control@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'U1105',
 		name: 'East Devon District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B3410',
 		name: 'East Staffordshire Borough Council',
 		email: 'dcsupport@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W1715',
 		name: 'Eastleigh Borough Council',
 		email: 'ebcplanningsupport@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y1110',
 		name: 'Exeter City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F9498',
 		name: 'Exmoor National Park Authority',
-		email: 'plan@example.gov.uk'
+		email: 'plan@example.gov.uk',
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'A1720',
 		name: 'Fareham Borough Council',
 		email: 'devcontrol@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'P1615',
 		name: 'Forest of Dean District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U1620',
 		name: 'Gloucester City Council',
 		email: 'Development.Control@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'T1600',
 		name: 'Gloucestershire',
 		email: 'planningdc@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'J1725',
 		name: 'Gosport',
 		email: 'planning@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E5330',
 		name: 'Greenwich',
 		email: 'planning-enforcement@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'N1730',
 		name: 'Hart District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'X1735',
 		name: 'Havant Borough Council',
 		email: 'planning.development@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B5480',
 		name: 'Havering',
 		email: 'planning_appeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'W1850',
 		name: 'Herefordshire Council',
 		email: 'planning_enquiries@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P2114',
 		name: 'Isle of Wight Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'K3415',
 		name: 'Lichfield District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J1860',
 		name: 'Malvern Hills District Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Y1138',
 		name: 'Mid Devon District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B1740',
 		name: 'New Forest District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B9506',
 		name: 'New Forest National Park Authority',
 		email: 'appeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'P3420',
 		name: 'Newcastle-under-Lyme Borough Council',
 		email: 'planningapplications@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X1118',
 		name: 'North Devon District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'R3705',
 		name: 'North Warwickshire Borough Council',
 		email: 'planningcontrol@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W3710',
 		name: 'Nuneaton and Bedworth Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1160',
 		name: 'Plymouth City Council',
 		email: 'planningconsents@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L5810',
 		name: 'Richmond',
 		email: 'richmondplanningappeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E3715',
 		name: 'Rugby Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P1750',
 		name: 'Rushmoor Borough Council',
 		email: 'plan@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L3245',
 		name: 'Shropshire Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J0350',
 		name: 'Slough Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Q4625',
 		name: 'Solihull Metropolitan Borough Council',
 		email: 'planningenforcement@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Y9507',
 		name: 'South Downs National Park Authority',
 		email: 'planning@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'K1128',
 		name: 'South Hams District Council',
 		email: 'Dm.appeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Q3115',
 		name: 'South Oxfordshire District Council',
 		email: 'registration@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D1780',
 		name: 'Southampton City Council',
 		email: 'planning.appeal@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y3425',
 		name: 'Stafford Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'B3438',
 		name: 'Staffordshire Moorlands District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J3720',
 		name: 'Stratford-on-Avon District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C1625',
 		name: 'Stroud District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U3935',
 		name: 'Swindon Borough Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z3445',
 		name: 'Tamworth Borough Council',
 		email: 'planningadmin@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P1133',
 		name: 'Teignbridge District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C3240',
 		name: 'Telford and Wrekin Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C1760',
 		name: 'Test Valley Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G1630',
 		name: 'Tewkesbury Borough Council',
 		email: 'appealsadmin@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z0835',
 		name: 'The Isles of Scilly Council',
 		email: 'planning@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'X1165',
 		name: 'Torbay Council',
 		email: 'planning@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'W1145',
 		name: 'Torridge District Council',
 		email: 'planningsupport@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'V3120',
 		name: 'Vale of White Horse District Council',
 		email: 'registration@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'V4630',
 		name: 'Walsall Metropolitan Borough Council',
 		email: 'planningservices@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T3725',
 		name: 'Warwick District Council',
 		email: 'planning_appeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W0340',
 		name: 'West Berkshire District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Q1153',
 		name: 'West Devon Borough Council',
 		email: 'dc@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D3125',
 		name: 'West Oxfordshire District Council',
 		email: 'Planning.Appeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Y3940',
 		name: 'Wiltshire Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L1765',
 		name: 'Winchester City Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D4635',
 		name: 'Wolverhampton City Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M3835',
 		name: 'Worthing Borough Council',
 		email: 'planning-worthing@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H1840',
 		name: 'Wychavon District Council',
 		email: 'Planning.Appeals@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'R1845',
 		name: 'Wyre Forest District Council',
 		email: 'planning.admin@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M1005',
 		name: 'Amber Valley Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W3005',
 		name: 'Ashfield District Council',
 		email: 'planning.admin@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D3505',
 		name: 'Babergh District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R4408',
 		name: 'Barnsley Borough Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A3010',
 		name: 'Bassetlaw District Council',
 		email: 'planning.appeal@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T2405',
 		name: 'Blaby District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M2372',
 		name: 'Blackburn with Darwen Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'R1010',
 		name: 'Bolsover District Council',
 		email: 'dev.control@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N4205',
 		name: 'Bolton Metropolitan Borough Council',
 		email: 'planning.control@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z2505',
 		name: 'Boston Borough Council',
 		email: 'Planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H1515',
 		name: 'Brentwood Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'K2610',
 		name: 'Broadland District Council',
 		email: 'appealbdc@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E9505',
 		name: 'Broads Authority',
 		email: 'planning@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W1905',
 		name: 'Borough of Broxbourne',
 		email: 'planning@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J3015',
 		name: 'Broxtowe Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z2315',
 		name: 'Burnley Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A4710',
 		name: 'Calderdale Metropolitan Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q0505',
 		name: 'Cambridge City Council',
 		email: 'asappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E0535',
 		name: 'Cambridgeshire County Council',
 		email: 'planningdc@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M1520',
 		name: 'Castle Point Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X2410',
 		name: 'Charnwood Borough Council',
 		email: 'development.control@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A1015',
 		name: 'Chesterfield Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'L3815',
 		name: 'Chichester District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M2515',
 		name: 'City of Lincoln Council',
 		email: 'developmentteam@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'F0935',
 		name: 'Cumberland Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A1910',
 		name: 'Dacorum Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1350',
 		name: 'Darlington Borough Council',
 		email: 'planning.enquiries@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U1050',
 		name: 'Derbyshire County Council',
 		email: 'planningcontrol@example.gov.uk',
-		teamId: null
+		teamId: null,
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P1045',
 		name: 'Derbyshire Dales District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'F4410',
 		name: 'Doncaster Metropolitan Borough Council',
 		email: 'tsi@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'V0510',
 		name: 'East Cambridgeshire District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'D2510',
 		name: 'East Lindsey District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J2285',
@@ -660,151 +766,176 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'N1025',
 		name: 'Erewash Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z1585',
 		name: 'Essex County Council',
 		email: 'mineralsandwastedm@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'D0515',
 		name: 'Fenland District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M2325',
 		name: 'Fylde Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H4505',
 		name: 'Gateshead Metropolitan Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'N3020',
 		name: 'Gedling Borough Council',
 		email: 'PandEServiceSupport@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'K2230',
 		name: 'Gravesham Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'U2615',
 		name: 'Great Yarmouth Borough Council',
 		email: 'plan@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'D0650',
 		name: 'Halton Borough Council',
 		email: 'dev.control@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q1770',
 		name: 'Hampshire County Council',
 		email: 'planning@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F2415',
 		name: 'Harborough District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1540',
 		name: 'Harlow District Council',
 		email: 'planning.services@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H0724',
 		name: 'Hartlepool Borough Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B1415',
 		name: 'Hastings Borough Council',
 		email: 'dcenquiries@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M1900',
 		name: 'Hertfordshire County Council',
 		email: 'spatialplanning@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'N1920',
 		name: 'Hertsmere Borough Council',
 		email: 'appeals.planning@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H1033',
 		name: 'High Peak Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'K2420',
 		name: 'Hinckley and Bosworth Borough Council',
 		email: 'planningappeal@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H0520',
 		name: 'Huntingdonshire District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R2330',
 		name: 'Hyndburn Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'R3515',
 		name: 'Ipswich Borough Council',
 		email: 'development.management@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W2275',
 		name: 'Kent County Council',
 		email: 'planning.applications@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V2004',
 		name: 'Kingston-Upon-Hull City Council',
 		email: 'dev.control@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z4718',
 		name: 'Kirklees Metropolitan Council',
 		email: 'dc.admin@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'V4305',
 		name: 'Knowsley Metropolitan Borough Council',
 		email: 'dcconsultations@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q9495',
@@ -816,769 +947,897 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'Q2371',
 		name: 'Lancashire County Council',
 		email: 'devcon@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W2465',
 		name: 'Leicester City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z5060',
 		name: 'London Borough of Barking and Dagenham Council',
 		email: 'Planning@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R5510',
 		name: 'London Borough of Hillingdon',
 		email: 'PlanningAppeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'N5660',
 		name: 'London Borough of Lambeth',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W5780',
 		name: 'London Borough of Redbridge',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X1545',
 		name: 'Maldon District Council',
 		email: 'dc.planning@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X3025',
 		name: 'Mansfield District Council',
 		email: 'pbc@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A2280',
 		name: 'Medway Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Y2430',
 		name: 'Melton Borough Council',
 		email: 'externaldevelopmentcontrol@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D3830',
 		name: 'Mid Sussex District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W0734',
 		name: 'Middlesbrough Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B3030',
 		name: 'Newark & Sherwood District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X2600',
 		name: 'Norfolk County Council',
 		email: 'mawp@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R1038',
 		name: 'North East Derbyshire District Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'B2002',
 		name: 'North East Lincolnshire Council',
 		email: 'Planning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'X1925',
 		name: 'North Hertfordshire District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'R2520',
 		name: 'North Kesteven District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Y2620',
 		name: 'North Norfolk District Council',
 		email: 'planning-appeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W4515',
 		name: 'North Tyneside Council',
 		email: 'development.control@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'G2435',
 		name: 'North West Leicestershire District Council',
 		email: 'development.control@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W9500',
 		name: 'North York Moors National Park Authority',
 		email: 'dc@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'T9501',
 		name: 'Northumberland National Park Authority',
 		email: 'planning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q3060',
 		name: 'Nottingham City Council',
 		email: 'PlanningAppeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'L2440',
 		name: 'Oadby and Wigston Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'F5730',
 		name: 'Old Oak and Park Royal Development Corporation',
 		email: 'planningapplications@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'U3100',
 		name: 'Oxfordshire County Council',
 		email: 'planning@example.gov.uk',
-		teamId: 7 // West1
+		teamId: 7, // West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M9496',
 		name: 'Peak District National Park Authority',
 		email: 'legal@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'E2340',
 		name: 'Pendle Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J0540',
 		name: 'Peterborough City Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'N2345',
 		name: 'Preston City Council',
 		email: 'devcon@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'V0728',
 		name: 'Redcar and Cleveland Borough Council',
 		email: 'planning_admin@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'T2350',
 		name: 'Ribble Valley Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B1550',
 		name: 'Rochford District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'B2355',
 		name: 'Rossendale Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U1430',
 		name: 'Rother District Council',
 		email: 'Planning-Appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P4415',
 		name: 'Rotherham Metropolitan Borough Council',
 		email: 'development.control@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K5600',
 		name: 'Royal Borough of Kensington and Chelsea',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'P3040',
 		name: 'Rushcliffe Borough Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A2470',
 		name: 'Rutland County Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M4320',
 		name: 'Sefton Metropolitan Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'G2245',
 		name: 'Sevenoaks District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'W0530',
 		name: 'South Cambridgeshire District Council',
 		email: 'DSAppeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'F1040',
 		name: 'South Derbyshire District Council',
 		email: 'Planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'A2525',
 		name: 'South Holland District Council',
 		email: 'planningadvice@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'E2530',
 		name: 'South Kesteven District Council',
 		email: 'Planning@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'L2630',
 		name: 'South Norfolk District Council',
 		email: 'appealsnc@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'F2360',
 		name: 'South Ribble Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A4520',
 		name: 'South Tyneside Council',
 		email: 'planningapplications@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K1935',
 		name: 'Stevenage Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'V3500',
 		name: 'Suffolk County Council',
 		email: 'planning@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'J4525',
 		name: 'Sunderland City Council',
 		email: 'dc@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'B3600',
 		name: 'Surrey County Council',
 		email: 'mwcd@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V2255',
 		name: 'Swale Borough Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1560',
 		name: 'Tendring District Council',
 		email: 'appeals.planningservices@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Z2260',
 		name: 'Thanet District Council',
 		email: 'planning.services@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1940',
 		name: 'Three Rivers District Council',
 		email: 'trdc.appeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M1595',
 		name: 'Thurrock Borough Council',
 		email: 'plan.appeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'H2265',
 		name: 'Tonbridge and Malling Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M2270',
 		name: 'Tunbridge Wells Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Y1945',
 		name: 'Watford Borough Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C1950',
 		name: 'Welwyn Hatfield Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'K0940',
 		name: 'Westmorland and Furness Council',
 		email: 'appeals4@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'N2535',
 		name: 'West Lindsey District Council',
 		email: 'Planning.Customer.Care@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'F3545',
 		name: 'West Suffolk',
 		email: 'planning.helpdesk@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V4250',
 		name: 'Wigan Metropolitan Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W4325',
 		name: 'Wirral Metropolitan Borough Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U2370',
 		name: 'Wyre Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'C9499',
 		name: 'Yorkshire Dales National Park Authority',
 		email: 'planning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Y3805',
 		name: 'Adur District Council',
 		email: 'planning-Adur@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P4605',
 		name: 'Birmingham City Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 10 //west4
+		teamId: 10, //west4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'R0335',
 		name: 'Bracknell Forest Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z0116',
 		name: 'Bristol City Council',
 		email: 'development.management@example.gov.uk',
-		teamId: 10 //west4
+		teamId: 10, //west4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B1605',
 		name: 'Cheltenham Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C3105',
 		name: 'Cherwell District Council',
 		email: 'submit.appeal@example.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T1410',
 		name: 'Eastbourne Borough Council',
 		email: 'customerfirst@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M1710',
 		name: 'East Hampshire District Council',
 		email: 'planning.appeals@example.gov.ukuk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'L2250',
 		name: 'Folkestone and Hythe District Council',
 		email: 'Planning@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1425',
 		name: 'Lewes District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X5210',
 		name: 'London Borough of Camden',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'F5540',
 		name: 'London Borough of Hounslow',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T5720',
 		name: 'London Borough of Merton',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A5840',
 		name: 'London Borough of Southwark',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P5870',
 		name: 'London Borough of Sutton',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H5960',
 		name: 'London Borough of Wandsworth',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y0435',
 		name: 'Milton Keynes Council',
 		email: 'dcappeals@example.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'D0121',
 		name: 'North Somerset Council',
 		email: 'DMAppeals@example.gov.uk',
-		teamId: 10 //west4
+		teamId: 10, //west4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G3110',
 		name: 'Oxford City Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Z1775',
 		name: 'Portsmouth City Council',
 		email: 'planningapps@example.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E0345',
 		name: 'Reading Borough Council',
 		email: 'plgadmin@example.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Z5630',
 		name: 'Royal Borough of Kingston Upon Thames',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 14 //East4
+		teamId: 14, //East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'T0355',
 		name: 'Royal Borough of Windsor and Maidenhead',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 10 //west4
+		teamId: 10, //west4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'G4620',
 		name: 'Sandwell Metropolitan Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 7 //West1
+		teamId: 7, //West1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P0119',
 		name: 'South Gloucestershire Council',
 		email: 'planningsupport@example.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C3430',
 		name: 'South Staffordshire District Council',
 		email: 'dcapps@example.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'M3455',
 		name: 'Stoke-on-Trent City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 8 //West2
+		teamId: 8, //West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X0360',
 		name: 'Wokingham Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D1835',
 		name: 'Worcester City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 9 //West3
+		teamId: 9, //West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C3810',
 		name: 'Arun District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E2205',
 		name: 'Ashford Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V1505',
 		name: 'Basildon Borough Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'K0235',
 		name: 'Bedford Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'J2373',
 		name: 'Blackpool Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z1510',
 		name: 'Braintree District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'F2605',
 		name: 'Breckland District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Q1445',
 		name: 'Brighton and Hove City Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P1805',
 		name: 'Bromsgrove District Council',
 		email: 'newplan@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C0440',
 		name: 'Buckinghamshire Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 1
+		teamId: 1,
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'T4210',
 		name: 'Bury Metropolitan Borough Council',
 		email: 'development.control@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J2210',
 		name: 'Canterbury City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P0240',
 		name: 'Central Bedfordshire Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W1525',
 		name: 'Chelmsford City Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'R0660',
 		name: 'Cheshire East Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A0665',
 		name: 'Cheshire West and Chester Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D2320',
 		name: 'Chorley Borough Council',
 		email: 'dcon@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W4705',
 		name: 'City of Bradford Metropolitan District Council',
 		email: 'appealsplanning@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K5030',
 		name: 'City of London Council',
 		email: 'plncomments@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'X5990',
 		name: 'City of Westminster Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'C2741',
 		name: 'City of York Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A1530',
 		name: 'Colchester City Council',
 		email: 'planning.services@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Q3820',
 		name: 'Crawley Borough Council',
 		email: 'development.control@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'T2215',
 		name: 'Dartford Borough Council',
 		email: 'dc.appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'C1055',
 		name: 'Derby City Council',
 		email: 'pins.correspondence@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'X2220',
 		name: 'Dover District Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X1355',
 		name: 'Durham County Council',
 		email: 'planning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J1915',
 		name: 'East Hertfordshire District Council',
 		email: 'planning.tech@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'E2001',
 		name: 'East Riding of Yorkshire Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'X3540',
 		name: 'East Suffolk Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'G1440',
@@ -1590,355 +1849,414 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'K3605',
 		name: 'Elmbridge Borough Council',
 		email: 'tpappeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'J1535',
 		name: 'Epping Forest District Council',
 		email: 'appealsadmin@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P3610',
 		name: 'Epsom and Ewell Borough Council',
 		email: 'PlanningAppeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Y3615',
 		name: 'Guildford Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Z3825',
 		name: 'Horsham District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'V2635',
 		name: "King's Lynn and West Norfolk Borough Council",
 		email: 'borough.planning@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'A2335',
 		name: 'Lancaster City Council',
 		email: 'dm@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'N4720',
 		name: 'Leeds City Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'M2460',
 		name: 'Leicestershire County Council',
 		email: 'planningcontrol@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Q2500',
 		name: 'Lincolnshire County Council',
 		email: 'Dev_planningenquiries@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Z4310',
 		name: 'Liverpool City Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D5120',
 		name: 'London Borough of Bexley',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'T5150',
 		name: 'London Borough of Brent',
 		email: 'appeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'L5240',
 		name: 'London Borough of Croydon',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'A5270',
 		name: 'London Borough of Ealing',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'Q5300',
 		name: 'London Borough of Enfield',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'U5360',
 		name: 'London Borough of Hackney',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'H5390',
 		name: 'London Borough of Hammersmith and Fulham',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 10 // West4
+		teamId: 10, // West4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'Y5420',
 		name: 'London Borough of Haringey',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M5450',
 		name: 'London Borough of Harrow',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'V5570',
 		name: 'London Borough of Islington',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'C5690',
 		name: 'London Borough of Lewisham',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'G5750',
 		name: 'London Borough of Newham',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'E5900',
 		name: 'London Borough of Tower Hamlets',
 		email: 'development.control@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'B0230',
 		name: 'Luton Borough Council',
 		email: 'dcappeals@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'U2235',
 		name: 'Maidstone Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'B4215',
 		name: 'Manchester City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W3520',
 		name: 'Mid Suffolk District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'C3620',
 		name: 'Mole Valley District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'M4510',
 		name: 'Newcastle Upon Tyne City Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Y2003',
 		name: 'North Lincolnshire Council',
 		email: 'planning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'M2840',
 		name: 'North Northamptonshire Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P2745',
 		name: 'North Yorkshire Council',
 		email: 'NYCplanningappeals@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'P2935',
 		name: 'Northumberland County Council',
 		email: 'planning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'G2625',
 		name: 'Norwich City Council',
 		email: 'planning@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'L3055',
 		name: 'Nottinghamshire County Council',
 		email: 'development.management@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'W4223',
 		name: 'Oldham Metropolitan Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q1825',
 		name: 'Redditch Borough Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 9 // West3
+		teamId: 9, // West3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'L3625',
 		name: 'Reigate and Banstead Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P4225',
 		name: 'Rochdale Metropolitan Borough Council',
 		email: 'development.management@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'Q3630',
 		name: 'Runnymede Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'U4230',
 		name: 'Salford City Council',
 		email: 'planning.contact@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J4423',
 		name: 'Sheffield City Council',
 		email: 'InspectoratePlanningAppeals@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'E3335',
 		name: 'Somerset Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'D1590',
 		name: 'Southend-on-Sea Borough Council',
 		email: 'planningappeal@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Z3635',
 		name: 'Spelthorne Borough Council',
 		email: 'planningdm.appeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'B1930',
 		name: 'St Albans City Council',
 		email: 'pins.appeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'H4315',
 		name: 'St Helens Metropolitan Borough Council',
 		email: 'planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D3450',
 		name: 'Staffordshire County Council',
 		email: 'planning@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'C4235',
 		name: 'Stockport Metropolitan Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H0738',
 		name: 'Stockton-on-Tees Borough Council',
 		email: 'planningdevelopmentservices@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'D3640',
 		name: 'Surrey Heath Borough Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'G4240',
 		name: 'Tameside Metropolitan Borough Council',
 		email: 'planningmail@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'M3645',
 		name: 'Tandridge District Council',
 		email: 'PlanningAppealsLegal@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'Q4245',
 		name: 'Trafford Metropolitan Borough Council',
 		email: 'appeals.planning@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'C1570',
 		name: 'Uttlesford District Council',
 		email: 'planning@example.gov.uk',
-		teamId: 11 // East1
+		teamId: 11, // East1
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'X4725',
 		name: 'Wakefield Metropolitan District Council',
 		email: 'appeals@example.gov.uk',
-		teamId: 18 // North4
+		teamId: 18, // North4
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'U5930',
 		name: 'Waltham Forest London Borough Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 14 // East4
+		teamId: 14, // East4
+		enforcementTeamId: 6 // Enforcement Appeals Team - Team 4
 	},
 	{
 		lpaCode: 'M0655',
 		name: 'Warrington Borough Council',
 		email: 'devcontrol@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'H3700',
@@ -1950,37 +2268,43 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'R3650',
 		name: 'Waverley Borough Council',
 		email: 'consultation.planning@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'C1435',
 		name: 'Wealden District Council',
 		email: 'planning.appeals@example.gov.uk',
-		teamId: 12 // East2
+		teamId: 12, // East2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'P2365',
 		name: 'West Lancashire District Council',
 		email: 'plan.appeals@example.gov.uk',
-		teamId: 15 // North1
+		teamId: 15, // North1
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'W2845',
 		name: 'West Northamptonshire Council',
 		email: 'planningappeals@example.gov.uk',
-		teamId: 17 // North3
+		teamId: 17, // North3
+		enforcementTeamId: 3 // Enforcement Appeals Team - Team 1
 	},
 	{
 		lpaCode: 'P3800',
 		name: 'West Sussex County Council',
 		email: 'planning.applications@example.gov.uk',
-		teamId: 8 // West2
+		teamId: 8, // West2
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'A3655',
 		name: 'Woking Borough Council',
 		email: 'developmentcontrol@example.gov.uk',
-		teamId: 13 // East3
+		teamId: 13, // East3
+		enforcementTeamId: 4 // Enforcement Appeals Team - Team 2
 	},
 	{
 		lpaCode: 'E1855',
@@ -1992,13 +2316,15 @@ export const localPlanningDepartmentList = [
 		lpaCode: 'F0745',
 		name: 'Hartlepool Development Corporation',
 		email: 'HDCplanning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'K0750',
 		name: 'Middlesbrough Development Corporation',
 		email: 'MDCplanning@example.gov.uk',
-		teamId: 16 // North2
+		teamId: 16, // North2
+		enforcementTeamId: 5 // Enforcement Appeals Team - Team 3
 	},
 	{
 		lpaCode: 'J1155',

--- a/appeals/api/src/database/seed/teams/dev.js
+++ b/appeals/api/src/database/seed/teams/dev.js
@@ -1,12 +1,31 @@
 export const teamsToCreate = [
 	{ id: 1, name: 'Ops Test', email: 'opstest@planninginspectorate.co.uk' },
 	{ id: 2, name: 'DevTeam1', email: 'devteam1@planninginspectorate.gov.uk' },
-	{ id: 3, name: 'DevTeam2', email: 'devteam2@planninginspectorate.gov.uk' },
-	{ id: 6, name: 'Major Casework Officer', email: null },
+	{
+		id: 3,
+		name: 'Enforcement Appeals Team - Team 1',
+		email: 'TeamE1@planninginspectorate.gov.uk'
+	},
+	{
+		id: 4,
+		name: 'Enforcement Appeals Team - Team 2',
+		email: 'TeamE2@planninginspectorate.gov.uk'
+	},
+	{
+		id: 5,
+		name: 'Enforcement Appeals Team - Team 3',
+		email: 'TeamE3@planninginspectorate.gov.uk'
+	},
+	{
+		id: 6,
+		name: 'Enforcement Appeals Team - Team 4',
+		email: 'TeamE4@planninginspectorate.gov.uk'
+	},
 	{
 		id: 7,
 		name: 'Enforcement Appeals Officer',
 		email: 'ECAT@planninginspectorate.gov.uk'
 	},
-	{ id: 8, name: 'PADS team', email: 'PADSplanning@planninginspectorate.gov.uk' }
+	{ id: 8, name: 'PADS team', email: 'PADSplanning@planninginspectorate.gov.uk' },
+	{ id: 9, name: 'DevTeam2', email: 'devteam2@planninginspectorate.gov.uk' }
 ];

--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
@@ -136,32 +136,59 @@ describe('/appeals/case-submission', () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue({});
 		});
 		test.each([
-			['HAS', appealIngestionInputHouseholder, validAppellantCase, { id: 1 }],
-			['CAS_PLANNING', appealIngestionInputCasPlanning, validAppellantCaseCasPlanning, { id: 1 }],
-			['S78', appealIngestionInputS78, validAppellantCaseS78, { name: 'Major Casework Officer' }],
-			['S20', appealIngestionInputS20, validAppellantCaseS20, { name: 'Major Casework Officer' }],
+			['HAS', appealIngestionInputHouseholder, validAppellantCase, { id: 1 }, 1],
+			[
+				'CAS_PLANNING',
+				appealIngestionInputCasPlanning,
+				validAppellantCaseCasPlanning,
+				{ id: 1 },
+				1
+			],
+			[
+				'S78',
+				appealIngestionInputS78,
+				validAppellantCaseS78,
+				{ name: 'Major Casework Officer' },
+				1
+			],
+			[
+				'S20',
+				appealIngestionInputS20,
+				validAppellantCaseS20,
+				{ name: 'Major Casework Officer' },
+				1
+			],
 			[
 				'CAS_ADVERTISEMENT',
 				appealIngestionInputCasAdverts,
 				validAppellantCaseCasAdverts,
-				{ id: 1 }
+				{ id: 1 },
+				1
 			],
-			['ADVERTISEMENT', appealIngestionInputAdverts, validAppellantCaseAdverts, { id: 1 }],
+			['ADVERTISEMENT', appealIngestionInputAdverts, validAppellantCaseAdverts, { id: 1 }, 1],
 			[
 				'ENFORCEMENT_NOTICE',
 				appealIngestionInputEnforcementNotice,
 				validAppellantCaseEnforcementNotice,
-				{ id: 1 }
+				{ id: 2 },
+				2
 			],
 			[
 				'ENFORCEMENT_LISTED_BUILDING',
 				appealIngestionInputEnforcementListedBuilding,
 				validAppellantCaseEnforcementListedBuilding,
-				{ id: 1 }
+				{ id: 2 },
+				2
 			]
 		])(
 			'POST valid %s appellant case payload and create appeal',
-			async (appealType, appealIngestionInput, validAppellantCase, expectedTeamQueryParam) => {
+			async (
+				appealType,
+				appealIngestionInput,
+				validAppellantCase,
+				expectedTeamQueryParam,
+				expectedAssignedTeamId
+			) => {
 				const result = createIntegrationMocks(appealIngestionInput);
 				const payload = validAppellantCase;
 				const response = await request.post('/appeals/case-submission').send(payload);
@@ -183,7 +210,7 @@ describe('/appeals/case-submission', () => {
 								createdAt: expect.any(String)
 							}
 						},
-						assignedTeamId: 1
+						assignedTeamId: expectedAssignedTeamId
 					}
 				});
 				expect(databaseConnector.team.findUnique).toHaveBeenCalledWith(
@@ -1288,10 +1315,12 @@ describe('/appeals/representation-submission', () => {
  * @returns {{id: number, reference: string, assignedTeamId: number}}
  */
 const createIntegrationMocks = (/** @type {*} */ appealIngestionInput) => {
+	const caseType = appealIngestionInput.appealType?.connect?.key;
+	const isEnforcementOrLdc = caseType === 'C' || caseType === 'F' || caseType === 'X';
 	const appealCreatedResult = {
 		id: 100,
 		reference: '6000100',
-		assignedTeamId: 1
+		assignedTeamId: isEnforcementOrLdc ? 2 : 1
 	};
 
 	// @ts-ignore
@@ -1303,7 +1332,10 @@ const createIntegrationMocks = (/** @type {*} */ appealIngestionInput) => {
 	// @ts-ignore
 	databaseConnector.appeal.findMany.mockResolvedValue([]);
 	// @ts-ignore
-	databaseConnector.appeal.create.mockResolvedValue({ id: appealCreatedResult.id });
+	databaseConnector.appeal.create.mockResolvedValue({
+		id: appealCreatedResult.id,
+		appealTypeId: 1
+	});
 	// @ts-ignore
 	databaseConnector.appeal.update.mockResolvedValue(appealCreatedResult);
 	// @ts-ignore
@@ -1350,7 +1382,8 @@ const createIntegrationMocks = (/** @type {*} */ appealIngestionInput) => {
 	databaseConnector.user.upsert.mockResolvedValue({ id: 1 });
 	// @ts-ignore
 	databaseConnector.lPA.findUnique.mockResolvedValue({
-		teamId: 1
+		teamId: 1,
+		enforcementTeamId: 2
 	});
 	// @ts-ignore
 	databaseConnector.folder.findMany.mockResolvedValue(
@@ -1375,9 +1408,9 @@ const createIntegrationMocks = (/** @type {*} */ appealIngestionInput) => {
 		{ key: APPEAL_REDACTED_STATUS.NOT_REDACTED }
 	]);
 
-	databaseConnector.appealType.findFirst.mockResolvedValue({
-		appealType: appealIngestionInput.appealType?.connect
-	});
+	databaseConnector.appealType.findFirst.mockResolvedValue(
+		appealIngestionInput.appealType?.connect
+	);
 
 	return appealCreatedResult;
 };

--- a/appeals/api/src/server/endpoints/local-planning-authorities/__tests__/local-planning-authorities.test.js
+++ b/appeals/api/src/server/endpoints/local-planning-authorities/__tests__/local-planning-authorities.test.js
@@ -30,6 +30,13 @@ describe('local-planning-authorities', () => {
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
+	afterAll(() => {
+		databaseConnector.appeal.findUnique.mockResolvedValue({});
+		databaseConnector.appeal.update.mockResolvedValue({});
+		databaseConnector.lPA.findMany.mockResolvedValue([]);
+		databaseConnector.lPA.findUnique.mockResolvedValue({});
+		databaseConnector.user.upsert.mockResolvedValue({});
+	});
 	describe('GET /local-planning-authorities', () => {
 		test('returns 200 when getting list of LPAs', async () => {
 			// @ts-ignore
@@ -263,6 +270,46 @@ describe('local-planning-authorities', () => {
 			});
 			expect(response.status).toEqual(200);
 		}, 30000);
+
+		test('updates assignedTeamId to new LPA enforcementTeamId if appeal is enforcement type', async () => {
+			const enforcementAppeal = {
+				...householdAppeal,
+				appealType: { key: 'C' }
+			};
+			const newLpaWithTeam = {
+				...newLPA,
+				teamId: 10,
+				enforcementTeamId: 20
+			};
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(enforcementAppeal);
+			// @ts-ignore
+			databaseConnector.lPA.findMany.mockResolvedValue([validLPA, newLpaWithTeam]);
+			// @ts-ignore
+			databaseConnector.lPA.findUnique.mockResolvedValue(newLpaWithTeam);
+			// @ts-ignore
+			databaseConnector.user.upsert.mockResolvedValue({
+				id: 1,
+				azureAdUserId
+			});
+
+			const response = await request
+				.post(`/appeals/${enforcementAppeal.id}/lpa`)
+				.send({
+					newLpaId: 48
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
+				data: {
+					assignedTeamId: 20
+				},
+				where: {
+					id: enforcementAppeal.id
+				}
+			});
+			expect(response.status).toEqual(200);
+		});
 
 		test('returns 400 if invalid request', async () => {
 			// @ts-ignore

--- a/appeals/api/src/server/endpoints/local-planning-authorities/local-planning-authorities.service.js
+++ b/appeals/api/src/server/endpoints/local-planning-authorities/local-planning-authorities.service.js
@@ -4,14 +4,131 @@ import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import lpaRepository from '#repositories/lpa.repository.js';
+import { databaseConnector } from '#utils/database-connector.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import {
 	AUDIT_TRAIL_LPA_UPDATED,
 	ERROR_NO_RECIPIENT_EMAIL
 } from '@pins/appeals/constants/support.js';
-import { isEnforcementCaseType } from '@pins/appeals/utils/appeal-type-checks.js';
+import {
+	isEnforcementCaseType,
+	isLdcOrDiscontinuanceOrEnforcementCaseType
+} from '@pins/appeals/utils/appeal-type-checks.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+
+/**
+ * @param {string|null|undefined} caseType
+ * @param {import('@pins/appeals.api').Schema.LPA} lpaDetails
+ * @returns {Promise<number|null>}
+ */
+const determineEnforcementTeam = async (caseType, lpaDetails) => {
+	return lpaDetails.enforcementTeamId || null;
+};
+
+/**
+ * @param {number} appealId
+ * @param {import('@pins/appeals.api').Schema.LPA} newLpaDetails
+ * @returns {Promise<void>}
+ */
+const updateAppealAssignedTeam = async (appealId, newLpaDetails) => {
+	const appealDetails = await databaseConnector.appeal.findUnique({
+		where: { id: appealId },
+		select: {
+			appealType: {
+				select: {
+					key: true
+				}
+			}
+		}
+	});
+
+	if (!appealDetails) {
+		return;
+	}
+
+	const caseType = appealDetails.appealType?.key;
+	if (isLdcOrDiscontinuanceOrEnforcementCaseType(caseType)) {
+		const teamId = await determineEnforcementTeam(caseType, newLpaDetails);
+		if (teamId) {
+			await databaseConnector.appeal.update({
+				where: { id: appealId },
+				data: { assignedTeamId: teamId }
+			});
+		}
+	}
+};
+
+/**
+ * @param {Appeal|Partial<Appeal>} appeal
+ * @param {number} newLpaId
+ * @param {string|undefined} azureAdUserId
+ * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
+ * @param {boolean} isChild
+ *
+ * @returns {Promise<void>}
+ */
+/**
+ * @param {Appeal|Partial<Appeal>} appeal
+ * @param {import('@pins/appeals.api').Schema.LPA} newLpaDetails
+ * @param {string|undefined} azureAdUserId
+ * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
+ * @returns {Promise<void>}
+ */
+const sendLpaChangeNotifications = async (appeal, newLpaDetails, azureAdUserId, notifyClient) => {
+	const appealId = Number(appeal.id);
+	const currentLPA = appeal.lpa;
+	const siteAddress = appeal.address
+		? formatAddressSingleLine(appeal.address)
+		: 'Address not available';
+
+	const teamEmail = await getTeamEmailFromAppealId(appealId);
+	const isEnforcement = isEnforcementCaseType(appeal.appealType?.key || '');
+	const recipientEmail = appeal.appellant?.email || appeal.agent?.email;
+	if (!recipientEmail) {
+		throw new Error(ERROR_NO_RECIPIENT_EMAIL);
+	}
+	const appellantPersonalisation = {
+		appeal_reference_number: appeal.reference || '',
+		site_address: siteAddress,
+		team_email_address: teamEmail,
+		local_planning_authority: newLpaDetails.name,
+		lpa_reference: appeal.applicationReference || '',
+		...(isEnforcement && {
+			enforcement_reference: appeal?.appellantCase?.enforcementReference || ''
+		})
+	};
+	await notifySend({
+		azureAdUserId: azureAdUserId || '',
+		templateName: 'lpa-changed-appellant',
+		notifyClient,
+		recipientEmail: recipientEmail,
+		personalisation: appellantPersonalisation
+	});
+
+	if (currentLPA && appeal.reference) {
+		const lpaPersonalisation = {
+			appeal_reference_number: appeal.reference,
+			site_address: siteAddress,
+			team_email_address: teamEmail,
+			local_planning_authority: newLpaDetails.name,
+			lpa_reference: appeal.applicationReference || '',
+			...(isEnforcement && {
+				enforcement_reference: appeal?.appellantCase?.enforcementReference || ''
+			})
+		};
+
+		currentLPA.email
+			? await notifySend({
+					azureAdUserId: azureAdUserId || '',
+					templateName: 'lpa-removed',
+					notifyClient,
+					recipientEmail: currentLPA.email,
+					personalisation: lpaPersonalisation
+				})
+			: null;
+	}
+};
 
 /**
  * @param {Appeal|Partial<Appeal>} appeal
@@ -23,70 +140,30 @@ import { isEnforcementCaseType } from '@pins/appeals/utils/appeal-type-checks.js
  * @returns {Promise<void>}
  */
 const changeLpa = async (appeal, newLpaId, azureAdUserId, notifyClient, isChild) => {
-	const appealId = Number(appeal.id);
-	const currentLPA = appeal.lpa;
-	await lpaRepository.updateLpaByAppealId(appealId, newLpaId);
-	const newLpaDetails = await lpaRepository.getLpaById(newLpaId);
-	if (!isChild && appeal.reference && newLpaDetails) {
-		const siteAddress = appeal.address
-			? formatAddressSingleLine(appeal.address)
-			: 'Address not available';
+	try {
+		const appealId = Number(appeal.id);
+		await lpaRepository.updateLpaByAppealId(appealId, newLpaId);
+		const newLpaDetails = await lpaRepository.getLpaById(newLpaId);
 
-		const teamEmail = await getTeamEmailFromAppealId(appealId);
-		const isEnforcement = isEnforcementCaseType(appeal.appealType?.key || '');
-		const recipientEmail = appeal.appellant?.email || appeal.agent?.email;
-		if (!recipientEmail) {
-			throw new Error(ERROR_NO_RECIPIENT_EMAIL);
+		if (newLpaDetails) {
+			await updateAppealAssignedTeam(appealId, newLpaDetails);
 		}
-		const appellantPersonalisation = {
-			appeal_reference_number: appeal.reference,
-			site_address: siteAddress,
-			team_email_address: teamEmail,
-			local_planning_authority: newLpaDetails.name,
-			lpa_reference: appeal.applicationReference || '',
-			...(isEnforcement && {
-				enforcement_reference: appeal?.appellantCase?.enforcementReference || ''
-			})
-		};
-		await notifySend({
-			azureAdUserId: azureAdUserId || '',
-			templateName: 'lpa-changed-appellant',
-			notifyClient,
-			recipientEmail: recipientEmail,
-			personalisation: appellantPersonalisation
+
+		if (!isChild && appeal.reference && newLpaDetails) {
+			await sendLpaChangeNotifications(appeal, newLpaDetails, azureAdUserId, notifyClient);
+		}
+
+		await createAuditTrail({
+			appealId: appealId,
+			azureAdUserId,
+			details: stringTokenReplacement(AUDIT_TRAIL_LPA_UPDATED, [newLpaDetails?.name || ''])
 		});
 
-		if (currentLPA && appeal.reference) {
-			const lpaPersonalisation = {
-				appeal_reference_number: appeal.reference,
-				site_address: siteAddress,
-				team_email_address: teamEmail,
-				local_planning_authority: newLpaDetails.name,
-				lpa_reference: appeal.applicationReference || '',
-				...(isEnforcement && {
-					enforcement_reference: appeal?.appellantCase?.enforcementReference || ''
-				})
-			};
-
-			currentLPA.email
-				? await notifySend({
-						azureAdUserId: azureAdUserId || '',
-						templateName: 'lpa-removed',
-						notifyClient,
-						recipientEmail: currentLPA.email,
-						personalisation: lpaPersonalisation
-					})
-				: null;
-		}
+		await broadcasters.broadcastAppeal(appealId);
+	} catch (err) {
+		console.error('ERROR IN changeLpa:', err);
+		throw err;
 	}
-
-	await createAuditTrail({
-		appealId: appealId,
-		azureAdUserId,
-		details: stringTokenReplacement(AUDIT_TRAIL_LPA_UPDATED, [newLpaDetails?.name || ''])
-	});
-
-	await broadcasters.broadcastAppeal(appealId);
 };
 
 export const lpaService = {

--- a/appeals/api/src/server/repositories/__tests__/integrations.repository.test.js
+++ b/appeals/api/src/server/repositories/__tests__/integrations.repository.test.js
@@ -1,0 +1,108 @@
+// @ts-nocheck
+import { databaseConnector } from '#utils/database-connector.js';
+import { jest } from '@jest/globals';
+
+// Setup mock modules for the repository functions called in createAppeal
+const mockGetAppealTypeByTypeId = jest.fn();
+jest.unstable_mockModule('../appeal-type.repository.js', () => ({
+	getAppealTypeByTypeId: mockGetAppealTypeByTypeId
+}));
+
+const mockGetEnforcementTeamIdFromLpaCode = jest.fn();
+const mockGetTeamIdFromLpaCode = jest.fn();
+const mockGetTeamIdFromName = jest.fn();
+jest.unstable_mockModule('../team.repository.js', () => ({
+	getEnforcementTeamIdFromLpaCode: mockGetEnforcementTeamIdFromLpaCode,
+	getTeamIdFromLpaCode: mockGetTeamIdFromLpaCode,
+	getTeamIdFromName: mockGetTeamIdFromName
+}));
+
+// Now import the repository under test
+const { createAppeal } = await import('../integrations.repository.js');
+
+describe('integrations.repository - createAppeal', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const mockAppealData = {
+		lpa: {
+			connect: {
+				lpaCode: 'E60000123'
+			}
+		},
+		appealTypeId: 1
+	};
+
+	const setupPrismaMocks = (teamId) => {
+		databaseConnector.appeal.create.mockResolvedValue({
+			id: 42,
+			appealTypeId: 1
+		});
+
+		databaseConnector.appeal.update.mockResolvedValue({
+			id: 42,
+			reference: 'APP/42',
+			assignedTeamId: teamId
+		});
+
+		databaseConnector.appeal.findUnique.mockResolvedValue({
+			id: 42,
+			reference: 'APP/42',
+			assignedTeamId: teamId
+		});
+	};
+
+	describe('LDC or Discontinuance or Enforcement case types', () => {
+		const enforcementCases = [
+			['C', 'Enforcement Notice (C)'],
+			['F', 'Enforcement Listed Building (F)'],
+			['G', 'Discontinuance Notice (G)'],
+			['X', 'Lawful Development Certificate (X)']
+		];
+
+		it.each(enforcementCases)(
+			'assigns team using getEnforcementTeamIdFromLpaCode for case type %s (%s)',
+			async (caseType) => {
+				mockGetAppealTypeByTypeId.mockResolvedValue({ key: caseType });
+				mockGetEnforcementTeamIdFromLpaCode.mockResolvedValue(10);
+				setupPrismaMocks(10);
+
+				const result = await createAppeal(mockAppealData, [], [], [], 'written');
+
+				expect(mockGetEnforcementTeamIdFromLpaCode).toHaveBeenCalledWith('E60000123');
+				expect(databaseConnector.appeal.update).toHaveBeenCalledWith(
+					expect.objectContaining({
+						data: expect.objectContaining({
+							assignedTeamId: 10
+						})
+					})
+				);
+				expect(result.appeal.assignedTeamId).toBe(10);
+			}
+		);
+
+		it.each(enforcementCases)(
+			'falls back to getTeamIdFromLpaCode if getEnforcementTeamIdFromLpaCode returns null for case type %s (%s)',
+			async (caseType) => {
+				mockGetAppealTypeByTypeId.mockResolvedValue({ key: caseType });
+				mockGetEnforcementTeamIdFromLpaCode.mockResolvedValue(null);
+				mockGetTeamIdFromLpaCode.mockResolvedValue(20);
+				setupPrismaMocks(20);
+
+				const result = await createAppeal(mockAppealData, [], [], [], 'written');
+
+				expect(mockGetEnforcementTeamIdFromLpaCode).toHaveBeenCalledWith('E60000123');
+				expect(mockGetTeamIdFromLpaCode).toHaveBeenCalledWith('E60000123');
+				expect(databaseConnector.appeal.update).toHaveBeenCalledWith(
+					expect.objectContaining({
+						data: expect.objectContaining({
+							assignedTeamId: 20
+						})
+					})
+				);
+				expect(result.appeal.assignedTeamId).toBe(20);
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -8,7 +8,11 @@ import { CASE_RELATIONSHIP_RELATED } from '@pins/appeals/constants/support.js';
 import { isLdcOrDiscontinuanceOrEnforcementCaseType } from '@pins/appeals/utils/appeal-type-checks.js';
 import { APPEAL_CASE_STATUS, APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 import { getAppealTypeByTypeId } from './appeal-type.repository.js';
-import { getTeamIdFromLpaCode, getTeamIdFromName } from './team.repository.js';
+import {
+	getEnforcementTeamIdFromLpaCode,
+	getTeamIdFromLpaCode,
+	getTeamIdFromName
+} from './team.repository.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.Representation} Representation */
@@ -57,8 +61,11 @@ export const createAppeal = async (
 			const appealType = await getAppealTypeByTypeId(Number(appeal.appealTypeId));
 
 			let teamId;
-			if (isLdcOrDiscontinuanceOrEnforcementCaseType(appealType?.key)) {
-				teamId = await getTeamIdFromName(TEAM_NAME_MAP.ENFORCEMENT_APPEALS_TEAM);
+			const caseType = appealType?.key;
+			if (isLdcOrDiscontinuanceOrEnforcementCaseType(caseType)) {
+				teamId =
+					(await getEnforcementTeamIdFromLpaCode(data.lpa.connect?.lpaCode || '')) ||
+					(await getTeamIdFromLpaCode(data.lpa.connect?.lpaCode || ''));
 			} else if (appellantSelectedProcedureType === inquiryProcedureTypeId) {
 				teamId = await getTeamIdFromName(TEAM_NAME_MAP.MAJOR_CASEWORK);
 			} else {

--- a/appeals/api/src/server/repositories/team.repository.js
+++ b/appeals/api/src/server/repositories/team.repository.js
@@ -22,6 +22,24 @@ export const getTeamIdFromLpaCode = async (lpaCode) => {
 
 /**
  *
+ * @param {string} lpaCode
+ * @returns {Promise< number | null>}
+ */
+export const getEnforcementTeamIdFromLpaCode = async (lpaCode) => {
+	const team = await databaseConnector.lPA.findUnique({
+		where: { lpaCode },
+		select: { enforcementTeamId: true }
+	});
+
+	if (!team) {
+		return null;
+	}
+
+	return team.enforcementTeamId;
+};
+
+/**
+ *
  * @param {string} name
  * @returns {Promise< number | null>}
  */


### PR DESCRIPTION
…assignments (A2-7249)

## Describe your changes
Functionality Implemented:
Added database migration and seeding to map Local Planning Authorities (LPAs) to specific enforcement case teams.

Implemented auto-assignment logic during appeal creation to assign cases to correct case teams based on LPA code for Enforcement, Enforcement Listed Building, Discontinuance, and Lawful Development Certificate appeal types.

Added fallback mechanism to generic LPA case teams if no enforcement case team is mapped otherwise null.

Testing Added:
Added unit tests verifying auto-assignment and fallback logic across all four enforcement-related case types.
Added tests for local planning authority updates and integrations.
Manual testing of appeal creation and team updates with LPA change

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7249)
