### PR TITLE
feat(appeals): add isRedacted to rep (no-ticket)

### DIFF
--- a/appeals/api/src/database/migrations/20260715121036_add_representation_redacted_bool_and_indexes/migration.sql
+++ b/appeals/api/src/database/migrations/20260715121036_add_representation_redacted_bool_and_indexes/migration.sql
@@ -1,0 +1,28 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Representation] ADD [isRedacted] BIT NOT NULL CONSTRAINT [Representation_isRedacted_df] DEFAULT 0;
+
+-- Set current isRedacted values
+EXEC('UPDATE [dbo].[Representation] SET [isRedacted] = 1 WHERE [redactedRepresentation] IS NOT NULL and [redactedRepresentation] <> [originalRepresentation];');
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [AppealGround_appealId_isDeleted_idx] ON [dbo].[AppealGround]([appealId], [isDeleted]);
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [LPANotificationMethodsSelected_lpaQuestionnaireId_idx] ON [dbo].[LPANotificationMethodsSelected]([lpaQuestionnaireId]);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -382,6 +382,7 @@ model AppealGround {
   isDeleted      Boolean @default(false)
 
   @@unique([groundId, appealId])
+  @@index([appealId, isDeleted])
 }
 
 /// AppellantCaseValidationOutcome model
@@ -744,6 +745,7 @@ model LPANotificationMethodsSelected {
   lpaQuestionnaireId    Int
 
   @@id([notificationMethodId, lpaQuestionnaireId])
+  @@index([lpaQuestionnaireId])
 }
 
 /// DesignatedSite model
@@ -947,6 +949,7 @@ model Representation {
   dateLastUpdated                        DateTime                                 @default(now())
   originalRepresentation                 String?                                  @db.NVarChar(Max)
   redactedRepresentation                 String?                                  @db.NVarChar(Max)
+  isRedacted                             Boolean                                  @default(false)
   represented                            ServiceUser?                             @relation("represented", fields: [representedId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   representedId                          Int?
   representative                         ServiceUser?                             @relation("representative", fields: [representativeId], references: [id], onDelete: NoAction, onUpdate: NoAction)

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -193,32 +193,32 @@ const formatDocumentationSummary = (appeal) => {
 		ipComments: {
 			status: ipComments.length > 0 ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 			counts: countBy(ipComments, 'status'),
-			isRedacted: ipComments.some((comment) => Boolean(comment.redactedRepresentation))
+			isRedacted: ipComments.some((comment) => comment?.isRedacted ?? false)
 		},
 		lpaStatement: {
 			status: formatRepresentationStatus(lpaStatement ?? null),
 			representationStatus: lpaStatement?.status ?? null,
 			receivedAt: lpaStatement?.dateCreated,
-			isRedacted: Boolean(lpaStatement?.redactedRepresentation)
+			isRedacted: lpaStatement?.isRedacted ?? false
 		},
 		lpaFinalComments: {
 			status: formatRepresentationStatus(lpaFinalComment ?? null),
 			representationStatus: lpaFinalComment?.status ?? null,
 			receivedAt: lpaFinalComment?.dateCreated,
-			isRedacted: Boolean(lpaFinalComment?.redactedRepresentation)
+			isRedacted: lpaFinalComment?.isRedacted ?? false
 		},
 		appellantFinalComments: {
 			status: formatRepresentationStatus(appellantFinalComment ?? null),
 			representationStatus: appellantFinalComment?.status ?? null,
 			receivedAt: appellantFinalComment?.dateCreated,
-			isRedacted: Boolean(appellantFinalComment?.redactedRepresentation)
+			isRedacted: appellantFinalComment?.isRedacted ?? false
 		},
 		lpaProofOfEvidence: {
 			status:
 				lpaProofOfEvidence.length > 0 ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 			representationStatus: lpaProofOfEvidence[0]?.status ?? null,
 			receivedAt: lpaProofOfEvidence[0]?.dateCreated,
-			isRedacted: Boolean(lpaProofOfEvidence[0]?.redactedRepresentation)
+			isRedacted: lpaProofOfEvidence[0]?.isRedacted ?? false
 		},
 		appellantProofOfEvidence: {
 			status:
@@ -227,14 +227,14 @@ const formatDocumentationSummary = (appeal) => {
 					: DOCUMENT_STATUS_NOT_RECEIVED,
 			representationStatus: appellantProofOfEvidence[0]?.status ?? null,
 			receivedAt: appellantProofOfEvidence[0]?.dateCreated,
-			isRedacted: Boolean(appellantProofOfEvidence[0]?.redactedRepresentation)
+			isRedacted: appellantProofOfEvidence[0]?.isRedacted ?? false
 		},
 		appellantStatement: {
 			status:
 				appellantStatement.length > 0 ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 			representationStatus: appellantStatement[0]?.status ?? null,
 			receivedAt: appellantStatement[0]?.dateCreated,
-			isRedacted: Boolean(appellantStatement[0]?.redactedRepresentation)
+			isRedacted: appellantStatement[0]?.isRedacted ?? false
 		},
 		rule6PartyProofs:
 			(appeal.appealRule6Parties || []).reduce((/** @type {Object<string, any>} */ acc, party) => {
@@ -249,7 +249,7 @@ const formatDocumentationSummary = (appeal) => {
 						status: DOCUMENT_STATUS_RECEIVED,
 						representationStatus: rule6RepFromParty[0].status,
 						receivedAt: rule6RepFromParty[0].dateCreated,
-						isRedacted: Boolean(rule6RepFromParty[0].redactedRepresentation),
+						isRedacted: rule6RepFromParty[0].isRedacted ?? false,
 						organisationName: party.serviceUser?.organisationName,
 						rule6PartyId: party.id
 					};
@@ -278,7 +278,7 @@ const formatDocumentationSummary = (appeal) => {
 						status: DOCUMENT_STATUS_RECEIVED,
 						representationStatus: rule6RepFromParty[0].status,
 						receivedAt: rule6RepFromParty[0].dateCreated,
-						isRedacted: Boolean(rule6RepFromParty[0].redactedRepresentation),
+						isRedacted: rule6RepFromParty[0].isRedacted ?? false,
 						organisationName: party.serviceUser?.organisationName,
 						rule6PartyId: party.id
 					};

--- a/appeals/api/src/server/endpoints/integrations/__tests__/representation-mapping.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/representation-mapping.test.js
@@ -187,23 +187,19 @@ describe('representation mapper', () => {
 			const mapped = mapRepresentationEntity({
 				...mockRepresentation,
 				representationRejectionReasonsSelected: [
+					// @ts-ignore
 					{
-						// @ts-ignore
 						representationRejectionReason: {
 							name: 'Contains links to web pages',
 							hasText: false
 						}
 					},
 					{
-						// @ts-ignore
 						representationRejectionReason: {
 							name: 'other_reason',
 							hasText: true
 						},
-						representationRejectionReasonText: [
-							// @ts-ignore
-							{ text: 'Custom rejection reason text' }
-						]
+						representationRejectionReasonText: [{ text: 'Custom rejection reason text' }]
 					}
 				]
 			});

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/representation.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/representation.js
@@ -9,11 +9,53 @@ import { schemas, validateFromSchema } from '../integrations.validators.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 
+/** @satisfies {import('#db-client/models.ts').RepresentationFindUniqueArgs['select'] } */
+export const broadcastRepSelect = {
+	id: true,
+	representationType: true,
+	status: true,
+	redactedRepresentation: true,
+	originalRepresentation: true,
+	source: true,
+	reviewer: true,
+	representedId: true,
+	dateCreated: true,
+	appeal: {
+		select: {
+			id: true,
+			reference: true
+		}
+	},
+	lpa: {
+		select: {
+			id: true
+		}
+	},
+	representationRejectionReasonsSelected: {
+		select: {
+			representationRejectionReason: {
+				select: {
+					hasText: true,
+					name: true
+				}
+			},
+			representationRejectionReasonText: {
+				select: {
+					text: true
+				}
+			}
+		}
+	},
+	attachments: {
+		select: {
+			documentGuid: true
+		}
+	}
+};
+
 /**
- *
  * @param {number} representationId
  * @param {string} updateType
- * @returns
  */
 export const broadcastRepresentation = async (representationId, updateType) => {
 	if (!config.serviceBusEnabled && config.NODE_ENV !== 'development') {
@@ -22,17 +64,7 @@ export const broadcastRepresentation = async (representationId, updateType) => {
 
 	const rep = await databaseConnector.representation.findUnique({
 		where: { id: representationId },
-		include: {
-			appeal: true,
-			lpa: true,
-			representationRejectionReasonsSelected: {
-				include: {
-					representationRejectionReason: true,
-					representationRejectionReasonText: true
-				}
-			},
-			attachments: true
-		}
+		select: broadcastRepSelect
 	});
 
 	if (!rep || rep === null) {
@@ -42,7 +74,6 @@ export const broadcastRepresentation = async (representationId, updateType) => {
 		return false;
 	}
 
-	// @ts-ignore
 	const msg = mapRepresentationEntity(rep);
 
 	if (msg) {

--- a/appeals/api/src/server/endpoints/integrations/integrations.service.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.service.js
@@ -76,7 +76,6 @@ const importLPAQuestionnaire = async (caseReference, data, documents, relatedRef
  * @param {Appeal} appeal
  * @param {Omit<import('#db-client/models.ts').RepresentationCreateInput, 'appeal'>} data
  * @param {import('#db-client/models.ts').DocumentVersionCreateInput[]} attachments
- * @returns {Promise<{rep: Representation, documentVersions: DocumentVersion[]}>}
  */
 const importRepresentation = async (appeal, data, attachments) => {
 	const result = await createRepresentation(appeal, data, attachments);

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -326,12 +326,12 @@ export const copyRepresentations = async (sourceAppeal, destinationAppeal) => {
 				status: representation.status ?? null,
 				lpaCode: representation.lpa?.lpaCode ?? null,
 				originalRepresentation: representation.originalRepresentation ?? null,
-				redactedRepresentation: representation.redactedRepresentation ?? null
+				redactedRepresentation: representation.redactedRepresentation ?? null,
+				isRedacted: representation.isRedacted ?? false
 			};
 		})
 	);
 
-	// @ts-ignore
 	await representationRepository.createRepresentations(
 		copiedRepresentations.filter((rep) => rep.status === 'fulfilled').map((rep) => rep.value)
 	);

--- a/appeals/api/src/server/endpoints/representations/representations.controller.js
+++ b/appeals/api/src/server/endpoints/representations/representations.controller.js
@@ -2,7 +2,6 @@ import { Prisma } from '#db-client/client.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { sendRepresentationReceivedNotifications } from '#endpoints/integrations/integrations.controller.js';
-import representationRepository from '#repositories/representation.repository.js';
 import { isStatePassed } from '#state/transition-state.js';
 import BackOfficeAppError from '#utils/app-error.js';
 import { currentStatus } from '#utils/current-status.js';
@@ -130,31 +129,6 @@ export const getRepresentation = async (req, res) => {
 };
 
 /**
- * @param {Request} req
- * @param {Response} res
- * @returns {Promise<Response>}
- */
-export const addRedactedRepresentation = async (req, res) => {
-	const { repId } = req.params;
-	const { redactedRepresentation } = req.body;
-
-	const rep = await representationRepository.updateRepresentationById(Number(repId), {
-		redactedRepresentation
-	});
-
-	if (!rep) {
-		return res.status(404).send({
-			errors: {
-				repId: ERROR_NOT_FOUND
-			}
-		});
-	}
-
-	await broadcasters.broadcastRepresentation(rep.id, EventType.Update);
-	return res.send(formatRepresentation(rep));
-};
-
-/**
  * @param {Request} request
  * @param {Response} response
  * @returns {Promise<Response>}
@@ -198,7 +172,8 @@ export async function updateRepresentation(request, response) {
 
 	const updatedRep = await representationService.updateRepresentation(
 		parseInt(repId),
-		status === APPEAL_REPRESENTATION_STATUS.PUBLISHED ? { ...request.body, status } : request.body
+		status === APPEAL_REPRESENTATION_STATUS.PUBLISHED ? { ...request.body, status } : request.body,
+		existingRep
 	);
 
 	if (status !== existingRep.status) {
@@ -284,7 +259,7 @@ export const createRepresentation = () => async (req, res) => {
 	}
 
 	const rep = await representationService.createRepresentation(
-		parseInt(appealId),
+		Number.parseInt(appealId, 10),
 		String(req.get('azureAdUserId')),
 		shouldAutoPublish,
 		req.appeal.appealStatus.find((item) => item.valid === true)?.status ?? '',

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -380,12 +380,17 @@ export const updateAttachments = async (repId, attachments) => {
 /**
  * @param {number} repId
  * @param {import('express').Request['body']} payload
+ * @param {import('#db-client/models.ts').RepresentationModel} existingRep
  * */
-export async function updateRepresentation(repId, payload) {
+export async function updateRepresentation(repId, payload, existingRep) {
 	if (payload.rejectionReasons) {
 		await representationRepository.updateRejectionReasons(repId, payload.rejectionReasons);
 	}
-	const updatedRep = await representationRepository.updateRepresentationById(repId, payload);
+	const updatedRep = await representationRepository.updateRepresentationById(
+		repId,
+		payload,
+		existingRep
+	);
 
 	if (!updatedRep.represented?.addressId) {
 		return updatedRep;

--- a/appeals/api/src/server/mappers/api/shared/__tests__/map-documentation-summary.test.js
+++ b/appeals/api/src/server/mappers/api/shared/__tests__/map-documentation-summary.test.js
@@ -54,12 +54,13 @@ describe('mapDocumentationSummary', () => {
 					representationType: APPEAL_REPRESENTATION_TYPE.COMMENT,
 					status: 'valid',
 					dateCreated: date1,
-					redactedRepresentation: 'redacted'
+					isRedacted: true
 				},
 				{
 					representationType: APPEAL_REPRESENTATION_TYPE.COMMENT,
 					status: 'awaiting_review',
-					dateCreated: date2
+					dateCreated: date2,
+					isRedacted: false
 				}
 			]
 		};
@@ -82,8 +83,7 @@ describe('mapDocumentationSummary', () => {
 					representationType: APPEAL_REPRESENTATION_TYPE.LPA_STATEMENT,
 					status: 'valid',
 					dateCreated: new Date(),
-					originalRepresentation: 'original',
-					redactedRepresentation: 'redacted' // Different, so isRedacted should be true
+					isRedacted: true
 				}
 			]
 		};
@@ -106,8 +106,7 @@ describe('mapDocumentationSummary', () => {
 					representationType: APPEAL_REPRESENTATION_TYPE.LPA_STATEMENT,
 					status: 'valid',
 					dateCreated: new Date(),
-					originalRepresentation: 'same',
-					redactedRepresentation: 'same' // Same, so isRedacted should be false
+					isRedacted: false
 				}
 			]
 		};
@@ -124,8 +123,7 @@ describe('mapDocumentationSummary', () => {
 			representations: [
 				{
 					representationType: APPEAL_REPRESENTATION_TYPE.LPA_STATEMENT,
-					originalRepresentation: 'original',
-					redactedRepresentation: 'redacted', // Sets the global "redactLPAStatementMatching" flag to TRUE
+					isRedacted: true,
 					dateCreated: new Date()
 				},
 				{
@@ -133,7 +131,7 @@ describe('mapDocumentationSummary', () => {
 					representedId: 1,
 					status: 'valid',
 					dateCreated: new Date(),
-					redactedRepresentation: 'some redacted content'
+					isRedacted: true
 				}
 			]
 		};
@@ -155,8 +153,7 @@ describe('mapDocumentationSummary', () => {
 			representations: [
 				{
 					representationType: APPEAL_REPRESENTATION_TYPE.LPA_STATEMENT,
-					originalRepresentation: 'original',
-					redactedRepresentation: 'redacted',
+					isRedacted: false,
 					dateCreated: new Date()
 				},
 				{
@@ -164,7 +161,7 @@ describe('mapDocumentationSummary', () => {
 					representedId: 1,
 					status: 'valid',
 					dateCreated: new Date(),
-					redactedRepresentation: 'redacted content'
+					isRedacted: true
 				}
 			]
 		};

--- a/appeals/api/src/server/mappers/api/shared/map-documentation-summary.js
+++ b/appeals/api/src/server/mappers/api/shared/map-documentation-summary.js
@@ -69,10 +69,6 @@ export const mapDocumentationSummary = (data) => {
 
 	const mostRecentIpComment = maxBy(ipComments, (comment) => new Date(comment.dateCreated));
 
-	const redactLPAStatementMatching = checkRedactedText(
-		lpaStatement?.redactedRepresentation || '',
-		lpaStatement?.originalRepresentation || ''
-	);
 	return {
 		appellantCase: {
 			status: formatAppellantCaseDocumentationStatus(appeal),
@@ -93,13 +89,13 @@ export const mapDocumentationSummary = (data) => {
 				status: ipComments.length > 0 ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 				receivedAt: mostRecentIpComment?.dateCreated.toISOString() ?? null,
 				counts: countBy(ipComments, 'status'),
-				isRedacted: ipComments.some((comment) => Boolean(comment.redactedRepresentation))
+				isRedacted: ipComments.some((comment) => comment.isRedacted)
 			},
 			lpaStatement: {
 				status: lpaStatement ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 				receivedAt: lpaStatement?.dateCreated.toISOString() ?? null,
 				representationStatus: lpaStatement?.status ?? null,
-				isRedacted: Boolean(lpaStatement?.redactedRepresentation && redactLPAStatementMatching)
+				isRedacted: lpaStatement?.isRedacted ?? false
 			},
 			rule6PartyStatements: reduce(
 				appeal.appealRule6Parties,
@@ -111,13 +107,7 @@ export const mapDocumentationSummary = (data) => {
 						status: statement ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 						receivedAt: statement?.dateCreated.toISOString() ?? null,
 						representationStatus: statement?.status ?? null,
-						isRedacted: Boolean(
-							statement?.redactedRepresentation &&
-							checkRedactedText(
-								statement?.originalRepresentation || '',
-								statement?.redactedRepresentation || ''
-							)
-						),
+						isRedacted: statement?.isRedacted ?? false,
 						organisationName: rule6Party?.serviceUser?.organisationName,
 						rule6PartyId: rule6Party?.id
 					};
@@ -161,13 +151,7 @@ export const mapDocumentationSummary = (data) => {
 						status: proof ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 						receivedAt: proof?.dateCreated.toISOString() ?? null,
 						representationStatus: proof?.status ?? null,
-						isRedacted: Boolean(
-							proof?.redactedRepresentation &&
-							checkRedactedText(
-								proof?.originalRepresentation || '',
-								proof?.redactedRepresentation || ''
-							)
-						),
+						isRedacted: proof?.isRedacted ?? false,
 						organisationName: rule6Party?.serviceUser?.organisationName,
 						rule6PartyId: rule6Party?.id
 					};

--- a/appeals/api/src/server/mappers/integration/map-representation-entity.js
+++ b/appeals/api/src/server/mappers/integration/map-representation-entity.js
@@ -18,14 +18,15 @@ import {
 import { serviceUserIdStartRange } from './map-service-user-entity.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
-/** @typedef {import('@pins/appeals.api').Schema.Representation & { appeal?: Appeal }} RepresentationWithAppeal */
 /** @typedef {import('@planning-inspectorate/data-model').Schemas.AppealRepresentation} AppealRepresentation */
 /** @typedef {'Contains links to web pages'|'Duplicated or repeated comment'|'Includes inflammatory content'|'Includes personal or medical information'|'No list of suggested conditions'|'Not relevant to this appeal'|'Received after deadline'|'other_reason'} RejectionReason*/
+/** @typedef {import('#db-client/models.ts').RepresentationModel} Representation */
+/** @typedef {typeof import('#endpoints/integrations/integrations.broadcasters/representation.js').broadcastRepSelect} RepresentationBroadcaster */
+/** @typedef {import('#db-client/models.ts').RepresentationGetPayload<{ select: RepresentationBroadcaster }>} RepresentationBroadcastData */
 
 /**
- *
- * @param {RepresentationWithAppeal} data
- * @returns {AppealRepresentation | undefined}
+ * @param {RepresentationBroadcastData|null} data
+ * @returns {import('@planning-inspectorate/data-model').Schemas.AppealRepresentation|undefined}
  */
 export const mapRepresentationEntity = (data) => {
 	if (data && data.appeal) {
@@ -56,8 +57,8 @@ const mapRepresentationUserId = (id) => (id ? (serviceUserIdStartRange + id).toS
 
 /**
  *
- * @param {Appeal} appeal
- * @returns {{ caseId: number, caseReference: string }}}
+ * @param {{id: Appeal['id'], reference: Appeal['reference']}} appeal
+ * @returns {{ caseId: number, caseReference: string }}
  */
 const mapAppealInfo = (appeal) => {
 	return {
@@ -68,7 +69,7 @@ const mapAppealInfo = (appeal) => {
 
 /**
  *
- * @param {string} type
+ * @param {Representation['representationType']} type
  * @returns {'comment' | 'final_comment' | 'proofs_evidence' | 'statement' | null}
  */
 const mapRepresentationType = (type) => {
@@ -77,7 +78,7 @@ const mapRepresentationType = (type) => {
 };
 
 /**
- * @param {string} status
+ * @param {Representation['status']} status
  * @returns {'archived' | 'awaiting_review' | 'draft' | 'invalid' | 'invalid_incomplete' | 'published' | 'referred' | 'valid' | 'withdrawn' | null}
  */
 const mapRepresentationStatus = (status) => {
@@ -87,7 +88,7 @@ const mapRepresentationStatus = (status) => {
 
 /**
  *
- * @param {RepresentationWithAppeal} data
+ * @param {{lpa: Object|null, source: Representation['source']}} data
  * @returns {'lpa' | 'citizen' | null}
  */
 const mapSource = (data) => {
@@ -104,7 +105,7 @@ const mapSource = (data) => {
 
 /**
  *
- * @param {RepresentationWithAppeal} data
+ * @param {RepresentationBroadcastData} data
  * @returns {{invalidOrIncompleteDetails: RejectionReason[], otherInvalidOrIncompleteDetails: string[]}}
  */
 const mapReasons = (data) => {

--- a/appeals/api/src/server/middleware/check-representation-exists.js
+++ b/appeals/api/src/server/middleware/check-representation-exists.js
@@ -16,7 +16,9 @@ export const checkRepresentationExistsById = async (req, res, next) => {
 		params: { repId }
 	} = req;
 
-	const representation = await representationRepository.getById(Number(repId));
+	const representation = await representationRepository.checkRepresentationExistsById(
+		Number(repId)
+	);
 
 	if (!representation) {
 		return res.status(404).send({ errors: { repId: ERROR_NOT_FOUND } });

--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -176,7 +176,6 @@ export const createOrUpdateLpaQuestionnaire = async (
  * @param {Appeal} appeal
  * @param {Omit<import('#db-client/models.ts').RepresentationCreateInput, 'appeal'>} data
  * @param {import('#db-client/models.ts').DocumentVersionCreateInput[]} attachments
- * @returns {Promise<{rep: Representation, documentVersions: DocumentVersion[]}>}
  */
 export const createRepresentation = async (appeal, data, attachments) => {
 	const transaction = await databaseConnector.$transaction(async (tx) => {

--- a/appeals/api/src/server/repositories/representation.repository.js
+++ b/appeals/api/src/server/repositories/representation.repository.js
@@ -1,9 +1,33 @@
 import { databaseConnector } from '#utils/database-connector.js';
 import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
 
-/** @typedef {import('#db-client/models.ts').RepresentationUpdateInput} RepresentationUpdateInput */
-/** @typedef {import('#db-client/models.ts').RepresentationUncheckedCreateInput} RepresentationCreateInput */
 /** @typedef {import('#db-client/models.ts').RepresentationWhereInput} RepresentationWhereInput */
+/** @typedef {import('#db-client/models.ts').RepresentationModel} RepresentationModel */
+/** @typedef {import('#db-client/models.ts').RepresentationCreateArgs} RepresentationCreateArgs */
+/** @typedef {import('#db-client/models.ts').RepresentationCreateManyInput} RepresentationCreateManyInput */
+
+/**
+ * @typedef {Object} RepresentationUpdateData
+ * @property {RepresentationModel['appealId']} [appealId]
+ * @property {RepresentationModel['representedId']} [representedId]
+ * @property {RepresentationModel['status']} [status]
+ * @property {RepresentationModel['redactedRepresentation']} [redactedRepresentation]
+ * @property {RepresentationModel['notes']} [notes]
+ * @property {RepresentationModel['reviewer']} [reviewer]
+ * @property {RepresentationModel['siteVisitRequested']} [siteVisitRequested]
+ */
+
+/**
+ * @param {number} id
+ */
+const checkRepresentationExistsById = (id) => {
+	return databaseConnector.representation.findUnique({
+		where: { id },
+		select: {
+			id: true
+		}
+	});
+};
 
 /**
  * @param {number} id
@@ -40,7 +64,7 @@ const getById = (id) => {
 
 /**
  * @param {number[]} appealIds
- * @param {{ representationType?: string[], status?: string }} [options]
+ * @param {{ representationType?: RepresentationModel['representationType'][], status?: RepresentationModel['status'] }} [options]
  * @param {number} [pageNumber]
  * @param {number} [pageSize]
  * */
@@ -108,7 +132,8 @@ const getRepresentations = async (appealIds, options, pageNumber, pageSize) => {
 				dateCreated: true,
 				originalRepresentation: true,
 				source: true,
-				redactedRepresentation: true
+				redactedRepresentation: true,
+				isRedacted: true
 			},
 			orderBy: { dateCreated: 'desc' },
 			...(pageNumber && pageSize ? { skip: pageNumber * pageSize } : {}),
@@ -123,7 +148,7 @@ const getRepresentations = async (appealIds, options, pageNumber, pageSize) => {
 
 /**
  * @param {number[]} appealIds
- * @param {{ status?: string }} options
+ * @param {{ status?: RepresentationModel['status'] }} options
  * @returns {Promise<{ [key: string]: number }>}
  */
 const getRepresentationCounts = async (appealIds, options) => {
@@ -154,9 +179,10 @@ const getRepresentationCounts = async (appealIds, options) => {
 
 /**
  * @param {number} id
- * @param {RepresentationUpdateInput & { appealId?: number, representedId?: number }} data
+ * @param {RepresentationUpdateData} data
+ * @param {{ originalRepresentation?: RepresentationModel['originalRepresentation'] }} [existingRep]
  */
-const updateRepresentationById = (id, data) => {
+const updateRepresentationById = async (id, data, existingRep) => {
 	const {
 		status,
 		redactedRepresentation,
@@ -167,6 +193,13 @@ const updateRepresentationById = (id, data) => {
 		appealId
 	} = data;
 
+	const redacted = redactedRepresentation
+		? isRedacted({
+				redactedRepresentation: redactedRepresentation,
+				originalRepresentation: existingRep?.originalRepresentation
+			})
+		: undefined;
+
 	return databaseConnector.representation.update({
 		where: {
 			id
@@ -174,7 +207,10 @@ const updateRepresentationById = (id, data) => {
 		data: {
 			...(appealId && { appealId }),
 			...(status && { status }),
-			...(redactedRepresentation && { redactedRepresentation }),
+			...(redactedRepresentation && {
+				redactedRepresentation: redacted ? redactedRepresentation : null
+			}),
+			...(redactedRepresentation && { isRedacted: redacted }),
 			...(notes && { notes }),
 			...(representedId && { representedId }),
 			reviewer,
@@ -202,10 +238,10 @@ const updateRepresentationById = (id, data) => {
 /**
  * @param {number[]} appealIds
  * @param {RepresentationWhereInput} options
- * @param {RepresentationUpdateInput & { appealId?: number }} data
+ * @param {{ status?: RepresentationModel['status'] }} data
  */
 const updateRepresentations = (appealIds, options, data) => {
-	const { status, redactedRepresentation, notes, reviewer, siteVisitRequested, appealId } = data;
+	const { status } = data;
 
 	return databaseConnector.$transaction(async (tx) => {
 		const reps = await tx.representation.findMany({
@@ -221,13 +257,8 @@ const updateRepresentations = (appealIds, options, data) => {
 				}
 			},
 			data: {
-				...(appealId && { appealId }),
 				...(status && { status }),
-				...(redactedRepresentation && { redactedRepresentation }),
-				...(notes && { notes }),
-				reviewer,
-				dateLastUpdated: new Date(),
-				siteVisitRequested
+				dateLastUpdated: new Date()
 			}
 		});
 
@@ -243,7 +274,7 @@ const updateRepresentations = (appealIds, options, data) => {
 
 /**
  * @param {number[]} appealIds
- * @param {string} [representationType]
+ * @param {RepresentationModel['representationType']} [representationType]
  * @returns {Promise<Record<string, number>>}
  * */
 const countAppealRepresentationsByStatus = async (appealIds, representationType) => {
@@ -266,17 +297,38 @@ const countAppealRepresentationsByStatus = async (appealIds, representationType)
 };
 
 /**
- * @param {RepresentationCreateInput} data
- * @returns {Promise<import('@pins/appeals.api').Schema.Representation>}
- * */
-const createRepresentation = (data) => databaseConnector.representation.create({ data });
+ * @param {string | null | undefined} value
+ */
+const normalizeWhitespace = (value) => (value ?? '').replace(/\s+/g, ' ').trim();
 
 /**
- * @param {RepresentationCreateInput[]} data
- * @returns {Promise<import('@pins/appeals.api').Schema.Representation[]>}
+ * @param {{ redactedRepresentation?: string | null, originalRepresentation?: string | null }} rep
+ */
+const isRedacted = (rep) =>
+	rep.redactedRepresentation != null &&
+	normalizeWhitespace(rep.redactedRepresentation) !==
+		normalizeWhitespace(rep.originalRepresentation);
+
+/**
+ * @param {RepresentationCreateArgs['data']} data
+ * @returns {Promise<import('@pins/appeals.api').Schema.Representation>}
  * */
-// @ts-ignore
-const createRepresentations = (data) => databaseConnector.representation.createMany({ data });
+const createRepresentation = (data) =>
+	databaseConnector.representation.create({
+		data: {
+			...data,
+			isRedacted: isRedacted(data)
+		}
+	});
+
+/**
+ * @param {RepresentationCreateManyInput[]} data
+ * */
+const createRepresentations = (data) => {
+	return databaseConnector.representation.createMany({
+		data: data.map((rep) => ({ ...rep, isRedacted: isRedacted(rep) }))
+	});
+};
 
 /**
  * @param {number} repId
@@ -409,6 +461,7 @@ const getInterestedPartyEmails = async (appealIds) => {
 };
 
 export default {
+	checkRepresentationExistsById,
 	getById,
 	getInterestedPartyEmails,
 	getRepresentations,

--- a/appeals/web/src/client/components/redact-button/__tests__/index.test.js
+++ b/appeals/web/src/client/components/redact-button/__tests__/index.test.js
@@ -35,6 +35,14 @@ const setupJSDOMGlobals = () => {
 	global.Node = window.Node;
 	global.Element = window.Element;
 
+	// JSDOM does not implement innerText (a rendered-text feature); delegate to textContent
+	Object.defineProperty(window.HTMLElement.prototype, 'innerText', {
+		configurable: true,
+		get() {
+			return this.textContent;
+		}
+	});
+
 	return () => {
 		Object.keys(originalGlobals).forEach((key) => {
 			if (originalGlobals[key] === undefined) {
@@ -377,6 +385,19 @@ describe('initRedactButtons (Integration Tests)', () => {
 
 		revertButton.onclick(mockEvent);
 		expect(textarea.value).toBe(originalText);
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+	});
+
+	it('should preserve line breaks when reverting to the original comment', () => {
+		const originalText = 'Line one\nLine two';
+		setupTestDOM({ originalText: originalText, textareaText: 'Changed text' });
+		const revertButton = document.querySelector(SELECTORS.REVERT_BUTTON);
+		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+
+		initRedactButtons();
+		revertButton.onclick(mockEvent);
+
+		expect(textarea.value).toBe('Line one\nLine two');
 		expect(mockEvent.preventDefault).toHaveBeenCalled();
 	});
 

--- a/appeals/web/src/client/components/redact-button/index.js
+++ b/appeals/web/src/client/components/redact-button/index.js
@@ -56,6 +56,12 @@ export const isHTMLButtonElement = (element) => element instanceof HTMLButtonEle
  * */
 export const isHTMLDivElement = (element) => element instanceof HTMLDivElement;
 
+/**
+ * @param {HTMLElement} element
+ * @returns {string}
+ */
+export const getRenderedText = (element) => element.innerText.replace(/\r\n?/g, '\n').trim();
+
 export const initRedactButtons = () => {
 	const originalCommentText = document.querySelector(SELECTORS.ORIGINAL_COMMENT_IDENTIFIER);
 	const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
@@ -84,5 +90,5 @@ export const initRedactButtons = () => {
 
 	redactButton.onclick = generateOnClick(textarea);
 	undoButton.onclick = setAreaText(textarea, savedRedaction);
-	revertButton.onclick = setAreaText(textarea, originalCommentText.textContent?.trim() ?? '');
+	revertButton.onclick = setAreaText(textarea, getRenderedText(originalCommentText));
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/types.d.ts
+++ b/appeals/web/src/server/appeals/appeal-details/representations/types.d.ts
@@ -17,6 +17,7 @@ export interface Representation {
 	status: RepresentationStatus;
 	originalRepresentation: string;
 	redactedRepresentation: string;
+	isRedacted: boolean;
 	created: string;
 	notes: string;
 	attachments: any[];


### PR DESCRIPTION
## Describe your changes

- adds isRedacted field to representation
- revert representation field no longer removes line breaks
- checks when updating for is redacted rather than pulling both and doing a comparison
- adds missing indexes suggested in Azure