### PR TITLE
feat(appeals): mapping for remove variation of conditions question display (A2-8633)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-expedited.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-expedited.test.js
@@ -120,4 +120,47 @@ describe('appellant-case-expedited', () => {
 			expect(element.innerHTML).toContain('5. Upload documents</h2>');
 		}
 	);
+
+	it.each([
+		{ decision: 'refused', applicationDecision: 'refused' },
+		{ decision: 'granted', applicationDecision: 'granted' }
+	])(
+		'should render expedited fields for S78 + removal-or-variation-of-conditions + $decision',
+		async ({ applicationDecision }) => {
+			const expeditedAppellantCaseData = {
+				...appellantCaseDataNotValidated,
+				applicationDate: '2026-04-02T00:00:00.000Z',
+				applicationDecision,
+				typeOfPlanningApplication:
+					APPEAL_TYPE_OF_PLANNING_APPLICATION.REMOVAL_OR_VARIATION_OF_CONDITIONS,
+				reasonForAppealAppellant: 'My reason',
+				anySignificantChanges: 'No',
+				screeningOpinionIndicatesEiaRequired: false,
+				ownershipCertificate: false
+			};
+
+			nock('http://test/')
+				.get('/appeals/2?include=all')
+				.reply(200, {
+					...appealDataFullPlanning,
+					appealId: 2
+				});
+			nock('http://test/')
+				.get('/appeals/2/appellant-cases/0')
+				.reply(200, expeditedAppellantCaseData);
+
+			const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+			const element = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(element.innerHTML).toContain('Why are you appealing?');
+			expect(element.innerHTML).toContain('My reason</dd>');
+			expect(element.innerHTML).toContain(
+				'Have there been any significant changes that would affect the application?'
+			);
+			expect(element.innerHTML).toContain(
+				'Did you submit an environmental statement with the application?'
+			);
+			expect(element.innerHTML).not.toContain('Draft statement of common ground');
+		}
+	);
 });

--- a/packages/appeals/utils/__tests__/appeal-type-checks.test.js
+++ b/packages/appeals/utils/__tests__/appeal-type-checks.test.js
@@ -1,7 +1,13 @@
+import {
+	APPEAL_APPLICATION_DECISION,
+	APPEAL_CASE_TYPE,
+	APPEAL_TYPE_OF_PLANNING_APPLICATION
+} from '@planning-inspectorate/data-model';
 import { APPEAL_TYPE } from '../../constants/common';
 import {
 	isAnyEnforcementAppealType,
-	isLdcOrDiscontinuanceOrEnforcementAppealType
+	isLdcOrDiscontinuanceOrEnforcementAppealType,
+	isS78ExpeditedAppealType
 } from '../appeal-type-checks';
 
 describe('isAnyEnforcementAppealType', () => {
@@ -45,5 +51,83 @@ describe('isLdcOrDiscontinuanceOrEnforcementAppealType', () => {
 		APPEAL_TYPE.CAS_ADVERTISEMENT
 	])('returns false for %s', (appealType) => {
 		expect(isLdcOrDiscontinuanceOrEnforcementAppealType(appealType)).toBe(false);
+	});
+});
+
+describe('isS78ExpeditedAppealType', () => {
+	const S78 = APPEAL_CASE_TYPE.W;
+	const afterCutoff = '2026-04-01T00:00:00.000Z';
+	const beforeCutoff = '2026-03-31T00:00:00.000Z';
+
+	it.each([
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.PRIOR_APPROVAL,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.REMOVAL_OR_VARIATION_OF_CONDITIONS
+	])('returns true for S78 + %s + refused + date on/after cutoff', (typeOfPlanningApplication) => {
+		expect(
+			isS78ExpeditedAppealType(
+				S78,
+				afterCutoff,
+				APPEAL_APPLICATION_DECISION.REFUSED,
+				typeOfPlanningApplication
+			)
+		).toBe(true);
+	});
+
+	it.each([
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.PRIOR_APPROVAL,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.REMOVAL_OR_VARIATION_OF_CONDITIONS
+	])('returns true for S78 + %s + granted + date on/after cutoff', (typeOfPlanningApplication) => {
+		expect(
+			isS78ExpeditedAppealType(
+				S78,
+				afterCutoff,
+				APPEAL_APPLICATION_DECISION.GRANTED,
+				typeOfPlanningApplication
+			)
+		).toBe(true);
+	});
+	it.each([
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.PRIOR_APPROVAL,
+		APPEAL_TYPE_OF_PLANNING_APPLICATION.REMOVAL_OR_VARIATION_OF_CONDITIONS
+	])('returns false for S78 + %s + granted + date before cutoff', (typeOfPlanningApplication) => {
+		expect(
+			isS78ExpeditedAppealType(
+				S78,
+				beforeCutoff,
+				APPEAL_APPLICATION_DECISION.GRANTED,
+				typeOfPlanningApplication
+			)
+		).toBe(false);
+	});
+
+	it('returns true for HOUSEHOLDER_PLANNING + granted', () => {
+		expect(
+			isS78ExpeditedAppealType(
+				S78,
+				afterCutoff,
+				APPEAL_APPLICATION_DECISION.GRANTED,
+				APPEAL_TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING
+			)
+		).toBe(true);
+	});
+
+	it('returns false for HOUSEHOLDER_PLANNING + refused', () => {
+		expect(
+			isS78ExpeditedAppealType(
+				S78,
+				afterCutoff,
+				APPEAL_APPLICATION_DECISION.REFUSED,
+				APPEAL_TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING
+			)
+		).toBe(false);
 	});
 });

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -94,7 +94,9 @@ export const isS78ExpeditedAppealType = (
 		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL ||
 		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING ||
 		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS ||
-		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.PRIOR_APPROVAL;
+		typeOfPlanningApplication === APPEAL_TYPE_OF_PLANNING_APPLICATION.PRIOR_APPROVAL ||
+		typeOfPlanningApplication ===
+			APPEAL_TYPE_OF_PLANNING_APPLICATION.REMOVAL_OR_VARIATION_OF_CONDITIONS;
 
 	return isEligibleDecision && isEligiblePlanningApplication;
 };


### PR DESCRIPTION
## Describe your changes

Updates:
Added REMOVAL_OR_VARIATION_OF_CONDITIONS to the eligible appeal types for S78 expedited.

Testing:
Added more comprehensive testing for the isS78ExpeditedAppealType logic checks
Added tests for expected field rendering on the appellant case for REMOVAL_OR_VARIATION_OF_CONDITIONS

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8633)
