### PR TITLE
feat(web): add hyperlinks to FO submissions in case history (A2-8090)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
@@ -4,6 +4,7 @@ import {
 	getAppellantCaseLink,
 	getLPAQuestionnaireLink,
 	tryMapDocument,
+	tryMapRepresentationType,
 	tryMapUsers
 } from '#appeals/appeal-details/audit/audit.mapper.js';
 import { statusFormatMap } from '#appeals/appeal-details/representations/document-attachments/controller/redaction-status.js';
@@ -241,5 +242,64 @@ describe('audit', () => {
 				'<td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Issue decision</strong></td>'
 			);
 		});
+	});
+});
+describe('tryMapRepresentationType', () => {
+	const appeal = { appealId: 1 };
+
+	it('should return the correct link for interested party comment', () => {
+		const log = 'ip_comment was received';
+		const result = tryMapRepresentationType(appeal.appealId, log);
+		expect(result).toBe(
+			`<a class="govuk-link" href="/appeals-service/appeal-details/1/interested-party-comments">Interested party comment</a> was received`
+		);
+	});
+
+	it('should return the correct link for LPA statement', () => {
+		const log = 'lpa_statement was received';
+		const result = tryMapRepresentationType(appeal.appealId, log);
+		expect(result).toBe(
+			`<a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-statement">LPA statement</a> was received`
+		);
+	});
+
+	it('should return the correct link for appellant statement', () => {
+		const log = 'appellant_statement was received';
+		const result = tryMapRepresentationType(appeal.appealId, log);
+		expect(result).toBe(
+			`<a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-statement">Appellant statement</a> was received`
+		);
+	});
+
+	it('should return the correct link for LPA final comment', () => {
+		const log = 'lpa_final_comment was received';
+		const result = tryMapRepresentationType(appeal.appealId, log);
+		expect(result).toBe(
+			`<a class="govuk-link" href="/appeals-service/appeal-details/1/final-comments/lpa">LPA final comment</a> was received`
+		);
+	});
+
+	it('should return the correct link for appellant final comment', () => {
+		const log = 'appellant_final_comment was received';
+		const result = tryMapRepresentationType(appeal.appealId, log);
+		expect(result).toBe(
+			`<a class="govuk-link" href="/appeals-service/appeal-details/1/final-comments/appellant">Appellant final comment</a> was received`
+		);
+	});
+
+	it('should return the correct link for appellant proof of evidence', () => {
+		const log = 'appellant_proofs_evidence was received';
+		const result = tryMapRepresentationType(appeal.appealId, log);
+		expect(result).toBe(
+			`<a class="govuk-link" href="/appeals-service/appeal-details/1/proof-of-evidence/appellant/manage-documents">Appellant proof of evidence and witnesses</a> was received`
+		);
+	});
+
+	it('should return the correct link for LPA proof of evidence', () => {
+		const log = 'lpa_proofs_evidence was received';
+		const result = tryMapRepresentationType(appeal.appealId, log);
+		expect(result).toBe(
+			`<a class="govuk-link" href="/appeals-service/appeal-details/1/proof-of-evidence/lpa/manage-documents">LPA proof of evidence and witnesses</a> was received`
+		);
 	});
 });

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
@@ -40,7 +40,7 @@ export const mapMessageContent = async (appeal, log, docInfo, session, apiClient
 	result = tryMapDocumentRedactionStatus(result);
 	result = tryMapDocument(appeal.appealId, result, docInfo, appeal?.lpaQuestionnaireId || null);
 
-	result = tryMapRepresentationType(result);
+	result = tryMapRepresentationType(appeal.appealId, result);
 	result = tryMapStatus(result, appeal.appealType, appeal.procedureType);
 
 	result = result.replace(/\n/g, '<br>');
@@ -255,15 +255,40 @@ const tryMapStatus = (log, appealType, appealProcedureType) => {
 
 /**
  *
+ * @param {number} appealId
  * @param {string} log
  * @returns {string}
  */
-const tryMapRepresentationType = (log) =>
+export const tryMapRepresentationType = (appealId, log) =>
 	log
-		.replace('ip_comment', 'An interested party comment')
-		.replace('lpa_statement', 'The LPA statement')
-		.replace('lpa_final_comment', 'The LPA final comment')
-		.replace('appellant_final_comment', 'The appellant final comment');
+		.replace(
+			'ip_comment',
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/interested-party-comments">Interested party comment</a>`
+		)
+		.replace(
+			'lpa_statement',
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-statement">LPA statement</a>`
+		)
+		.replace(
+			'appellant_statement',
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-statement">Appellant statement</a>`
+		)
+		.replace(
+			'lpa_final_comment',
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/lpa">LPA final comment</a>`
+		)
+		.replace(
+			'appellant_final_comment',
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/appellant">Appellant final comment</a>`
+		)
+		.replace(
+			'appellant_proofs_evidence',
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/proof-of-evidence/appellant/manage-documents">Appellant proof of evidence and witnesses</a>`
+		)
+		.replace(
+			'lpa_proofs_evidence',
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/proof-of-evidence/lpa/manage-documents">LPA proof of evidence and witnesses</a>`
+		);
 
 /**
  *


### PR DESCRIPTION
## Describe your changes

This PR adds hyperlinks of FO submissions to case history and test for these links.

Submissions now hyperlinked:
- LPA/ Appellant statement
- LPA / Appellant proof of evidence
- LPA / Appellant final comments

N.B. This PR does not cover Rule 6 org submissions of the above types.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8090)
