### PR TITLE
fix(api): allowing brackets in doc filename validation (a2-8825)

### DIFF
--- a/appeals/api/src/server/common/validators/__tests__/filename-parameter.test.js
+++ b/appeals/api/src/server/common/validators/__tests__/filename-parameter.test.js
@@ -66,6 +66,11 @@ describe('validateFileNameParameter', () => {
 			const result = await runValidation(validator, { document: { fileName: 'file.tar-gz' } });
 			expect(result.isEmpty()).toBe(true);
 		});
+
+		test('accepts filename with parentheses brackets', async () => {
+			const result = await runValidation(validator, { document: { fileName: 'file (1).pdf' } });
+			expect(result.isEmpty()).toBe(true);
+		});
 	});
 
 	describe('optional field handling', () => {

--- a/appeals/api/src/server/common/validators/filename-parameter.js
+++ b/appeals/api/src/server/common/validators/filename-parameter.js
@@ -10,6 +10,6 @@ import { body } from 'express-validator';
 export const validateFileNameParameter = (parameterName) =>
 	body(parameterName)
 		.optional({ checkFalsy: true })
-		// Filename must only contain alphanumeric characters, underscores, hyphens and one period followed by a suffix
-		.matches('^[a-zA-Z0-9_ -]+\\.[a-zA-Z0-9_-]+$')
+		// Filename must only contain alphanumeric characters, spaces, brackets, underscores, hyphens and one period followed by a suffix
+		.matches('^[a-zA-Z0-9_ ()-]+\\.[a-zA-Z0-9_-]+$')
 		.withMessage(ERROR_INVALID_FILENAME);

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
@@ -272,6 +272,16 @@ describe('appeal-documents', () => {
 			);
 		});
 
+		it('should redirect to manage documents page when filename contains parentheses', async () => {
+			const response = await request
+				.post(fullUrl)
+				.send({ fileName: 'valid-fileName_(123)', documentId });
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toContain(
+				`Found. Redirecting to ${fullUrl.replace('change-document-name', 'manage-documents')}`
+			);
+		});
+
 		it('should render change filename page with blank filename error', async () => {
 			const response = await request.post(fullUrl).send({});
 			expect(response.statusCode).toBe(200);
@@ -292,7 +302,7 @@ describe('appeal-documents', () => {
 			}).innerHTML;
 
 			expect(element).toContain(
-				'>File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens and underscores'
+				'>File name must only include letters a to z, numbers 0 to 9, spaces and special characters such as hyphens, underscores, and parentheses'
 			);
 		});
 
@@ -306,7 +316,7 @@ describe('appeal-documents', () => {
 			}).innerHTML;
 
 			expect(element).toContain(
-				'>File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens and underscores'
+				'>File name must only include letters a to z, numbers 0 to 9, spaces and special characters such as hyphens, underscores, and parentheses'
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.validators.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.validators.js
@@ -21,10 +21,10 @@ export const validateDocumentName = createValidator(
 		.notEmpty()
 		.withMessage('File name must be entered')
 		.bail()
-		// Filename must only contain alphanumeric characters, underscores and hyphens
-		.matches('^[a-zA-Z0-9_ -]+$')
+		// Filename must only contain alphanumeric characters, spaces, underscores, hyphens, and parentheses
+		.matches('^[a-zA-Z0-9_ ()-]+$')
 		.withMessage(
-			'File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens and underscores'
+			'File name must only include letters a to z, numbers 0 to 9, spaces and special characters such as hyphens, underscores, and parentheses'
 		)
 		.bail()
 		.custom((value, { req }) => {


### PR DESCRIPTION

- Added brackets to api-side filename validator regex
- Added brackets to web-side validator
- Added test for checking brackets web & api
- Updated banner error message to include new conditions
- Updated tests to reflect changes

Ticket: https://pins-ds.atlassian.net/browse/A2-8825