### PR TITLE
feat/a2-8805-updates-to-hearing-set-up-notify-template

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/notify-hearing-set-up.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-hearing-set-up.test.js
@@ -46,10 +46,10 @@ describe('hearing-set-up.md', () => {
 			'',
 			'The details of the hearing are subject to change. We will contact you by email if we make any changes.',
 			'',
-			'We expect the hearing to finish on the same day. If the hearing needs more time, you will arrange the next steps on the day.',
+			'If the hearing needs more time, you will arrange the next steps on the day.',
 			'',
 			'',
-			'The Planning Inspectorate',
+			'Planning Inspectorate',
 			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
@@ -106,7 +106,7 @@ describe('hearing-set-up.md', () => {
 			'We will contact you when the local planning authority confirms the venue address for the hearing.',
 			'',
 			'',
-			'The Planning Inspectorate',
+			'Planning Inspectorate',
 			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
@@ -163,7 +163,7 @@ describe('hearing-set-up.md', () => {
 			'Email caseofficers@planninginspectorate.gov.uk to confirm the venue address for the hearing.',
 			'',
 			'',
-			'The Planning Inspectorate',
+			'Planning Inspectorate',
 			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 

--- a/appeals/api/src/server/notify/templates/hearing-set-up.content.md
+++ b/appeals/api/src/server/notify/templates/hearing-set-up.content.md
@@ -27,8 +27,8 @@ You need to attend the hearing on {{hearing_date}}.
 
 The details of the hearing are subject to change. We will contact you by email if we make any changes.
 
-We expect the hearing to finish on the same day. If the hearing needs more time, you will arrange the next steps on the day.
+If the hearing needs more time, you will arrange the next steps on the day.
 {% endif %}
 
-The Planning Inspectorate
+Planning Inspectorate
 {{team_email_address}}


### PR DESCRIPTION
- Removed text from hearing-set-up.content.md
- Updated tests

The third requirement on this ticket (ELB ref number replacing planning application ref number) was previously fixed and has been confirmed to be working by the ticket reporter. This AC was added as a testing requirement.

Ticket: https://pins-ds.atlassian.net/browse/A2-8805