### PR TITLE
feat(appeals): remove the ECAT from appeals and remove from filter an…

### DIFF
--- a/appeals/api/src/database/migrations/20260717082437_reassign_ecat_appeals/migration.sql
+++ b/appeals/api/src/database/migrations/20260717082437_reassign_ecat_appeals/migration.sql
@@ -1,0 +1,25 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- Reassign appeals assigned to 'Enforcement Appeals Team' to the correct enforcement team based on the LPA
+UPDATE a
+SET a.assignedTeamId = l.enforcementTeamId
+FROM [dbo].[Appeal] a
+JOIN [dbo].[LPA] l ON a.lpaId = l.id
+JOIN [dbo].[Team] t ON a.assignedTeamId = t.id
+WHERE t.name = 'Enforcement Appeals Team'
+AND l.enforcementTeamId IS NOT NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/seed/teams/dev.js
+++ b/appeals/api/src/database/seed/teams/dev.js
@@ -1,3 +1,5 @@
+import { TEAM_NAME_MAP } from '@pins/appeals/constants/common.js';
+
 export const teamsToCreate = [
 	{ id: 1, name: 'Ops Test', email: 'opstest@planninginspectorate.co.uk' },
 	{ id: 2, name: 'DevTeam1', email: 'devteam1@planninginspectorate.gov.uk' },
@@ -23,7 +25,7 @@ export const teamsToCreate = [
 	},
 	{
 		id: 7,
-		name: 'Enforcement Appeals Officer',
+		name: TEAM_NAME_MAP.ENFORCEMENT_APPEALS_TEAM,
 		email: 'ECAT@planninginspectorate.gov.uk'
 	},
 	{ id: 8, name: 'PADS team', email: 'PADSplanning@planninginspectorate.gov.uk' },

--- a/appeals/api/src/database/seed/teams/prod.js
+++ b/appeals/api/src/database/seed/teams/prod.js
@@ -1,6 +1,12 @@
+import { TEAM_NAME_MAP } from '@pins/appeals/constants/common.js';
+
 export const teamsToCreate = [
 	{ id: 1, name: 'Major Casework Officer', email: null },
-	{ id: 2, name: 'Enforcement Appeals Team', email: 'ECAT@planninginspectorate.gov.uk' },
+	{
+		id: 2,
+		name: TEAM_NAME_MAP.ENFORCEMENT_APPEALS_TEAM,
+		email: 'ECAT@planninginspectorate.gov.uk'
+	},
 
 	{
 		id: 3,

--- a/appeals/api/src/database/seed/teams/training.js
+++ b/appeals/api/src/database/seed/teams/training.js
@@ -1,7 +1,13 @@
+import { TEAM_NAME_MAP } from '@pins/appeals/constants/common.js';
+
 export const teamsToCreate = [
 	{ id: 10000001, name: 'Ops Test', email: 'opstest@planninginspectorate.co.uk' },
 	{ id: 1, name: 'Major Casework Officer', email: null },
-	{ id: 2, name: 'Enforcement Appeals Team', email: 'ECAT@planninginspectorate.gov.uk' },
+	{
+		id: 2,
+		name: TEAM_NAME_MAP.ENFORCEMENT_APPEALS_TEAM,
+		email: 'ECAT@planninginspectorate.gov.uk'
+	},
 
 	{
 		id: 3,

--- a/appeals/api/src/server/endpoints/case-team/__tests__/case-team.test.js
+++ b/appeals/api/src/server/endpoints/case-team/__tests__/case-team.test.js
@@ -5,6 +5,7 @@ import { mocks } from '#tests/appeals/index.js';
 import { caseTeams } from '#tests/appeals/mocks.js';
 import { azureAdUserId } from '#tests/shared/mocks.js';
 import { jest } from '@jest/globals';
+import { TEAM_NAME_MAP } from '@pins/appeals/constants/common.js';
 import { getTeamEmailFromAppealId } from '../case-team.service.js';
 const { databaseConnector } = await import('#utils/database-connector.js');
 const householdAppeal = mocks.householdAppeal;
@@ -40,6 +41,25 @@ describe('case team routes', () => {
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(caseTeams);
+			});
+
+			it('should exclude Enforcement Appeals Team when querying database', async () => {
+				databaseConnector.team.findMany.mockResolvedValue([]);
+
+				await request.get(`/appeals/case-teams`).set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.team.findMany).toHaveBeenCalledWith({
+					where: {
+						NOT: {
+							name: TEAM_NAME_MAP.ENFORCEMENT_APPEALS_TEAM
+						}
+					},
+					select: {
+						id: true,
+						name: true,
+						email: true
+					}
+				});
 			});
 		});
 	});

--- a/appeals/api/src/server/repositories/team.repository.js
+++ b/appeals/api/src/server/repositories/team.repository.js
@@ -1,6 +1,7 @@
 import redisClient from '#infrastructure/redis.js';
 import { databaseConnector } from '#utils/database-connector.js';
 import logger from '#utils/logger.js';
+import { TEAM_NAME_MAP } from '@pins/appeals/constants/common.js';
 
 /**
  *
@@ -82,6 +83,11 @@ export const getCaseTeams = async () => {
 
 	const getTeams = async () =>
 		databaseConnector.team.findMany({
+			where: {
+				NOT: {
+					name: TEAM_NAME_MAP.ENFORCEMENT_APPEALS_TEAM
+				}
+			},
 			select: {
 				id: true,
 				name: true,


### PR DESCRIPTION
## Describe your changes

Adds migration to reassign appeals from ECAT to the correct LPA assignments.
Filters the ECAT team from the filter and selection dropdowns

Added test for ECAT removal from list

## Issue ticket number and link

[A2-8234](https://pins-ds.atlassian.net/browse/A2-8234)
[A2-8230](https://pins-ds.atlassian.net/browse/A2-8430)


[A2-8234]: https://pins-ds.atlassian.net/browse/A2-8234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[A2-8230]: https://pins-ds.atlassian.net/browse/A2-8230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ