### PR TITLE
fix(web): CAS Adverts expedite LPAQ updates (A2-8701)

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
@@ -445,7 +445,12 @@ describe('/appeals/lpaq-submission', () => {
 						appealType: true,
 						appellant: true,
 						inquiry: true,
-						lpa: true
+						lpa: true,
+						appellantCase: {
+							select: {
+								applicationDate: true
+							}
+						}
 					},
 					where: {
 						reference: '6000000'
@@ -763,7 +768,12 @@ describe('/appeals/representation-submission', () => {
 							appealType: true,
 							appellant: true,
 							inquiry: true,
-							lpa: true
+							lpa: true,
+							appellantCase: {
+								select: {
+									applicationDate: true
+								}
+							}
 						}
 					});
 					expect(databaseConnector.representation.create).toHaveBeenCalled();
@@ -859,7 +869,12 @@ describe('/appeals/representation-submission', () => {
 							appealType: true,
 							appellant: true,
 							inquiry: true,
-							lpa: true
+							lpa: true,
+							appellantCase: {
+								select: {
+									applicationDate: true
+								}
+							}
 						}
 					});
 					expect(databaseConnector.representation.create).toHaveBeenCalled();

--- a/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
@@ -225,7 +225,12 @@ const loadReferenceData = async (reference, useLeadAppealIfLinked = false) => {
 				},
 				inquiry: true,
 				appealTimetable: true,
-				address: true
+				address: true,
+				appellantCase: {
+					select: {
+						applicationDate: true
+					}
+				}
 			}
 		});
 

--- a/appeals/api/src/server/mappers/__tests__/mapper-factory.test.js
+++ b/appeals/api/src/server/mappers/__tests__/mapper-factory.test.js
@@ -225,6 +225,11 @@ describe('appeals api mappers', () => {
 			folders: []
 		};
 
+		const appealCASAdvertExpedite = {
+			...mocks.casAdvertExpediteAppeal,
+			folders: []
+		};
+
 		// @ts-ignore
 		const hasAppCaseOutput = mapCase({ appeal: appealHAS, context: contextEnum.appellantCase });
 		// @ts-ignore
@@ -232,6 +237,12 @@ describe('appeals api mappers', () => {
 		const s78ExpediteAppCaseOutput = mapCase({
 			// @ts-ignore
 			appeal: appealS78Expedite,
+			context: contextEnum.appellantCase
+		});
+
+		const casAdvertExpediteAppCaseOutput = mapCase({
+			// @ts-ignore
+			appeal: appealCASAdvertExpedite,
 			context: contextEnum.appellantCase
 		});
 
@@ -258,6 +269,20 @@ describe('appeals api mappers', () => {
 		expect(s78AppCaseOutput).not.toHaveProperty('enforcementNotice');
 
 		expect(s78ExpediteAppCaseOutput).toHaveProperty('planningObligation');
+
+		expect(casAdvertExpediteAppCaseOutput).toHaveProperty('anySignificantChanges');
+		expect(casAdvertExpediteAppCaseOutput).toHaveProperty(
+			'anySignificantChanges_courtJudgementSignificantChanges'
+		);
+		expect(casAdvertExpediteAppCaseOutput).toHaveProperty(
+			'anySignificantChanges_localPlanSignificantChanges'
+		);
+		expect(casAdvertExpediteAppCaseOutput).toHaveProperty(
+			'anySignificantChanges_nationalPolicySignificantChanges'
+		);
+		expect(casAdvertExpediteAppCaseOutput).toHaveProperty(
+			'anySignificantChanges_otherSignificantChanges'
+		);
 	});
 
 	test('should only map the lpaq fields for LDC', async () => {
@@ -349,5 +374,72 @@ describe('appeals integration mappers', () => {
 		// Enforcement specific
 		expect(elbLpaqOutput).not.toHaveProperty('isSiteOnCrownLand');
 		expect(elbLpaqOutput).not.toHaveProperty('changeOfUseRefuseOrWaste');
+	});
+
+	test('should only map the lpaq fields for CAS adverts expedite', async () => {
+		const appealCASAdvertExpedite = {
+			...mocks.casAdvertExpediteAppeal,
+			appealType: {
+				key: APPEAL_CASE_TYPE.ZA,
+				type: 'CAS advert'
+			},
+			folders: []
+		};
+
+		const casAdvertExpediteLpaqOutput = mapCase({
+			// @ts-ignore
+			appeal: appealCASAdvertExpedite,
+			context: contextEnum.lpaQuestionnaire
+		});
+		// CAS Advert Expedite
+		expect(casAdvertExpediteLpaqOutput).toHaveProperty(
+			'listOfDocumentsBeforeDecision',
+			'hoi oyf yrtd ytrtt ulliyuyg utg uyg ugyuo utyu uyg ouyg ouyg ouyg ouyg jhk bhm jvuhguyg oyg uygg ouy gouy uy uy oguy ouygo blargo'
+		);
+		expect(casAdvertExpediteLpaqOutput).toHaveProperty('anySignificantChangesLpa', true);
+		expect(casAdvertExpediteLpaqOutput).toHaveProperty(
+			'anySignificantChangesLpa_courtJudgementSignificantChanges',
+			'100'
+		);
+		expect(casAdvertExpediteLpaqOutput).toHaveProperty(
+			'anySignificantChangesLpa_courtJudgementSignificantChanges',
+			'100'
+		);
+		expect(casAdvertExpediteLpaqOutput).toHaveProperty(
+			'anySignificantChangesLpa_courtJudgementSignificantChanges',
+			'100'
+		);
+	});
+	test('should only map the lpaq fields for CAS adverts', async () => {
+		const appealCASAdvert = {
+			...mocks.advertAppeal,
+			appealType: {
+				key: APPEAL_CASE_TYPE.ZA,
+				type: 'CAS advert'
+			},
+			folders: []
+		};
+
+		const casAdvertLpaqOutput = mapCase({
+			// @ts-ignore
+			appeal: appealCASAdvert,
+			context: contextEnum.lpaQuestionnaire
+		});
+		// CAS Advert
+		expect(casAdvertLpaqOutput).not.toHaveProperty(
+			'listOfDocumentsBeforeDecision',
+			'hoi oyf yrtd ytrtt ulliyuyg utg uyg ugyuo utyu uyg ouyg ouyg ouyg ouyg jhk bhm jvuhguyg oyg uygg ouy gouy uy uy oguy ouygo blargo'
+		);
+
+		expect(casAdvertLpaqOutput).not.toHaveProperty('anySignificantChangesLpa');
+		expect(casAdvertLpaqOutput).not.toHaveProperty(
+			'anySignificantChangesLpa_courtJudgementSignificantChanges'
+		);
+		expect(casAdvertLpaqOutput).not.toHaveProperty(
+			'anySignificantChangesLpa_courtJudgementSignificantChanges'
+		);
+		expect(casAdvertLpaqOutput).not.toHaveProperty(
+			'anySignificantChangesLpa_courtJudgementSignificantChanges'
+		);
 	});
 });

--- a/appeals/api/src/server/mappers/api/cas-advert-expedited/index.js
+++ b/appeals/api/src/server/mappers/api/cas-advert-expedited/index.js
@@ -1,0 +1,7 @@
+import { mapCasAdvertAppellantCase } from './map-appellant-case.js';
+import { mapCasAdvertLpaQuestionnaire } from './map-lpa-questionnaire.js';
+
+export const apiCasAdvertExpeditedMappers = {
+	appellantCase: mapCasAdvertAppellantCase,
+	lpaQuestionnaire: mapCasAdvertLpaQuestionnaire
+};

--- a/appeals/api/src/server/mappers/api/cas-advert-expedited/map-appellant-case.js
+++ b/appeals/api/src/server/mappers/api/cas-advert-expedited/map-appellant-case.js
@@ -1,0 +1,23 @@
+/** @typedef {import('@pins/appeals.api').Api.AppellantCase} AppellantCase */
+/** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
+
+/**
+ *
+ * @param {MappingRequest} data
+ * @returns {AppellantCase|undefined}
+ */
+export const mapCasAdvertAppellantCase = (data) => {
+	const {
+		appeal: { appellantCase }
+	} = data;
+
+	const advertDetails = appellantCase?.appellantCaseAdvertDetails;
+
+	return {
+		highwayLand: advertDetails?.[0]?.highwayLand,
+		advertInPosition: advertDetails?.[0]?.advertInPosition,
+		landownerPermission: appellantCase?.landownerPermission,
+		siteGridReferenceEasting: appellantCase?.siteGridReferenceEasting,
+		siteGridReferenceNorthing: appellantCase?.siteGridReferenceNorthing
+	};
+};

--- a/appeals/api/src/server/mappers/api/cas-advert-expedited/map-lpa-questionnaire.js
+++ b/appeals/api/src/server/mappers/api/cas-advert-expedited/map-lpa-questionnaire.js
@@ -1,0 +1,59 @@
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('@pins/appeals.api').Api.LpaQuestionnaire} LpaQuestionnaire */
+/** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
+/**
+ *
+ * @param {MappingRequest} data
+ * @returns {LpaQuestionnaire|undefined}
+ */
+export const mapCasAdvertLpaQuestionnaire = (data) => {
+	const {
+		appeal: { lpaQuestionnaire }
+	} = data;
+
+	if (lpaQuestionnaire) {
+		return {
+			lpaProcedurePreference: lpaQuestionnaire.lpaProcedurePreference,
+			designatedSiteNames: [
+				...(lpaQuestionnaire.designatedSiteNames ?? []).map((item) => ({
+					id: item.designatedSite.id,
+					key: item.designatedSite.key,
+					name: item.designatedSite.name
+				})),
+				...(lpaQuestionnaire.designatedSiteNameCustom
+					? [
+							{
+								id: 0,
+								key: 'custom',
+								name: lpaQuestionnaire.designatedSiteNameCustom
+							}
+						]
+					: [])
+			],
+			extraConditions: lpaQuestionnaire.newConditionDetails,
+			hasExtraConditions: lpaQuestionnaire.newConditionDetails !== null,
+			affectsScheduledMonument: lpaQuestionnaire.affectsScheduledMonument,
+			hasProtectedSpecies: lpaQuestionnaire.hasProtectedSpecies,
+			isAonbNationalLandscape: lpaQuestionnaire.isAonbNationalLandscape,
+			lpaProcedurePreferenceDetails: lpaQuestionnaire.lpaProcedurePreferenceDetails,
+			lpaProcedurePreferenceDuration: lpaQuestionnaire.lpaProcedurePreferenceDuration,
+			consultedBodiesDetails: lpaQuestionnaire.consultedBodiesDetails,
+			reasonForNeighbourVisits: lpaQuestionnaire.reasonForNeighbourVisits,
+			isSiteInAreaOfSpecialControlAdverts: lpaQuestionnaire.isSiteInAreaOfSpecialControlAdverts,
+			wasApplicationRefusedDueToHighwayOrTraffic:
+				lpaQuestionnaire.wasApplicationRefusedDueToHighwayOrTraffic,
+			didAppellantSubmitCompletePhotosAndPlans:
+				lpaQuestionnaire.didAppellantSubmitCompletePhotosAndPlans,
+			listOfDocumentsBeforeDecision: lpaQuestionnaire?.listOfDocumentsBeforeDecision || null,
+			anySignificantChangesLpa: lpaQuestionnaire?.anySignificantChangesLpa || null,
+			anySignificantChangesLpa_localPlanSignificantChanges:
+				lpaQuestionnaire?.anySignificantChangesLpa_localPlanSignificantChanges || null,
+			anySignificantChangesLpa_nationalPolicySignificantChanges:
+				lpaQuestionnaire?.anySignificantChangesLpa_nationalPolicySignificantChanges || null,
+			anySignificantChangesLpa_otherSignificantChanges:
+				lpaQuestionnaire?.anySignificantChangesLpa_otherSignificantChanges || null,
+			anySignificantChangesLpa_courtJudgementSignificantChanges:
+				lpaQuestionnaire?.anySignificantChangesLpa_courtJudgementSignificantChanges || null
+		};
+	}
+};

--- a/appeals/api/src/server/mappers/api/index.js
+++ b/appeals/api/src/server/mappers/api/index.js
@@ -1,4 +1,5 @@
 import { apiAdvertMappers } from './advert/index.js';
+import { apiCasAdvertExpeditedMappers } from './cas-advert-expedited/index.js';
 import { apiCasAdvertMappers } from './cas-advert/index.js';
 import { apiEnforcementListedMappers } from './enforcement-listed/index.js';
 import { apiEnforcementMappers } from './enforcement/index.js';
@@ -13,6 +14,7 @@ export const apiMappers = {
 	apiS78Mappers,
 	apiS20Mappers,
 	apiCasAdvertMappers,
+	apiCasAdvertExpeditedMappers,
 	apiAdvertMappers,
 	apiEnforcementMappers,
 	apiLdcMappers,

--- a/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
+++ b/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
@@ -912,6 +912,75 @@ describe('mapQuestionnaireIn', () => {
 			})
 		},
 		{
+			desc: 'CAS adverts case expedited(ZA)',
+			input: {
+				casedata: {
+					caseType: APPEAL_CASE_TYPE.ZA,
+					lpaQuestionnaireSubmittedDate: '2026-10-22',
+					siteAccessDetails: ['access1'],
+					siteSafetyDetails: ['safety1'],
+					notificationMethod: ['post'],
+					affectedListedBuildingNumbers: ['LB1'],
+					designatedSitesNames: ['siteA'],
+					affectsScheduledMonument: true,
+					hasProtectedSpecies: true,
+					isAonbNationalLandscape: true,
+					hasStatutoryConsultees: true,
+					consultedBodiesDetails: 'details',
+					hasEmergingPlan: true,
+					lpaProcedurePreference: 'written',
+					lpaProcedurePreferenceDetails: 'preference details',
+					lpaProcedurePreferenceDuration: 12,
+					siteWithinSSSI: true,
+					isSiteInAreaOfSpecialControlAdverts: true,
+					wasApplicationRefusedDueToHighwayOrTraffic: true,
+					didAppellantSubmitCompletePhotosAndPlans: true,
+					significantChangesAffectingApplicationLpa: [
+						{ value: 'adopted-a-new-local-plan', comment: 'lp' },
+						{ value: 'national-policy-change', comment: 'np' },
+						{ value: 'court-judgement', comment: 'cj' },
+						{ value: 'other', comment: 'o' }
+					],
+					listOfDocumentsBeforeDecision: 'docs'
+				},
+				appeal: {
+					appellantCase: {
+						applicationDate: '2026-10-22'
+					}
+				}
+			},
+			expected: expect.objectContaining({
+				lpaQuestionnaireSubmittedDate: '2026-10-22',
+				siteAccessDetails: 'access1',
+				siteSafetyDetails: 'safety1',
+				listedBuildingDetails: { create: [{ listEntry: 'LB1', affectsListedBuilding: true }] },
+				lpaNotificationMethods: {
+					create: [{ lpaNotificationMethod: { connect: { key: 'post' } } }]
+				},
+				designatedSiteNames: {
+					create: [{ designatedSite: { connect: { key: 'siteA' } } }]
+				},
+				affectsScheduledMonument: true,
+				hasProtectedSpecies: true,
+				isAonbNationalLandscape: true,
+				hasStatutoryConsultees: true,
+				consultedBodiesDetails: 'details',
+				hasEmergingPlan: true,
+				lpaProcedurePreference: 'written',
+				lpaProcedurePreferenceDetails: 'preference details',
+				lpaProcedurePreferenceDuration: 12,
+				isSiteInAreaOfSpecialControlAdverts: true,
+				wasApplicationRefusedDueToHighwayOrTraffic: true,
+				didAppellantSubmitCompletePhotosAndPlans: true,
+				anySignificantChangesLpa: 'Yes',
+				anySignificantChangesLpa_otherSignificantChanges: 'o',
+				anySignificantChangesLpa_localPlanSignificantChanges: 'lp',
+				anySignificantChangesLpa_nationalPolicySignificantChanges: 'np',
+				anySignificantChangesLpa_courtJudgementSignificantChanges: 'cj',
+				listOfDocumentsBeforeDecision: 'docs'
+			})
+		},
+		{
 			desc: 'CAS adverts case (H)',
 			input: {
 				casedata: {
@@ -1033,7 +1102,11 @@ describe('mapQuestionnaireIn', () => {
 			})
 		}
 	])('mapQuestionnaireIn: $desc', ({ input, expected }) => {
-		const result = mapQuestionnaireIn(input, designatedSites);
+		const result = mapQuestionnaireIn(
+			input,
+			designatedSites,
+			input.appeal?.appellantCase?.applicationDate || null
+		);
 		expect(result).toMatchObject(expected);
 	});
 });

--- a/appeals/api/src/server/mappers/integration/cas-advert-expedited/index.js
+++ b/appeals/api/src/server/mappers/integration/cas-advert-expedited/index.js
@@ -1,0 +1,7 @@
+import { mapAppellantCase } from './map-appellant-case.js';
+import { mapLpaQuestionnaire } from './map-lpa-questionnaire.js';
+
+export const integrationCasAdvertExpeditedMappers = {
+	appellantCase: mapAppellantCase,
+	lpaQuestionnaire: mapLpaQuestionnaire
+};

--- a/appeals/api/src/server/mappers/integration/cas-advert-expedited/map-appellant-case.js
+++ b/appeals/api/src/server/mappers/integration/cas-advert-expedited/map-appellant-case.js
@@ -1,0 +1,25 @@
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('@planning-inspectorate/data-model').Schemas.AppealS78Case} AppealS78Case */
+/** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
+
+import { mapAppellantCaseSharedFields } from '#mappers/integration/shared/s20s78/map-appellant-case.js';
+
+/**
+ *
+ * @param {MappingRequest} data
+ */
+export const mapAppellantCase = (data) => {
+	const { appeal } = data;
+
+	const casedata = appeal.appellantCase;
+
+	return {
+		...mapAppellantCaseSharedFields(data),
+		advertDetails: casedata?.appellantCaseAdvertDetails?.map((advert) => ({
+			advertType: null,
+			isAdvertInPosition: advert.advertInPosition ?? null,
+			isSiteOnHighwayLand: advert.highwayLand ?? null
+		})),
+		hasLandownersPermission: casedata?.landownerPermission ?? null
+	};
+};

--- a/appeals/api/src/server/mappers/integration/cas-advert-expedited/map-lpa-questionnaire.js
+++ b/appeals/api/src/server/mappers/integration/cas-advert-expedited/map-lpa-questionnaire.js
@@ -1,0 +1,63 @@
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('@planning-inspectorate/data-model').Schemas.AppealHASCase} AppealHASCase */
+/** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
+
+/**
+ *
+ * @param {MappingRequest} data
+ * @returns {AppealHASCase}
+ */
+export const mapLpaQuestionnaire = (data) => {
+	const { appeal } = data;
+
+	const casedata = appeal.lpaQuestionnaire;
+
+	const designatedSitesNames = [
+		...(casedata?.designatedSiteNames ?? []).map((item) => item.designatedSite.key),
+		...(casedata?.designatedSiteNameCustom ? [casedata?.designatedSiteNameCustom] : [])
+	];
+	const significantChanges =
+		/** @type {import('@planning-inspectorate/data-model').Schemas.AppealS78Case['significantChangesAffectingApplicationLpa']} */ (
+			casedata?.anySignificantChangesLpa === 'Yes'
+				? [
+						{
+							value: 'adopted-a-new-local-plan',
+							comment: casedata?.anySignificantChangesLpa_localPlanSignificantChanges ?? null
+						},
+						{
+							value: 'national-policy-change',
+							comment: casedata?.anySignificantChangesLpa_nationalPolicySignificantChanges ?? null
+						},
+						{
+							value: 'court-judgement',
+							comment: casedata?.anySignificantChangesLpa_courtJudgementSignificantChanges ?? null
+						},
+						{
+							value: 'other',
+							comment: casedata?.anySignificantChangesLpa_otherSignificantChanges ?? null
+						}
+					].filter((c) => c.comment !== null)
+				: []
+		);
+	return {
+		affectsScheduledMonument: casedata?.affectsScheduledMonument ?? null,
+		hasProtectedSpecies: casedata?.hasProtectedSpecies ?? null,
+		isAonbNationalLandscape: casedata?.isAonbNationalLandscape ?? null,
+		hasStatutoryConsultees: casedata?.hasStatutoryConsultees ?? null,
+		consultedBodiesDetails: casedata?.consultedBodiesDetails ?? null,
+		hasEmergingPlan: casedata?.hasEmergingPlan ?? null,
+		// @ts-ignore
+		lpaProcedurePreference: casedata?.lpaProcedurePreference ?? null,
+		lpaProcedurePreferenceDetails: casedata?.lpaProcedurePreferenceDetails ?? null,
+		lpaProcedurePreferenceDuration: casedata?.lpaProcedurePreferenceDuration ?? null,
+		designatedSitesNames,
+		siteWithinSSSI: casedata?.siteWithinSSSI ?? null,
+		isSiteInAreaOfSpecialControlAdverts: casedata?.isSiteInAreaOfSpecialControlAdverts ?? null,
+		wasApplicationRefusedDueToHighwayOrTraffic:
+			casedata?.wasApplicationRefusedDueToHighwayOrTraffic ?? null,
+		didAppellantSubmitCompletePhotosAndPlans:
+			casedata?.didAppellantSubmitCompletePhotosAndPlans ?? null,
+		listOfDocumentsBeforeDecision: casedata?.listOfDocumentsBeforeDecision ?? null,
+		anySignificantChangesAffectingApplicationLpa: significantChanges
+	};
+};

--- a/appeals/api/src/server/mappers/integration/commands/index.js
+++ b/appeals/api/src/server/mappers/integration/commands/index.js
@@ -119,7 +119,11 @@ const mapAppealSubmission = (data) => {
 const mapQuestionnaireSubmission = (data, appeal, designatedSites) => {
 	const { casedata, documents } = data;
 	const questionnaireInput = {
-		...mapQuestionnaireIn({ casedata }, designatedSites),
+		...mapQuestionnaireIn(
+			{ casedata },
+			designatedSites,
+			appeal?.appellantCase?.applicationDate || null
+		),
 		neighbouringSites: {
 			create: casedata.neighbouringSiteAddresses?.map((site) => {
 				return {

--- a/appeals/api/src/server/mappers/integration/commands/questionnaire.mapper.js
+++ b/appeals/api/src/server/mappers/integration/commands/questionnaire.mapper.js
@@ -2,16 +2,20 @@
 /** @typedef {import('@pins/appeals.api').Schema.DesignatedSite} DesignatedSite */
 
 import { extractSignificantChangeValue } from '#utils/mapping/map-significant-changes.js';
-import { isEnforcementCaseType } from '@pins/appeals/utils/appeal-type-checks.js';
+import {
+	beforeExpeditedOriginalApplicationCutOff,
+	isEnforcementCaseType
+} from '@pins/appeals/utils/appeal-type-checks.js';
 import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
 
 /**
  *
  * @param {Pick<LPAQuestionnaireCommand, 'casedata'>} command
  * @param {DesignatedSite[]} designatedSites
+ * @param {Date|null} applicationDate
  * @returns {Omit<import('#db-client/models.ts').LPAQuestionnaireCreateInput, 'appeal'>}
  */
-export const mapQuestionnaireIn = (command, designatedSites) => {
+export const mapQuestionnaireIn = (command, designatedSites, applicationDate) => {
 	const casedata = command.casedata;
 
 	const isS20 = casedata.caseType === APPEAL_CASE_TYPE.Y;
@@ -57,7 +61,10 @@ export const mapQuestionnaireIn = (command, designatedSites) => {
 				...generateCommonSchemaFields(casedata),
 				...generateHasSchemaFields(casedata, listedBuildingsData),
 				//@ts-ignore
-				...generateCasAdvertSchemaFields(casedata, designatedSites)
+				...generateCasAdvertSchemaFields(casedata, designatedSites),
+				...(!beforeExpeditedOriginalApplicationCutOff(applicationDate)
+					? generateExpediteSchemaFields(casedata)
+					: [])
 			};
 		case APPEAL_CASE_TYPE.C: // ENFORCEMENT
 			return {
@@ -92,6 +99,37 @@ export const mapQuestionnaireIn = (command, designatedSites) => {
 		default:
 			throw new Error(`Unsupported case type '${casedata.caseType}'`);
 	}
+};
+
+/**
+ *
+ * @param { LPAQSubmissionCaseData } casedata
+ * @returns
+ */
+const generateExpediteSchemaFields = (casedata) => {
+	const significantChanges = /** @type {{value: string, comment: string}[] | undefined} */ (
+		casedata.significantChangesAffectingApplicationLpa
+	);
+	return {
+		anySignificantChangesLpa: (significantChanges?.length ?? 0) > 0 ? 'Yes' : 'No',
+		anySignificantChangesLpa_otherSignificantChanges: extractSignificantChangeValue(
+			significantChanges,
+			'Other'
+		),
+		anySignificantChangesLpa_localPlanSignificantChanges: extractSignificantChangeValue(
+			significantChanges,
+			'Local plan'
+		),
+		anySignificantChangesLpa_nationalPolicySignificantChanges: extractSignificantChangeValue(
+			significantChanges,
+			'National policy'
+		),
+		anySignificantChangesLpa_courtJudgementSignificantChanges: extractSignificantChangeValue(
+			significantChanges,
+			'Court judgment'
+		),
+		listOfDocumentsBeforeDecision: casedata.listOfDocumentsBeforeDecision
+	};
 };
 
 /**

--- a/appeals/api/src/server/mappers/integration/index.js
+++ b/appeals/api/src/server/mappers/integration/index.js
@@ -1,4 +1,5 @@
 import { integrationAdvertMappers } from './advert/index.js';
+import { integrationCasAdvertExpeditedMappers } from './cas-advert-expedited/index.js';
 import { integrationCasAdvertMappers } from './cas-advert/index.js';
 import { integrationEnforcementListedMappers } from './enforcement-listed/index.js';
 import { integrationEnforcementMappers } from './enforcement/index.js';
@@ -10,6 +11,7 @@ import { integrationSharedMappers } from './shared/index.js';
 export const integrationMappers = {
 	integrationAdvertMappers,
 	integrationCasAdvertMappers,
+	integrationCasAdvertExpeditedMappers,
 	integrationEnforcementMappers,
 	integrationEnforcementListedMappers,
 	integrationLDCMappers,

--- a/appeals/api/src/server/mappers/mapper-factory.js
+++ b/appeals/api/src/server/mappers/mapper-factory.js
@@ -1,7 +1,10 @@
 import { isFeatureActive } from '#utils/feature-flags.js';
 import mergeMaps from '#utils/merge-maps.js';
 import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
-import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
+import {
+	beforeExpeditedOriginalApplicationCutOff,
+	isS78ExpeditedAppealType
+} from '@pins/appeals/utils/appeal-type-checks.js';
 import {
 	APPEAL_CASE_STAGE,
 	APPEAL_CASE_TYPE,
@@ -79,8 +82,13 @@ function createDataMap(mappingRequest) {
 			}
 		}
 		case APPEAL_CASE_TYPE.ZA: {
-			const casAdvert = createMap(apiMappers.apiCasAdvertMappers, mappingRequest);
-			return mergeMaps(caseData, casAdvert);
+			if (!beforeExpeditedOriginalApplicationCutOff(appeal.appellantCase?.applicationDate)) {
+				const casAdvert = createMap(apiMappers.apiCasAdvertExpeditedMappers, mappingRequest);
+				return mergeMaps(caseData, casAdvert);
+			} else {
+				const casAdvert = createMap(apiMappers.apiCasAdvertMappers, mappingRequest);
+				return mergeMaps(caseData, casAdvert);
+			}
 		}
 		case APPEAL_CASE_TYPE.H: {
 			const advert = createMap(apiMappers.apiAdvertMappers, mappingRequest);
@@ -130,8 +138,16 @@ function createIntegrationMap(mappingRequest) {
 			return mergeMaps(caseData, s20);
 		}
 		case APPEAL_CASE_TYPE.ZA: {
-			const casAdvert = createMap(integrationMappers.integrationCasAdvertMappers, mappingRequest);
-			return mergeMaps(caseData, casAdvert);
+			if (!beforeExpeditedOriginalApplicationCutOff(appeal.appellantCase?.applicationDate)) {
+				const casAdvert = createMap(integrationMappers.integrationCasAdvertMappers, mappingRequest);
+				return mergeMaps(caseData, casAdvert);
+			} else {
+				const casAdvert = createMap(
+					integrationMappers.integrationCasAdvertExpeditedMappers,
+					mappingRequest
+				);
+				return mergeMaps(caseData, casAdvert);
+			}
 		}
 		case APPEAL_CASE_TYPE.H: {
 			const advert = createMap(integrationMappers.integrationAdvertMappers, mappingRequest);

--- a/appeals/api/src/server/tests/appeals/advert-expedite.js
+++ b/appeals/api/src/server/tests/appeals/advert-expedite.js
@@ -1,0 +1,625 @@
+import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+
+export default {
+	id: 2,
+	reference: '6000002',
+	submissionId: null,
+	appealTypeId: 2,
+	procedureTypeId: 3,
+	addressId: 1,
+	lpaId: 1,
+	applicationReference: '38699/APP/0/694045',
+	caseCreatedDate: new Date('2026-11-27T15:08:53.894Z'),
+	caseUpdatedDate: new Date('2026-11-27T15:08:53.894Z'),
+	caseValidDate: new Date('2026-05-27T14:08:50.414Z'),
+	caseExtensionDate: null,
+	caseStartedDate: new Date('2026-10-16T14:08:50.414Z'),
+	casePublishedDate: null,
+	caseCompletedDate: null,
+	withdrawalRequestDate: null,
+	caseResubmittedTypeId: null,
+	caseTransferredId: null,
+	allocationId: null,
+	appellantId: 2,
+	agentId: null,
+	caseOfficerUserId: 1,
+	inspectorUserId: null,
+	address: {
+		id: 1,
+		addressLine1: '19 Beauchamp Road',
+		addressLine2: null,
+		postcode: 'BS7 8LQ',
+		addressCounty: null,
+		addressTown: 'Bristol',
+		addressCountry: null
+	},
+	procedureType: {
+		id: 3,
+		name: 'Written',
+		key: 'written'
+	},
+	parentAppeals: [],
+	childAppeals: [],
+	neighbouringSites: [],
+	allocation: null,
+	specialisms: [],
+	appellantCase: {
+		id: 2,
+		appealId: 2,
+		appellantCaseValidationOutcomeId: 1,
+		applicationDate: new Date('2026-10-16T14:08:50.409Z'),
+		applicationDecision: 'refused',
+		applicationDecisionDate: new Date('2026-10-27T15:08:50.409Z'),
+		caseSubmittedDate: new Date('2026-11-27T15:08:53.894Z'),
+		caseSubmissionDueDate: null,
+		siteAccessDetails: null,
+		siteSafetyDetails: null,
+		siteAreaSquareMetres: 120,
+		floorSpaceSquareMetres: 340,
+		ownsAllLand: true,
+		ownsSomeLand: false,
+		knowsOtherOwnersId: 1,
+		knowsAllOwnersId: null,
+		hasAdvertisedAppeal: true,
+		appellantCostsAppliedFor: null,
+		originalDevelopmentDescription: 'lorem ipsum',
+		changedDevelopmentDescription: false,
+		ownersInformed: null,
+		enforcementNotice: null,
+		isGreenBelt: true,
+		agriculturalHolding: false,
+		tenantAgriculturalHolding: false,
+		otherTenantsAgriculturalHolding: false,
+		informedTenantsAgriculturalHolding: true,
+		appellantProcedurePreference: 'written',
+		appellantProcedurePreferenceDetails: null,
+		appellantProcedurePreferenceDuration: 1,
+		appellantProcedurePreferenceWitnessCount: 0,
+		planningObligation: false,
+		statusPlanningObligation: null,
+		siteViewableFromRoad: null,
+		caseworkReason: null,
+		developmentType: null,
+		jurisdiction: null,
+		numberOfResidencesNetChange: null,
+		siteGridReferenceEasting: null,
+		siteGridReferenceNorthing: null,
+		appellantCaseIncompleteReasonsSelected: [],
+		appellantCaseInvalidReasonsSelected: [],
+		appellantCaseValidationOutcome: {
+			id: 1,
+			name: 'Valid'
+		},
+		knowsOtherOwners: {
+			id: 1,
+			key: 'some',
+			name: 'Some'
+		},
+		knowsAllOwners: null,
+		reasonForAppealAppellant: null,
+		anySignificantChanges: true,
+		anySignificantChanges_otherSignificantChanges: 'testing1',
+		anySignificantChanges_localPlanSignificantChanges: 'testing2',
+		anySignificantChanges_nationalPolicySignificantChanges: 'testing3',
+		anySignificantChanges_courtJudgementSignificantChanges: 'testing4',
+		screeningOpinionIndicatesEiaRequired: null,
+		ownershipCertificate: null
+	},
+	appellant: {
+		id: 2,
+		organisationName: 'Eva Sharma Ltd',
+		salutation: null,
+		firstName: 'Eva',
+		middleName: null,
+		lastName: 'Sharma',
+		email: 'test9@example.com',
+		website: null,
+		phoneNumber: null,
+		addressId: null
+	},
+	assignedTeam: {
+		id: 1,
+		email: 'temp@email.com',
+		name: 'temp'
+	},
+	agent: null,
+	lpa: {
+		id: 2,
+		name: 'Dorset Council',
+		lpaCode: 'DORS',
+		email: 'dors@lpa-email.gov.uk'
+	},
+	appealStatus: [
+		{
+			id: 1,
+			status: 'statements',
+			createdAt: new Date('2024-05-27T14:08:50.414Z'),
+			valid: true,
+			appealId: 2,
+			subStateMachineName: null,
+			compoundStateName: null
+		}
+	],
+	stateList: [
+		{
+			completed: true,
+			key: 'assign_case_officer'
+		},
+		{
+			completed: true,
+			key: 'validation'
+		},
+		{
+			completed: true,
+			key: 'ready_to_start'
+		},
+		{
+			completed: false,
+			key: 'lpa_questionnaire'
+		},
+		{
+			completed: false,
+			key: 'statements'
+		},
+		{
+			completed: false,
+			key: 'final_comments'
+		},
+		{
+			completed: false,
+			key: 'event'
+		},
+		{
+			completed: false,
+			key: 'awaiting_event'
+		},
+		{
+			completed: false,
+			key: 'issue_determination'
+		},
+		{
+			completed: false,
+			key: 'awaiting_transfer'
+		},
+		{
+			completed: false,
+			key: 'invalid'
+		},
+		{
+			completed: false,
+			key: 'transferred'
+		},
+		{
+			completed: false,
+			key: 'closed'
+		},
+		{
+			completed: false,
+			key: 'withdrawn'
+		},
+		{
+			completed: false,
+			key: 'complete'
+		}
+	],
+	appealTimetable: {
+		id: 2,
+		appealId: 2,
+		caseResubmissionDueDate: null,
+		lpaQuestionnaireDueDate: new Date('2026-10-23T22:59:00.000Z'),
+		ipCommentsDueDate: new Date('2026-11-20T23:59:00.000Z'),
+		lpaStatementDueDate: new Date('2026-11-20T23:59:00.000Z'),
+		finalCommentsDueDate: new Date('2026-12-04T23:59:00.000Z'),
+		s106ObligationDueDate: new Date('2026-12-04T23:59:00.000Z'),
+		statementOfCommonGroundDueDate: new Date('2026-12-04T23:59:00.000Z'),
+		planningObligationDueDate: new Date('2026-12-04T23:59:00.000Z'),
+		issueDeterminationDate: null,
+		proofOfEvidenceAndWitnessesDueDate: new Date('2026-12-04T23:59:00.000Z'),
+		caseManagementConferenceDueDate: new Date('2026-12-04T23:59:00.000Z')
+	},
+	appealType: {
+		id: 2,
+		type: 'Planning appeal',
+		key: APPEAL_CASE_TYPE.W,
+		processCode: null,
+		enabled: false
+	},
+	caseOfficer: {
+		id: 1,
+		azureAdUserId: '00000000-0000-0000-0000-000000000000'
+	},
+	inspector: null,
+	inspectorDecision: null,
+	lpaQuestionnaire: {
+		id: 2,
+		appealId: 2,
+		lpaQuestionnaireValidationOutcomeId: null,
+		lpaqCreatedDate: new Date('2026-05-08T23:00:00.000Z'),
+		lpaQuestionnaireSubmittedDate: new Date('2026-05-08T23:00:00.000Z'),
+		lpaStatement: null,
+		newConditionDetails: null,
+		siteAccessDetails: 'There is a tall hedge around the site which obstructs the view of the site',
+		siteSafetyDetails: 'There may be no mobile reception at the site',
+		isCorrectAppealType: true,
+		inConservationArea: true,
+		lpaCostsAppliedFor: false,
+		isGreenBelt: false,
+		affectsScheduledMonument: null,
+		hasProtectedSpecies: null,
+		isAonbNationalLandscape: null,
+		designatedSitesNames: null,
+		isGypsyOrTravellerSite: null,
+		isPublicRightOfWay: null,
+		eiaEnvironmentalImpactSchedule: 'schedule-1',
+		eiaDevelopmentDescription: 'mineral-industry',
+		eiaSensitiveAreaDetails: null,
+		eiaColumnTwoThreshold: true,
+		eiaScreeningOpinion: null,
+		eiaRequiresEnvironmentalStatement: true,
+		eiaCompletedEnvironmentalStatement: null,
+		consultedBodiesDetails: null,
+		hasStatutoryConsultees: null,
+		hasInfrastructureLevy: true,
+		isInfrastructureLevyFormallyAdopted: false,
+		infrastructureLevyAdoptedDate: null,
+		infrastructureLevyExpectedDate: null,
+		lpaProcedurePreference: 'inquiry',
+		lpaProcedurePreferenceDetails: 'Need for a detailed examination',
+		lpaProcedurePreferenceDuration: null,
+		lpaFinalCommentDetails: null,
+		lpaAddedWitnesses: null,
+		siteWithinSSSI: null,
+		reasonForNeighbourVisits: null,
+		importantInformation: null,
+		redeterminedIndicator: null,
+		dateCostsReportDespatched: null,
+		dateNotRecoveredOrDerecovered: null,
+		dateRecovered: null,
+		originalCaseDecisionDate: null,
+		targetDate: null,
+		siteNoticesSentDate: null,
+		listedBuildingDetails: [
+			{
+				id: 1,
+				lpaQuestionnaireId: 2,
+				listEntry: '1264111',
+				affectsListedBuilding: false
+			},
+			{
+				id: 2,
+				lpaQuestionnaireId: 2,
+				listEntry: '1356956',
+				affectsListedBuilding: false
+			},
+			{
+				id: 3,
+				lpaQuestionnaireId: 3,
+				listEntry: '1202152',
+				affectsListedBuilding: true
+			},
+			{
+				id: 4,
+				lpaQuestionnaireId: 4,
+				listEntry: '1356318',
+				affectsListedBuilding: true
+			}
+		],
+		lpaNotificationMethods: [
+			{
+				notificationMethodId: 1,
+				lpaQuestionnaireId: 2,
+				lpaNotificationMethod: {
+					id: 1,
+					key: 'letter',
+					name: 'Letter/email to interested parties'
+				}
+			},
+			{
+				notificationMethodId: 2,
+				lpaQuestionnaireId: 2,
+				lpaNotificationMethod: {
+					id: 2,
+					key: 'advert',
+					name: 'A press advert'
+				}
+			}
+		],
+		lpaQuestionnaireIncompleteReasonsSelected: [],
+		lpaQuestionnaireValidationOutcome: null,
+		listOfDocumentsBeforeDecision:
+			'hoi oyf yrtd ytrtt ulliyuyg utg uyg ugyuo utyu uyg ouyg ouyg ouyg ouyg jhk bhm jvuhguyg oyg uygg ouy gouy uy uy oguy ouygo blargo',
+		anySignificantChangesLpa: true,
+		anySignificantChangesLpa_courtJudgementSignificantChanges: '100',
+		anySignificantChangesLpa_localPlanSignificantChanges: '100',
+		anySignificantChangesLpa_nationalPolicySignificantChanges: '100',
+		anySignificantChangesLpa_otherSignificantChanges: '100'
+	},
+	siteVisit: null,
+	caseNotes: [],
+	representations: [
+		{
+			id: 4474,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.585Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.585Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5975,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'back-office-appeals'
+		},
+		{
+			id: 4475,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.595Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.595Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5976,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4476,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.603Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.603Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5977,
+			representativeId: null,
+			lpaCode: null,
+			status: 'valid',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'back-office-appeals'
+		},
+		{
+			id: 4477,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.612Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.612Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5978,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4478,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.622Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.622Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5979,
+			representativeId: null,
+			lpaCode: null,
+			status: 'valid',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'back-office-appeals'
+		},
+		{
+			id: 4479,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.632Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.632Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5980,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4480,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.641Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.641Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5981,
+			representativeId: null,
+			lpaCode: null,
+			status: 'valid',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'back-office-appeals'
+		},
+		{
+			id: 4481,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.650Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.650Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5982,
+			representativeId: null,
+			lpaCode: null,
+			status: 'valid',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4482,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.660Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.660Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5983,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'back-office-appeals'
+		},
+		{
+			id: 4483,
+			appealId: 2377,
+			representationType: 'comment',
+			dateCreated: new Date('2026-11-27T15:08:55.670Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.670Z'),
+			originalRepresentation:
+				'I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.',
+			redactedRepresentation: null,
+			representedId: 5984,
+			representativeId: null,
+			lpaCode: null,
+			status: 'invalid',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4484,
+			appealId: 2377,
+			representationType: 'statement',
+			dateCreated: new Date('2026-11-27T15:08:55.688Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.688Z'),
+			originalRepresentation: 'Statement from appellant',
+			redactedRepresentation: null,
+			representedId: 5985,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4485,
+			appealId: 2377,
+			representationType: 'statement',
+			dateCreated: new Date('2026-11-27T15:08:55.697Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.697Z'),
+			originalRepresentation: 'Statement from LPA',
+			redactedRepresentation: null,
+			representedId: null,
+			representativeId: null,
+			lpaCode: 'DORS',
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4486,
+			appealId: 2377,
+			representationType: 'appellant_final_comment',
+			dateCreated: new Date('2026-11-27T15:08:55.704Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.704Z'),
+			originalRepresentation: 'Final comment from appellant',
+			redactedRepresentation: null,
+			representedId: 5875,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4487,
+			appealId: 2377,
+			representationType: 'lpa_final_comment',
+			dateCreated: new Date('2026-11-27T15:08:55.711Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.711Z'),
+			originalRepresentation: 'Final comment from LPA',
+			redactedRepresentation: null,
+			representedId: null,
+			representativeId: null,
+			lpaCode: 'DORS',
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4488,
+			appealId: 2377,
+			representationType: 'appellant_proofs_evidence',
+			dateCreated: new Date('2026-11-27T15:08:55.704Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.704Z'),
+			originalRepresentation: 'Proof of evidence from appellant',
+			redactedRepresentation: null,
+			representedId: 5875,
+			representativeId: null,
+			lpaCode: null,
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		},
+		{
+			id: 4489,
+			appealId: 2377,
+			representationType: 'lpa_proofs_evidence',
+			dateCreated: new Date('2026-11-27T15:08:55.711Z'),
+			dateLastUpdated: new Date('2026-11-27T15:08:55.711Z'),
+			originalRepresentation: 'Proof of evidence from LPA',
+			redactedRepresentation: null,
+			representedId: null,
+			representativeId: null,
+			lpaCode: 'DORS',
+			status: 'awaiting_review',
+			reviewer: null,
+			notes: null,
+			siteVisitRequested: false,
+			source: 'citizen'
+		}
+	],
+	linkedAppeals: [],
+	relatedAppeals: []
+};

--- a/appeals/api/src/server/tests/appeals/index.js
+++ b/appeals/api/src/server/tests/appeals/index.js
@@ -1,3 +1,5 @@
+import casAdvertExpedite from './advert-expedite.js';
+import advert from './advert.js';
 import enforcementListed from './enforcement-listed.js';
 import enforcement from './enforcement.js';
 import has from './has.js';
@@ -13,5 +15,7 @@ export const mocks = {
 	s20Appeal: s20,
 	enforcementAppeal: enforcement,
 	ldcAppeal: ldc,
-	enforcementListedAppeal: enforcementListed
+	enforcementListedAppeal: enforcementListed,
+	advertAppeal: advert,
+	casAdvertExpediteAppeal: casAdvertExpedite
 };

--- a/appeals/pdf-service-api/src/controllers/pdf.js
+++ b/appeals/pdf-service-api/src/controllers/pdf.js
@@ -54,6 +54,8 @@ try {
 const mapTemplateDataForView = (templateName, templateData) => {
 	switch (templateName) {
 		case 'lpa-questionnaire-pdf':
+			templateData.lpaQuestionnaireData.applicationDate =
+				templateData?.appellantCaseData?.applicationDate;
 			return mapQuestionnaireData(templateData.lpaQuestionnaireData);
 		case 'appellant-case-pdf':
 			return mapAppellantCaseData(templateData.appellantCaseData);

--- a/appeals/pdf-service-api/src/mappers/lpa-questionnaire/sections/appeal-process/row-keys.js
+++ b/appeals/pdf-service-api/src/mappers/lpa-questionnaire/sections/appeal-process/row-keys.js
@@ -1,4 +1,5 @@
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 export const rowKeys = {
 	[APPEAL_TYPE.HOUSEHOLDER]: ['otherAppeals', 'hasExtraConditions'],
 	[APPEAL_TYPE.CAS_PLANNING]: ['otherAppeals', 'hasExtraConditions'],
@@ -7,7 +8,11 @@ export const rowKeys = {
 		'lpaProcedurePreferenceDetails',
 		'lpaProcedurePreferenceDuration',
 		'otherAppeals',
-		'hasExtraConditions'
+		'hasExtraConditions',
+		{
+			key: 'anySignificantChangesLpa',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		}
 	],
 	[APPEAL_TYPE.ADVERTISEMENT]: [
 		'lpaProcedurePreference',

--- a/appeals/pdf-service-api/src/mappers/lpa-questionnaire/sections/original-evidence/row-keys.js
+++ b/appeals/pdf-service-api/src/mappers/lpa-questionnaire/sections/original-evidence/row-keys.js
@@ -1,4 +1,5 @@
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 
 export const rowKeys = {
 	[APPEAL_TYPE.S78_EXPEDITED]: [
@@ -27,5 +28,35 @@ export const rowKeys = {
 		'didSubmitAdditionalDocumentsLPA',
 		'additionalDocumentsLPA',
 		'listOfDocumentsBeforeDecision'
+	],
+	[APPEAL_TYPE.CAS_ADVERTISEMENT]: [
+		{
+			key: 'didSubmitDesignAccessStatementLPA',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		},
+		{
+			key: 'designAccessStatementLPA',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		},
+		{
+			key: 'didSubmitPlansDrawingsLPA',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		},
+		{
+			key: 'plansDrawingsLPA',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		},
+		{
+			key: 'didSubmitAdditionalDocumentsLPA',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		},
+		{
+			key: 'additionalDocumentsLPA',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		},
+		{
+			key: 'listOfDocumentsBeforeDecision',
+			condition: (data) => !beforeExpeditedOriginalApplicationCutOff(data?.applicationDate)
+		}
 	]
 };

--- a/appeals/web/src/server/app/components/download-all-generated-pdfs.component.js
+++ b/appeals/web/src/server/app/components/download-all-generated-pdfs.component.js
@@ -105,9 +105,14 @@ async function getTasks(currentAppealData, apiClient, representationType) {
 			templateName: 'lpa-questionnaire-pdf',
 			async fetchData() {
 				logger.debug('[DownloadAll] Fetching data for: LPA Questionnaire');
+				const appellantCaseId = currentAppealData.appellantCaseId;
 				const lpaQuestionnaireId = currentAppealData.lpaQuestionnaireId;
 				if (!lpaQuestionnaireId) return null;
-
+				const rawAppellantData = await getAppellantCaseFromAppealId(
+					apiClient,
+					appealId,
+					appellantCaseId
+				);
 				const rawData = await getLpaQuestionnaireFromId(
 					apiClient,
 					appealId,
@@ -121,7 +126,12 @@ async function getTasks(currentAppealData, apiClient, representationType) {
 					);
 				}
 
-				return rawData ? { lpaQuestionnaireData: { ...currentAppealData, ...rawData } } : null;
+				return rawData
+					? {
+							appellantCaseData: { ...rawAppellantData },
+							lpaQuestionnaireData: { ...currentAppealData, ...rawData }
+						}
+					: null;
 			}
 		},
 		{

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -1154,6 +1154,472 @@ exports[`LPA Questionnaire review GET / should render the Cas Advert LPA Questio
 </main>"
 `;
 
+exports[`LPA Questionnaire review GET / should render the Cas Advert expedite LPA Questionnaire page with the expected content 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">LPA questionnaire</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F4%2Flpa-questionnaire%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 1. Constraints, designations and other issues</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="constraints-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is CAS advert the correct type of appeal?</dt>
+                            <dd                             class="govuk-summary-list__value">Yes</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/is-correct-appeal-type/change"
+                                    data-cy="change-is-correct-appeal-type">Change<span class="govuk-visually-hidden"> Is CAS advert the correct type of appeal? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Does the development affect the setting of listed buildings?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list">
+                                    <li><a href='https://historicengland.org.uk/listing/the-list/list-entry/123456'
+                                        class="govuk-link" aria-label="Listed building number 1 2 3 4 5 6">123456</a>
+                                    </li>
+                                    <li><a href='https://historicengland.org.uk/listing/the-list/list-entry/123457'
+                                        class="govuk-link" aria-label="Listed building number 1 2 3 4 5 7">123457</a>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/affected-listed-buildings/manage"
+                                            lpaQuestionnaireData-cy="manage-affected-listed-building">Change<span class="govuk-visually-hidden"> affected listed building (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/affected-listed-buildings/add"
+                                            lpaQuestionnaireData-cy="add-affected-listed-building">Add<span class="govuk-visually-hidden"> affected listed building (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Would the development affect a scheduled monument?</dt>
+                            <dd                             class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/affects-scheduled-monument/change"
+                                    data-cy="change-affects-scheduled-monument">Change<span class="govuk-visually-hidden"> Would the development affect a scheduled monument? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
+                                            data-cy="manage-conservation-area-map-and-guidance">Manage<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
+                                            data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Would the development affect a protected species?</dt>
+                            <dd                             class="govuk-summary-list__value">Yes</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/has-protected-species/change"
+                                    data-cy="change-has-protected-species">Change<span class="govuk-visually-hidden"> Would the development affect a protected species? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the site in an area of special control of advertisements?</dt>
+                            <dd                             class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/area-special-control/change"
+                                    data-cy="change-area-special-control">Change<span class="govuk-visually-hidden"> Is the site in an area of special control of advertisements? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Green belt</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/green-belt/change/lpa"
+                                data-cy="change-site-within-green-belt">Change<span class="govuk-visually-hidden"> Green belt (1. Constraints, designations and other issues)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the site in a national landscape?</dt>
+                            <dd                             class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/is-aonb-national-landscape/change"
+                                    data-cy="change-is-aonb-national-landscape">Change<span class="govuk-visually-hidden"> Is the site in a national landscape? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the development in, near or likely to affect any designated sites?</dt>
+                            <dd                             class="govuk-summary-list__value">No
+                                <ul class="pins-summary-list-sublist"></ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/in-near-or-likely-to-affect-designated-sites/change"
+                                    data-cy="change-in-near-or-likely-to-affect-designated-sites">Change<span class="govuk-visually-hidden"> Is the development in, near or likely to affect any designated sites? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 2. Notifying relevant parties</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> List of neighbours&#39; addresses that you notified about the application</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
+                                            data-cy="manage-notifying-parties">Manage<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
+                                            data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> List of neighbours&#39; addresses that you notified about the application (2. Notifying relevant parties)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about this application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list__value">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/notification-methods/change"
+                                    data-cy="change-notification-methods">Change<span class="govuk-visually-hidden"> How did you notify relevant parties about this application? (2. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-site-notice">Add<span class="govuk-visually-hidden"> Site notice (2. Notifying relevant parties)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Letter or email notification</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-letter-or-email-notification">Add<span class="govuk-visually-hidden"> Letter or email notification (2. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Press advertisement</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter and the list of people that you notified</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter and the list of people that you notified (2. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 3. Consultation responses and representations</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
+                                            data-cy="manage-representations-from-other-parties">Manage<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
+                                            data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-eia-consulted-bodies-details"><dt class="govuk-summary-list__key"> Did you consult all the relevant statutory consultees about the development?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>Yes</span>
+                                <br><span>Some other people need to be consulted</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/environmental-impact-assessment/consulted-bodies-details/change"
+                                    data-cy="change-eia-consulted-bodies-details">Change<span class="govuk-visually-hidden"> Did you consult all the relevant statutory consultees about the development? (3. Consultation responses and representations)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 4. Planning officer’s report and supplementary documents</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <div class="full-width">
+                                    <ul class="govuk-list pins-file-list">
+                                        <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                        </li>
+                                    </ul>
+                                </div>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
+                                            data-cy="manage-officers-report">Manage<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Did you refuse the application because of highway or traffic public safety?</dt>
+                            <dd                             class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/public-safety/change"
+                                    data-cy="change-public-safety">Change<span class="govuk-visually-hidden"> Did you refuse the application because of highway or traffic public safety? (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Did the appellant submit complete and accurate photographs and plans?</dt>
+                            <dd                             class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/accurate-photographs-plans/change"
+                                    data-cy="change-accurate-photographs-plans">Change<span class="govuk-visually-hidden"> Did the appellant submit complete and accurate photographs and plans? (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Relevant policies from statutory development plan</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-development-plan-policies">Add<span class="govuk-visually-hidden"> Relevant policies from statutory development plan (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supplementary planning documents</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-supplementary-planning">Add<span class="govuk-visually-hidden"> Supplementary planning documents (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Emerging plan relevant to appeal</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-emerging-plan">Add<span class="govuk-visually-hidden"> Emerging plan relevant to appeal (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Other relevant policies</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-other-relevant-policies">Add<span class="govuk-visually-hidden"> Other relevant policies (4. Planning officer’s report and supplementary documents)</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 5. Site access</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Will the inspector need access to the appellant’s land or property?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/inspector-access/change/lpa"
+                                    data-cy="change-does-site-require-inspector-access">Change<span class="govuk-visually-hidden"> Will the inspector need access to the appellant’s land or property? (5. Site access)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-neighbouring-site-access"><dt class="govuk-summary-list__key"> Will the inspector need to enter a neighbour’s land or property?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/neighbouring-site-access/change"
+                                    data-cy="change-neighbouring-site-access">Change<span class="govuk-visually-hidden"> Will the inspector need to enter a neighbour’s land or property? (5. Site access)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                            <dd                             class="govuk-summary-list__value">1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/neighbouring-sites/manage">Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A) (5. Site access)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa">Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA) (5. Site access)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-health-and-safety"><dt class="govuk-summary-list__key"> Are there any potential safety risks?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/safety-risks/change/lpa"
+                                    data-cy="change-health-and-safety">Change<span class="govuk-visually-hidden"> Are there any potential safety risks? (5. Site access)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 6. Appeal process</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Which procedure do you think is most appropriate for this appeal?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/procedure-preference/change"
+                                    data-cy="change-procedure-preference">Change<span class="govuk-visually-hidden"> Which procedure do you think is most appropriate for this appeal? (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Why would you prefer this procedure?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/procedure-preference/details/change"
+                                    data-cy="change-procedure-preference-details">Change<span class="govuk-visually-hidden"> Why would you prefer this procedure? (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How many days would you expect the inquiry to last?</dt>
+                            <dd                             class="govuk-summary-list__value">Not applicable</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/procedure-preference/duration/change"
+                                    data-cy="change-procedure-preference-duration">Change<span class="govuk-visually-hidden"> How many days would you expect the inquiry to last? (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there any other ongoing appeals next to, or close to the site?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have there been any significant changes that would affect the application?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/any-significant-changes-lpa/change">Change<span class="govuk-visually-hidden"> Have there been any significant changes that would affect the application? (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there any new conditions?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>Yes</span>
+                                <br><span>Some extra conditions</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/extra-conditions/change">Change<span class="govuk-visually-hidden"> Are there any new conditions? (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 8. Original Evidence</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Design and access statement</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-design-access-statement-lpa">Add<span class="govuk-visually-hidden"> Design and access statement (8. Original Evidence)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Plans and drawings</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-plans-drawings-lpa">Add<span class="govuk-visually-hidden"> Plans and drawings (8. Original Evidence)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Any other documents submitted with the application</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-additional-documents-lpa">Add<span class="govuk-visually-hidden"> Any other documents submitted with the application (8. Original Evidence)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What documents and plans did you use to make your decision?</dt>
+                            <dd                             class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/4/lpa-questionnaire/1/list-of-documents-before-decision/change"
+                                    data-cy="change-list-of-documents-before-decision">Change<span class="govuk-visually-hidden"> What documents and plans did you use to make your decision? (8. Original Evidence)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> Additional documents</h2>
+                    <ul class="govuk-summary-card__actions">
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/21/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        </li>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/21">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list pins-summary-list--fullwidth-value" id="additional-documents">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <div class="full-width">
+                                    <ul class="govuk-list govuk-list--bullet pins-file-list">
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                        </li>
+                                        <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                        </li>
+                                    </ul>
+                                </div>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`LPA Questionnaire review GET / should render the Householder LPA Questionnaire page with the expected content 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -86,6 +86,7 @@ const appealDataCasAdvert = {
 	...lpaqAppealData,
 	appealType: 'CAS advert'
 };
+
 const appealDataAdvert = {
 	...lpaqAppealData,
 	appealType: 'Advertisement'
@@ -1400,6 +1401,129 @@ describe('LPA Questionnaire review', () => {
 				'Are there any other ongoing appeals next to, or close to the site?</dt>'
 			);
 			expect(element.innerHTML).toContain('Are there any new conditions?</dt>');
+
+			expect(element.innerHTML).toContain('Additional documents</h2>');
+		}, 10000);
+
+		it('should render the Cas Advert expedite LPA Questionnaire page with the expected content', async () => {
+			nock('http://test/')
+				.get('/appeals/4?include=all')
+				.reply(200, {
+					...appealDataCasAdvert,
+					appealId: 4
+				});
+
+			const expeditedAppellantCaseData = {
+				applicationDate: '2026-04-02T00:00:00.000Z'
+			};
+
+			nock('http://test/')
+				.get('/appeals/4/appellant-cases/0')
+				.reply(200, expeditedAppellantCaseData);
+
+			nock('http://test/')
+				.get('/appeals/4/lpa-questionnaires/1')
+				.reply(200, {
+					...lpaQuestionnaireDataNotValidated,
+					lpaQuestionnaireId: 1
+				});
+
+			const response = await request.get('/appeals-service/appeal-details/4/lpa-questionnaire/1');
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('LPA questionnaire</h1>');
+
+			expect(element.innerHTML).toContain('1. Constraints, designations and other issues</h2>');
+			expect(element.innerHTML).toContain('Is CAS advert the correct type of appeal?</dt>');
+			expect(element.innerHTML).toContain(
+				'Does the development affect the setting of listed buildings?</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'Would the development affect a scheduled monument?</dt>'
+			);
+			expect(element.innerHTML).toContain('Conservation area map and guidance</dt>');
+			expect(element.innerHTML).toContain('Would the development affect a protected species?</dt>');
+			expect(element.innerHTML).toContain(
+				'Is the site in an area of special control of advertisements?</dt>'
+			);
+			expect(element.innerHTML).toContain('Green belt</dt>');
+			expect(element.innerHTML).toContain('Is the site in a national landscape?</dt>');
+			expect(element.innerHTML).toContain(
+				'Is the development in, near or likely to affect any designated sites?</dt>'
+			);
+
+			expect(element.innerHTML).toContain('2. Notifying relevant parties</h2>');
+			expect(element.innerHTML).toContain(
+				'List of neighbours&#39; addresses that you notified about the application</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'How did you notify relevant parties about this application?</dt>'
+			);
+			expect(element.innerHTML).toContain('Site notice</dt>');
+			expect(element.innerHTML).toContain('Letter or email notification</dt>');
+			expect(element.innerHTML).toContain('Press advertisement</dt>');
+			expect(element.innerHTML).toContain(
+				'Appeal notification letter and the list of people that you notified</dt>'
+			);
+
+			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
+			expect(element.innerHTML).toContain(
+				'Representations from members of the public or other parties</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'Did you consult all the relevant statutory consultees about the development?</dt>'
+			);
+
+			expect(element.innerHTML).toContain(
+				'4. Planning officer’s report and supplementary documents</h2>'
+			);
+			expect(element.innerHTML).toContain('Planning officer’s report</dt>');
+			expect(element.innerHTML).toContain(
+				'Did you refuse the application because of highway or traffic public safety?</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'Did the appellant submit complete and accurate photographs and plans?</dt>'
+			);
+			expect(element.innerHTML).toContain('Relevant policies from statutory development plan</dt>');
+			expect(element.innerHTML).toContain('Supplementary planning documents</dt>');
+			expect(element.innerHTML).toContain('Emerging plan relevant to appeal</dt>');
+			expect(element.innerHTML).toContain('Other relevant policies</dt>');
+
+			expect(element.innerHTML).toContain('5. Site access</h2>');
+			expect(element.innerHTML).toContain(
+				'Will the inspector need access to the appellant’s land or property?</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'Will the inspector need to enter a neighbour’s land or property?</dt>'
+			);
+			expect(element.innerHTML).toContain('Address of the neighbour’s land or property</dt>');
+			expect(element.innerHTML).toContain('Are there any potential safety risks?</dt>');
+
+			expect(element.innerHTML).toContain('6. Appeal process</h2>');
+			expect(element.innerHTML).toContain(
+				'Which procedure do you think is most appropriate for this appeal?</dt>'
+			);
+			expect(element.innerHTML).toContain('Why would you prefer this procedure?</dt>');
+			expect(element.innerHTML).toContain(
+				'How many days would you expect the inquiry to last?</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'Are there any other ongoing appeals next to, or close to the site?</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'Have there been any significant changes that would affect the application?'
+			);
+			expect(element.innerHTML).toContain('Are there any new conditions?</dt>');
+			expect(element.innerHTML).toContain('Original Evidence</h2>');
+			expect(element.innerHTML).toContain('Design and access statement</dt>');
+			expect(element.innerHTML).toContain('Plans and drawings</dt>');
+			expect(element.innerHTML).toContain(
+				'Any other documents submitted with the application</dt>'
+			);
+			expect(element.innerHTML).toContain(
+				'What documents and plans did you use to make your decision?</dt>'
+			);
 
 			expect(element.innerHTML).toContain('Additional documents</h2>');
 		}, 10000);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/cas-advert.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/cas-advert.js
@@ -1,11 +1,16 @@
 import { isDefined } from '#lib/ts-utilities.js';
+import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
 
 /**
  *
  * @param {{lpaq: MappedInstructions}} mappedLPAQData
+ * @param {String|undefined|null} submissionDate
  * @returns {PageComponent[]}
  */
-export const generateCasAdvertLpaQuestionnaireComponents = (mappedLPAQData) => {
+export const generateCasAdvertLpaQuestionnaireComponents = (
+	mappedLPAQData,
+	submissionDate = ''
+) => {
 	/** @type {PageComponent[]} */
 	const pageComponents = [];
 
@@ -148,10 +153,37 @@ export const generateCasAdvertLpaQuestionnaireComponents = (mappedLPAQData) => {
 				mappedLPAQData.lpaq?.procedurePreferenceDetails?.display.summaryListItem,
 				mappedLPAQData.lpaq?.procedurePreferenceDuration?.display.summaryListItem,
 				mappedLPAQData.lpaq?.otherAppeals?.display.summaryListItem,
+				!beforeExpeditedOriginalApplicationCutOff(submissionDate) && submissionDate
+					? mappedLPAQData.lpaq?.anySignificantChangesLpa?.display.summaryListItem
+					: undefined,
 				mappedLPAQData.lpaq?.extraConditions?.display.summaryListItem
 			].filter(isDefined)
 		}
 	});
+
+	if (!beforeExpeditedOriginalApplicationCutOff(submissionDate) && submissionDate) {
+		pageComponents.push({
+			/** @type {'summary-list'} */
+			type: 'summary-list',
+			wrapperHtml: {
+				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+				closing: '</div></div>'
+			},
+			parameters: {
+				card: {
+					title: {
+						text: '8. Original Evidence'
+					}
+				},
+				rows: [
+					mappedLPAQData.lpaq?.designAccessStatementLpa?.display.summaryListItem,
+					mappedLPAQData.lpaq?.plansDrawingsLpa?.display.summaryListItem,
+					mappedLPAQData.lpaq?.additionalDocumentsLpa?.display.summaryListItem,
+					mappedLPAQData.lpaq?.listOfDocumentsBeforeDecision?.display.summaryListItem
+				].filter(isDefined)
+			}
+		});
+	}
 
 	return pageComponents;
 };

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/index.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/generate-page-components/index.js
@@ -19,16 +19,17 @@ import { generateS78LpaQuestionnaireComponents } from './s78.js';
  *
  * @param {Appeal} appealDetails
  * @param {{lpaq: MappedInstructions}} mappedLPAQData
+ * @param {String|undefined|null} submittedDate
  * @returns {PageComponent[]}
  */
-export function generateCaseTypeSpecificComponents(appealDetails, mappedLPAQData) {
+export function generateCaseTypeSpecificComponents(appealDetails, mappedLPAQData, submittedDate) {
 	switch (appealDetails.appealType) {
 		case APPEAL_TYPE.HOUSEHOLDER:
 			return generateHASLpaQuestionnaireComponents(mappedLPAQData);
 		case APPEAL_TYPE.CAS_PLANNING:
 			return generateCasPlanningLpaQuestionnaireComponents(mappedLPAQData);
 		case APPEAL_TYPE.CAS_ADVERTISEMENT:
-			return generateCasAdvertLpaQuestionnaireComponents(mappedLPAQData);
+			return generateCasAdvertLpaQuestionnaireComponents(mappedLPAQData, submittedDate || null);
 		case APPEAL_TYPE.ADVERTISEMENT:
 			return generateAdvertLpaQuestionnaireComponents(mappedLPAQData);
 		case APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE:

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -31,6 +31,7 @@ import {
 	renderManageFolder,
 	renderUploadDocumentsCheckAndConfirm
 } from '../../appeal-documents/appeal-documents.controller.js';
+import * as appellantCaseService from '../appellant-case/appellant-case.service.js';
 import {
 	checkAndConfirmPage,
 	environmentServiceTeamReviewCasePage,
@@ -63,17 +64,27 @@ const renderLpaQuestionnaire = async (request, response, errors = null) => {
 		currentAppeal.appealId,
 		lpaQuestionnaireId
 	);
+	const appellantCaseResponse = await appellantCaseService
+		.getAppellantCaseFromAppealId(
+			request.apiClient,
+			currentAppeal.appealId,
+			currentAppeal.appellantCaseId
+		)
+		.catch((error) => {
+			return logger.error(error);
+		});
+
 	if (!lpaQuestionnaire) {
 		return response.status(404).render('app/404.njk');
 	}
-
 	const mappedPageContent = await lpaQuestionnairePage(
 		lpaQuestionnaire,
 		currentAppeal,
 		stripQueryString(request.originalUrl),
 		session,
 		request,
-		getBackLinkUrlFromQuery(request)
+		getBackLinkUrlFromQuery(request),
+		appellantCaseResponse?.applicationDate
 	);
 
 	return response.status(200).render('patterns/display-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -48,6 +48,7 @@ import { generateCaseTypeSpecificComponents } from './generate-page-components/i
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
  * @param {import('@pins/express/types/express.js').Request} request
  * @param {string|undefined} backUrl
+ * @param {String|undefined} caseSubmissionDate
  * @returns {Promise<PageContent>}
  */
 export async function lpaQuestionnairePage(
@@ -56,7 +57,8 @@ export async function lpaQuestionnairePage(
 	currentRoute,
 	session,
 	request,
-	backUrl
+	backUrl,
+	caseSubmissionDate
 ) {
 	const mappedLpaqDetails = initialiseAndMapLPAQData(
 		lpaqDetails,
@@ -75,13 +77,13 @@ export async function lpaQuestionnairePage(
 		false,
 		true
 	);
-
 	const caseSummary = generateCaseSummary(mappedAppealDetails);
 
 	/** @type {PageComponent[]} */
 	let appealTypeSpecificPageComponents = generateCaseTypeSpecificComponents(
 		appealDetails,
-		mappedLpaqDetails
+		mappedLpaqDetails,
+		caseSubmissionDate
 	);
 
 	/**

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/cas-advert.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/cas-advert.js
@@ -1,11 +1,14 @@
 import { mapLpaNeighbouringSitesLpaqAdapter } from '../appeal/submappers/lpa-neighbouring-sites.mapper.js';
 import { mapAdditionalDocumentsContents } from './submappers/map-additional-documents-contents.js';
+import { mapAdditionalDocumentsLpa } from './submappers/map-additional-documents-lpa.js';
 import { mapAdditionalDocuments } from './submappers/map-additional-documents.js';
 import { mapAffectsListedBuildingDetails } from './submappers/map-affects-listed-building-details.js';
 import { mapAffectsScheduledMonument } from './submappers/map-affects-scheduled-monument.js';
+import { mapAnySignificantChangesLpa } from './submappers/map-any-significant-changes-lpa.js';
 import { mapAppealNotification } from './submappers/map-appeal-notification.js';
 import { mapAppellantPhotosAndPlans } from './submappers/map-appellant-photos-and-plans.js';
 import { mapConservationAreaMap } from './submappers/map-conservation-area-map.js';
+import { mapDesignAccessStatementLpa } from './submappers/map-design-access-statement-lpa.js';
 import { mapInNearOrLikelyToAffectDesignatedSites } from './submappers/map-designated-sites.js';
 import { mapDevelopmentPlanPolicies } from './submappers/map-development-plan-policies.js';
 import { mapEiaConsultedBodiesDetails } from './submappers/map-eia-consulted-bodies-details.js';
@@ -16,12 +19,14 @@ import { mapHighwayTrafficPublicSafety } from './submappers/map-highway-traffic-
 import { mapIsAonbNationalLandscape } from './submappers/map-is-aonb-national-landscape.js';
 import { mapIsCorrectAppealType } from './submappers/map-is-correct-appeal-type.js';
 import { mapLettersToNeighbours } from './submappers/map-letters-to-neighbours.js';
+import { mapListOfDocumentsBeforeDecision } from './submappers/map-list-of-documents-before-decision.js';
 import { mapLpaHealthAndSafety } from './submappers/map-lpa-health-and-safety.js';
 import { mapNotificationMethods } from './submappers/map-notification-methods.js';
 import { mapNotifyingParties } from './submappers/map-notify-parties.js';
 import { mapOfficersReport } from './submappers/map-officers-report.js';
 import { mapOtherAppeals } from './submappers/map-other-appeals.js';
 import { mapOtherRelevantPolicies } from './submappers/map-other-relevant-policies.js';
+import { mapPlansDrawingsLpa } from './submappers/map-plans-drawings-lpa.js';
 import { mapPressAdvert } from './submappers/map-press-advert.js';
 import { mapProcedurePreferenceDetails } from './submappers/map-procedure-preference-details.js';
 import { mapProcedurePreferenceDuration } from './submappers/map-procedure-preference-duration.js';
@@ -71,5 +76,10 @@ export const submaps = {
 	otherAppeals: mapOtherAppeals,
 	reviewOutcome: mapReviewOutcome,
 	additionalDocumentsContents: mapAdditionalDocumentsContents,
-	additionalDocuments: mapAdditionalDocuments
+	additionalDocuments: mapAdditionalDocuments,
+	listOfDocumentsBeforeDecision: mapListOfDocumentsBeforeDecision,
+	anySignificantChangesLpa: mapAnySignificantChangesLpa,
+	designAccessStatementLpa: mapDesignAccessStatementLpa,
+	plansDrawingsLpa: mapPlansDrawingsLpa,
+	additionalDocumentsLpa: mapAdditionalDocumentsLpa
 };


### PR DESCRIPTION
## Describe your changes

- Added AnySignificantChangesLPA question
- Added listOfDocumentsBeforeDecision question
- Added original evidence section and questions
- Updated import and broadcast mappings
- Added applicationDate under applicatantSubmission when grabbing appeal data
- Updated PDF download 
- Updated api that calls PDF download and pass apellantSubmission with LPAQ as applicationDate attribute is needed for expedite check

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8701)
