### PR TITLE
fix(api): updates to hearing updated notify template (a2-8793)

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/notify-hearing-updated.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-hearing-updated.test.js
@@ -44,10 +44,10 @@ describe('hearing-updated.md', () => {
 			'',
 			'The details of the hearing are subject to change. We will contact you by email if we make any changes.',
 			'',
-			'We expect the hearing to finish on the same day. If the hearing needs more time, you will arrange the next steps on the day.',
+			'If the hearing needs more time, you will arrange the next steps on the day.',
 			'',
 			'',
-			'The Planning Inspectorate',
+			'Planning Inspectorate',
 			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
@@ -104,7 +104,7 @@ describe('hearing-updated.md', () => {
 			'Email caseofficers@planninginspectorate.gov.uk to confirm the venue address for the hearing.',
 			'',
 			'',
-			'The Planning Inspectorate',
+			'Planning Inspectorate',
 			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
@@ -161,7 +161,7 @@ describe('hearing-updated.md', () => {
 			'We will contact you when the local planning authority confirms the venue address for the hearing.',
 			'',
 			'',
-			'The Planning Inspectorate',
+			'Planning Inspectorate',
 			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 

--- a/appeals/api/src/server/notify/templates/hearing-updated.content.md
+++ b/appeals/api/src/server/notify/templates/hearing-updated.content.md
@@ -27,8 +27,8 @@ You need to attend the hearing on {{hearing_date}}.
 
 The details of the hearing are subject to change. We will contact you by email if we make any changes.
 
-We expect the hearing to finish on the same day. If the hearing needs more time, you will arrange the next steps on the day.
+If the hearing needs more time, you will arrange the next steps on the day.
 {% endif %}
 
-The Planning Inspectorate
+Planning Inspectorate
 {{team_email_address}}


### PR DESCRIPTION

- Removed sections of string from hearing-updated.content template
- Updated tests

The third requirement of this ticket (enforcement ref number replacing application ref number) has been confirmed as working already by the ticket reporter. 

Ticket: https://pins-ds.atlassian.net/browse/A2-8793
