### PR TITLE
feat(api): improve redact on validation and broadcast appeal performa…

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -178,7 +178,8 @@ const mockAppellantCaseInvalidReasonTextCreateMany = jest.fn().mockResolvedValue
 const mockLPAQuestionnaireIncompleteReasonTextCreateMany = jest.fn().mockResolvedValue({});
 const mockAppellantCaseEnforcementInvalidReasonTextDeleteMany = jest.fn().mockResolvedValue({});
 const mockAppellantCaseEnforcementInvalidReasonTextCreateMany = jest.fn().mockResolvedValue({});
-const mockDocumentRedactionStatusFindMany = jest.fn().mockResolvedValue({});
+const mockDocumentRedactionStatusFindMany = jest.fn().mockResolvedValue([]);
+const mockDocumentRedactionStatusFindUnique = jest.fn().mockResolvedValue({});
 const mockAuditTrailFindMany = jest.fn().mockResolvedValue({});
 const mockAuditTrailCreate = jest.fn().mockResolvedValue({});
 const mockAuditTrailDeleteMany = jest.fn().mockResolvedValue({});
@@ -701,7 +702,8 @@ class MockPrismaClient {
 
 	get documentRedactionStatus() {
 		return {
-			findMany: mockDocumentRedactionStatusFindMany
+			findMany: mockDocumentRedactionStatusFindMany,
+			findUnique: mockDocumentRedactionStatusFindUnique
 		};
 	}
 
@@ -962,6 +964,7 @@ jest.unstable_mockModule('node-fetch', () => ({
 const broadcastersMock = {
 	broadcastServiceUser: jest.fn(),
 	broadcastDocument: jest.fn(),
+	broadcastDocuments: jest.fn(),
 	broadcastAppeal: jest.fn(),
 	broadcastEvent: jest.fn(),
 	broadcastEventEstimates: jest.fn(),

--- a/appeals/api/src/database/migrations/20260728161952_add_representation_type_date_index/migration.sql
+++ b/appeals/api/src/database/migrations/20260728161952_add_representation_type_date_index/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [Representation_appealId_representationType_dateCreated_idx] ON [dbo].[Representation]([appealId], [representationType], [dateCreated] ASC);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -973,6 +973,7 @@ model Representation {
   representationRejectionReasonsSelected RepresentationRejectionReasonsSelected[]
 
   @@index([appealId])
+  @@index([appealId, representationType, dateCreated(sort: Asc)])
 }
 
 /// Representation model

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -158,7 +158,10 @@ const updateAppealTimetableById = async (req, res) => {
 					// is returning all data in a loop, return only needed data
 					const child =
 						childAppeal.child ||
-						(await appealRepository.deprecatedGetAppealById(Number(childAppeal.childId)));
+						(await appealRepository.deprecatedGetAppealById(Number(childAppeal.childId), {
+							omitDocuments: true,
+							omitRepresentations: true
+						}));
 					if (child) {
 						return updateAppealTimetable(child, body, notifyClient, azureAdUserId, true);
 					}

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -598,7 +598,7 @@ const getStartCaseNotifyPreviews = async (
 };
 
 /**
- * @param {Appeal} appeal
+ * @param {Omit<Appeal, 'documents' | 'representations'>} appeal
  * @param {object} body
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} azureAdUserId
@@ -694,7 +694,7 @@ const dueDateToAppealTimetableTextMapper = {
 };
 
 /**
- * @param {Appeal} appeal
+ * @param {Omit<Appeal, 'documents' | 'representations'>} appeal
  * @param {object} processedBody
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} azureAdUserId

--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -51,7 +51,13 @@ import {
 	ERROR_NOT_FOUND,
 	LENGTH_8
 } from '@pins/appeals/constants/support.js';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { EventType } from '@pins/event-client';
+import {
+	APPEAL_CASE_STAGE,
+	APPEAL_CASE_STATUS,
+	APPEAL_DOCUMENT_TYPE,
+	APPEAL_VIRUS_CHECK_STATUS
+} from '@planning-inspectorate/data-model';
 import {
 	appellantCaseEnforcementGroundsMismatchFacts,
 	appellantCaseEnforcementMissingDocuments
@@ -1011,6 +1017,31 @@ describe('appellant cases routes', () => {
 					databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
 						{ id: 1, key: 'no_redaction_required' }
 					]);
+					databaseConnector.$queryRaw.mockResolvedValue([
+						{
+							guid: '123',
+							name: 'document.pdf',
+							version: 1,
+							documentURI: 'https://example.com/document.pdf',
+							originalFilename: 'document.pdf',
+							size: 1024,
+							mime: 'application/pdf',
+							fileMD5: 'abc123',
+							virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+							stage: APPEAL_CASE_STAGE.APPELLANT_CASE,
+							documentType: APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION,
+							published: true,
+							datePublished: new Date(),
+							dateCreated: new Date(),
+							dateReceived: new Date(),
+							lastModified: new Date(),
+							representationType: null
+						}
+					]);
+					databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+						id: 1,
+						key: 'no_redaction_required'
+					});
 					// @ts-ignore
 					databaseConnector.document.findUnique.mockResolvedValue(null);
 
@@ -1084,6 +1115,14 @@ describe('appellant cases routes', () => {
 					}
 
 					expect(response.status).toEqual(200);
+					expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
+						[
+							expect.objectContaining({
+								guid: '123'
+							})
+						],
+						EventType.Update
+					);
 				}
 			);
 
@@ -1118,6 +1157,11 @@ describe('appellant cases routes', () => {
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
 					{ id: 1, key: 'no_redaction_required' }
 				]);
+				databaseConnector.$queryRaw.mockResolvedValue([]);
+				databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+					id: 1,
+					key: 'no_redaction_required'
+				});
 				databaseConnector.document.findUnique.mockResolvedValue(null);
 
 				const patchBody = {
@@ -1228,6 +1272,11 @@ describe('appellant cases routes', () => {
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
 					{ id: 1, key: 'no_redaction_required' }
 				]);
+				databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+					id: 1,
+					key: 'no_redaction_required'
+				});
+				databaseConnector.$queryRaw.mockResolvedValue([]);
 				databaseConnector.document.findUnique.mockResolvedValue(null);
 
 				const patchBody = {
@@ -1350,6 +1399,11 @@ describe('appellant cases routes', () => {
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
 					{ id: 1, key: 'no_redaction_required' }
 				]);
+				databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+					id: 1,
+					key: 'no_redaction_required'
+				});
+				databaseConnector.$queryRaw.mockResolvedValue([]);
 				databaseConnector.document.findUnique.mockResolvedValue(null);
 
 				const patchBody = {
@@ -1450,6 +1504,11 @@ describe('appellant cases routes', () => {
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
 					{ id: 1, key: 'no_redaction_required' }
 				]);
+				databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+					id: 1,
+					key: 'no_redaction_required'
+				});
+				databaseConnector.$queryRaw.mockResolvedValue([]);
 				databaseConnector.document.findUnique.mockResolvedValue(null);
 
 				const patchBody = {
@@ -1818,6 +1877,11 @@ describe('appellant cases routes', () => {
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
 					{ id: 1, key: 'no_redaction_required' }
 				]);
+				databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+					id: 1,
+					key: 'no_redaction_required'
+				});
+				databaseConnector.$queryRaw.mockResolvedValue([]);
 				// @ts-ignore
 				databaseConnector.document.findUnique.mockResolvedValue(null);
 

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -56,10 +56,9 @@ import formatDate, { dateISOStringToDisplayDate } from '@pins/appeals/utils/date
 import { camelToScreamingSnake, capitalizeFirstLetter } from '@pins/appeals/utils/string-case.js';
 import { EventType } from '@pins/event-client';
 import { loadEnvironment } from '@pins/platform';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { APPEAL_CASE_STATUS, APPEAL_REDACTED_STATUS } from '@planning-inspectorate/data-model';
 import { add } from 'date-fns';
 import transitionState from '../../state/transition-state.js';
-
 const environment = loadEnvironment(process.env.NODE_ENV);
 
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateAppellantCaseValidationOutcomeParams} UpdateAppellantCaseValidationOutcomeParams */
@@ -255,19 +254,24 @@ export const updateAppellantCaseValidationOutcome = async (
 
 	// TODO: performance
 	// is returning all data, return only needed data
-	const updatedAppeal = await appealRepository.deprecatedGetAppealById(Number(appealId));
+	/** @type {Omit<Appeal, 'documents' | 'representations'>|undefined} */
+	const updatedAppeal = await appealRepository.deprecatedGetAppealById(Number(appealId), {
+		omitDocuments: true,
+		omitRepresentations: true
+	});
 
 	if (isOutcomeValid(validationOutcome.name)) {
-		const latestDocumentVersionsUpdated = await documentRepository.setRedactionStatusOnValidation(
-			appeal.id
+		const noRedactionRequiredStatus = await commonRepository.getLookupListValueByKey(
+			'documentRedactionStatus',
+			{ key: 'key', value: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
 		);
-		for (const documentUpdated of latestDocumentVersionsUpdated) {
-			await broadcasters.broadcastDocument(
-				documentUpdated.documentGuid,
-				documentUpdated.version,
-				EventType.Update
-			);
-		}
+		const updatedDocuments = await documentRepository.setRedactionStatusOnValidation(
+			appeal.id,
+			appeal.reference,
+			appeal.appealType.key,
+			noRedactionRequiredStatus.id
+		);
+		await broadcasters.broadcastDocuments(updatedDocuments, EventType.Update);
 
 		const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
 		if (!recipientEmail) {

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -87,7 +87,11 @@ export const postInspectorDecision = async (req, res) => {
 							// TODO: performance
 							// is returning all data, return only needed data
 							const childAppeal = await appealRepository.deprecatedGetAppealById(
-								Number(decisionAppealId)
+								Number(decisionAppealId),
+								{
+									omitDocuments: true,
+									omitRepresentations: true
+								}
 							);
 
 							if (childAppeal) {

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -326,7 +326,7 @@ export const publishDecision = async (
 
 /**
  *
- * @param {Appeal} childAppeal
+ * @param {Omit<Appeal, 'documents' | 'representations'>} childAppeal
  * @param {string} outcome
  * @param {Date} documentDate
  * @param {string} azureAdUserId

--- a/appeals/api/src/server/endpoints/documents/documents.service.js
+++ b/appeals/api/src/server/endpoints/documents/documents.service.js
@@ -441,7 +441,7 @@ export const getDocumentRedactionStatusIds = async () => {
 
 /**
  *
- * @param {DocumentVersion} documentVersion
+ * @param {{virusCheckStatus: string}} documentVersion
  * @returns {string}
  */
 export const getAvScanStatus = (documentVersion) => {

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters.js
@@ -1,5 +1,5 @@
 import { broadcastAppeal } from './integrations.broadcasters/appeal.js';
-import { broadcastDocument } from './integrations.broadcasters/documents.js';
+import { broadcastDocument, broadcastDocuments } from './integrations.broadcasters/documents.js';
 import { broadcastEventEstimates } from './integrations.broadcasters/event-estimates.js';
 import { broadcastEvent } from './integrations.broadcasters/event.js';
 import { broadcastRepresentation } from './integrations.broadcasters/representation.js';
@@ -8,6 +8,7 @@ import { broadcastServiceUser } from './integrations.broadcasters/service-users.
 export const broadcasters = {
 	broadcastServiceUser,
 	broadcastDocument,
+	broadcastDocuments,
 	broadcastAppeal,
 	broadcastEvent,
 	broadcastEventEstimates,

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/appeal.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/appeal.js
@@ -94,7 +94,6 @@ export const broadcastAppeal = async (appealId, updateType = EventType.Update) =
 					}
 				}
 			},
-			representations: true,
 			appealGrounds: {
 				include: {
 					ground: true
@@ -107,6 +106,19 @@ export const broadcastAppeal = async (appealId, updateType = EventType.Update) =
 		pino.error(`Trying to broadcast info for appeal ${appealId} , but it was not found.`);
 		return false;
 	}
+
+	// get first rep by type for representation submission dates
+	//@ts-ignore
+	appeal.representations = (
+		await databaseConnector.representation.groupBy({
+			by: ['representationType'],
+			where: { appealId },
+			_min: { dateCreated: true }
+		})
+	).map((rep) => ({
+		representationType: rep.representationType,
+		dateCreated: rep._min.dateCreated
+	}));
 
 	const appealRelationships = [...appeal.parentAppeals, ...appeal.childAppeals];
 

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
@@ -5,8 +5,6 @@ import { mapDocumentEntity } from '#mappers/integration/map-document-entity.js';
 import { databaseConnector } from '#utils/database-connector.js';
 import pino from '#utils/logger.js';
 import { ODW_SYSTEM_ID } from '@pins/appeals/constants/common.js';
-import { REP_ATTACHMENT_DOCTYPE } from '@pins/appeals/constants/documents.js';
-import { APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 import { schemas, validateFromSchema } from '../integrations.validators.js';
 
 const entityInfo = {
@@ -72,16 +70,6 @@ export const broadcastDocument = async (documentId, version, updateType) => {
 		return false;
 	}
 
-	const latestDocumentVersion = document.versions?.length === 1 ? document.versions[0] : null;
-
-	// wait to broadcast representationAttachments if document type is not known
-	if (
-		latestDocumentVersion?.documentType === REP_ATTACHMENT_DOCTYPE &&
-		msg.documentType === APPEAL_DOCUMENT_TYPE.UNCATEGORISED
-	) {
-		return false;
-	}
-
 	const topic = producers.boDocument;
 	const res = await eventClient.sendEvents(topic, [msg], updateType, {
 		entityType: entityInfo.name,
@@ -93,4 +81,68 @@ export const broadcastDocument = async (documentId, version, updateType) => {
 	}
 
 	return true;
+};
+
+/**
+ * @param {import('#mappers/integration/map-document-entity.js').DocumentWithAppeal[]} documents
+ * @param {string} updateType
+ * @returns
+ */
+export const broadcastDocuments = async (documents, updateType) => {
+	if (!config.serviceBusEnabled && config.NODE_ENV !== 'development') {
+		return false;
+	}
+
+	if (!documents || documents.length === 0) {
+		pino.error(`No documents to broadcast`);
+		return false;
+	}
+
+	const messages = documents
+		.map((document) => mapDocumentEntity(document))
+		.filter((x) => x !== null)
+		.filter(Boolean);
+
+	if (!messages || messages.length === 0) {
+		pino.error(`Failed to map documents for broadcast`);
+		return false;
+	}
+
+	let failedToValidate = false;
+	for (const msg of messages) {
+		if (!msg) {
+			pino.error(`Failed to map document for broadcast`);
+		}
+
+		const validationResult = await validateFromSchema(schemas.events.document, msg);
+
+		if (validationResult !== true && validationResult.errors) {
+			const errorDetails = validationResult.errors?.map(
+				(e) => `${e.instancePath || '/'}: ${e.message}`
+			);
+
+			pino.error(`Error validating ${entityInfo.name} entity: ${errorDetails}`);
+			failedToValidate = true;
+		}
+	}
+	if (failedToValidate) return false;
+
+	// batch send document messages to service bus
+	const topic = producers.boDocument;
+	const batchSize = 100;
+	let allSucceeded = true;
+	for (let i = 0; i < messages.length; i += batchSize) {
+		const messageBatch = messages.slice(i, i + batchSize);
+		const batchResult = await eventClient.sendEvents(topic, messageBatch, updateType, {
+			entityType: entityInfo.name,
+			sourceSystem: ODW_SYSTEM_ID
+		});
+
+		if (!batchResult) {
+			pino.error(`Failed to send batch of ${messageBatch.length} documents to service bus`);
+			allSucceeded = false;
+		}
+	}
+
+	return allSucceeded;
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -196,11 +196,15 @@ export const importAppeal = async (req, res) => {
 			users
 		});
 
+		/** @type {(Omit<Appeal, 'documents' | 'representations'>|undefined)[]} */
 		const [parentAppeal, ...childAppeals] = await Promise.all(
 			[parentResult, ...childResults].map(async (caseData) => {
 				// TODO: performance
 				// is returning all data in a loop, return only needed data
-				return appealRepository.deprecatedGetAppealById(caseData.id);
+				return appealRepository.deprecatedGetAppealById(caseData.id, {
+					omitDocuments: true,
+					omitRepresentations: true
+				});
 			})
 		);
 

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -533,8 +533,12 @@ export const updateAppealStatusIfRequired = async (
 ) => {
 	// TODO: performance
 	// is returning all data, return only needed data
+	/** @type {Omit<Appeal, 'documents' | 'representations'> | undefined|null} */
 	const leadAppeal = leadAppealId
-		? await appealRepository.deprecatedGetAppealById(leadAppealId)
+		? await appealRepository.deprecatedGetAppealById(leadAppealId, {
+				omitDocuments: true,
+				omitRepresentations: true
+			})
 		: null;
 
 	if (!leadAppeal) {
@@ -543,8 +547,12 @@ export const updateAppealStatusIfRequired = async (
 
 	// TODO: performance
 	// is returning all data, return only needed data
+	/** @type {Omit<Appeal, 'documents' | 'representations'> | undefined|null} */
 	const unlinkedAppeal = unlinkedAppealId
-		? await appealRepository.deprecatedGetAppealById(unlinkedAppealId)
+		? await appealRepository.deprecatedGetAppealById(unlinkedAppealId, {
+				omitDocuments: true,
+				omitRepresentations: true
+			})
 		: null;
 
 	const { appellantCaseValidationOutcome: leadAppealAppellantCaseOutcome } =
@@ -556,38 +564,36 @@ export const updateAppealStatusIfRequired = async (
 
 	switch (currentStatus(leadAppeal)) {
 		case APPEAL_CASE_STATUS.VALIDATION:
-			{
-				if (unlinkedAppealId && unlinkedAppealAppellantCaseOutcome) {
-					if (!isEnforcementNotice) {
-						// The unlinked appeal has been validated correctly and can roll forward to the next status
-						await transitionState(
-							unlinkedAppealId,
-							azureAdUserId,
-							unlinkedAppealAppellantCaseOutcome.name
-						);
-					}
+			if (unlinkedAppealId && unlinkedAppealAppellantCaseOutcome) {
+				if (!isEnforcementNotice) {
+					// The unlinked appeal has been validated correctly and can roll forward to the next status
+					await transitionState(
+						unlinkedAppealId,
+						azureAdUserId,
+						unlinkedAppealAppellantCaseOutcome.name
+					);
 				}
-				if (leadAppealAppellantCaseOutcome) {
-					// transition all the linked appeals if they have all been validated
-					const linkedAppeals = [leadAppeal, ...getChildAppeals(leadAppeal)];
-					const shouldTransition = linkedAppeals.every((linkedAppeal) => {
-						const { appellantCaseValidationOutcome } = linkedAppeal?.appellantCase || {};
-						return !!appellantCaseValidationOutcome;
-					});
-					if (shouldTransition) {
-						await Promise.all(
-							linkedAppeals.map(async (linkedAppeal) => {
-								const { appellantCaseValidationOutcome } = linkedAppeal?.appellantCase || {};
-								if (linkedAppeal?.id && appellantCaseValidationOutcome?.name) {
-									await transitionState(
-										linkedAppeal.id,
-										azureAdUserId,
-										appellantCaseValidationOutcome.name
-									);
-								}
-							})
-						);
-					}
+			}
+			if (leadAppealAppellantCaseOutcome) {
+				// transition all the linked appeals if they have all been validated
+				const linkedAppeals = [leadAppeal, ...getChildAppeals(leadAppeal)];
+				const shouldTransition = linkedAppeals.every((linkedAppeal) => {
+					const { appellantCaseValidationOutcome } = linkedAppeal?.appellantCase || {};
+					return !!appellantCaseValidationOutcome;
+				});
+				if (shouldTransition) {
+					await Promise.all(
+						linkedAppeals.map(async (linkedAppeal) => {
+							const { appellantCaseValidationOutcome } = linkedAppeal?.appellantCase || {};
+							if (linkedAppeal?.id && appellantCaseValidationOutcome?.name) {
+								await transitionState(
+									linkedAppeal.id,
+									azureAdUserId,
+									appellantCaseValidationOutcome.name
+								);
+							}
+						})
+					);
 				}
 			}
 			break;

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -44,8 +44,15 @@ import {
 	LENGTH_10,
 	LENGTH_8
 } from '@pins/appeals/constants/support.js';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { EventType } from '@pins/event-client';
+import {
+	APPEAL_CASE_STAGE,
+	APPEAL_CASE_STATUS,
+	APPEAL_DOCUMENT_TYPE,
+	APPEAL_VIRUS_CHECK_STATUS
+} from '@planning-inspectorate/data-model';
 import { request } from '../../../app-test.js';
+
 const { databaseConnector } = await import('#utils/database-connector.js');
 
 describe('lpa questionnaires routes', () => {
@@ -201,6 +208,27 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.documentVersion.update.mockResolvedValue([]);
 				// @ts-ignore
 				databaseConnector.document.findUnique.mockResolvedValue(null);
+				databaseConnector.$queryRaw.mockResolvedValue([
+					{
+						guid: '123',
+						name: 'document.pdf',
+						version: 1,
+						documentURI: 'https://example.com/document.pdf',
+						originalFilename: 'document.pdf',
+						size: 1024,
+						mime: 'application/pdf',
+						fileMD5: 'abc123',
+						virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+						stage: APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE,
+						documentType: APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION,
+						published: true,
+						datePublished: new Date(),
+						dateCreated: new Date(),
+						dateReceived: new Date(),
+						lastModified: new Date(),
+						representationType: null
+					}
+				]);
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue({
 					id: 1,
@@ -253,6 +281,14 @@ describe('lpa questionnaires routes', () => {
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
 				expect(response.status).toEqual(200);
+				expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
+					[
+						expect.objectContaining({
+							guid: '123'
+						})
+					],
+					EventType.Update
+				);
 			});
 
 			test.each([

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -3,6 +3,7 @@ import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
+import commonRepository from '#repositories/common.repository.js';
 import * as documentRepository from '#repositories/document.repository.js';
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
 import transitionState from '#state/transition-state.js';
@@ -31,7 +32,11 @@ import {
 } from '@pins/appeals/utils/business-days.js';
 import formatDate from '@pins/appeals/utils/date-formatter.js';
 import { EventType } from '@pins/event-client';
-import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import {
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_STATUS,
+	APPEAL_REDACTED_STATUS
+} from '@planning-inspectorate/data-model';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateLPAQuestionnaireValidationOutcomeParams} UpdateLPAQuestionnaireValidationOutcomeParams */
@@ -147,16 +152,17 @@ const updateLPAQuestionnaireValidationOutcome = async (
 	}
 
 	if (isOutcomeComplete(validationOutcome.name)) {
-		const latestDocumentVersionsUpdated = await documentRepository.setRedactionStatusOnValidation(
-			appeal.id
+		const noRedactionRequiredStatus = await commonRepository.getLookupListValueByKey(
+			'documentRedactionStatus',
+			{ key: 'key', value: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
 		);
-		for (const documentUpdated of latestDocumentVersionsUpdated) {
-			await broadcasters.broadcastDocument(
-				documentUpdated.documentGuid,
-				documentUpdated.version,
-				EventType.Update
-			);
-		}
+		const updatedDocuments = await documentRepository.setRedactionStatusOnValidation(
+			appeal.id,
+			appeal.reference,
+			appeal.appealType.key,
+			noRedactionRequiredStatus.id
+		);
+		await broadcasters.broadcastDocuments(updatedDocuments, EventType.Update);
 
 		await sendLpaqCompleteEmailToLPA(notifyClient, appeal, siteAddress, azureAdUserId);
 		await sendLpaqCompleteEmailToAppellant(notifyClient, appeal, siteAddress, azureAdUserId);
@@ -164,7 +170,12 @@ const updateLPAQuestionnaireValidationOutcome = async (
 
 	// TODO: performance
 	// is returning all data, return only needed data
-	const updatedAppeal = await appealRepository.deprecatedGetAppealById(Number(appealId));
+	/** @type {Omit<Appeal, 'documents' | 'representations'> | undefined} */
+	const updatedAppeal = await appealRepository.deprecatedGetAppealById(Number(appealId), {
+		omitDocuments: true,
+		omitRepresentations: true
+	});
+
 	if (updatedAppeal) {
 		const { lpaQuestionnaire: updatedLpaQuestionnaire } = updatedAppeal;
 

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations-rule-6.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations-rule-6.test.js
@@ -450,6 +450,9 @@ describe('publishProofOfEvidence', () => {
 		databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
 			{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
 		]);
+		databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+			key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
+		});
 		databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
 		databaseConnector.representation.updateMany.mockResolvedValue([]);
 		databaseConnector.representation.findMany.mockResolvedValue([]);

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -19,11 +19,15 @@ import {
 	CASE_RELATIONSHIP_RELATED,
 	ERROR_NOT_FOUND
 } from '@pins/appeals/constants/support.js';
+import { EventType } from '@pins/event-client';
 import {
+	APPEAL_CASE_STAGE,
 	APPEAL_CASE_STATUS,
+	APPEAL_DOCUMENT_TYPE,
 	APPEAL_REDACTED_STATUS,
 	APPEAL_REPRESENTATION_STATUS,
-	APPEAL_REPRESENTATION_TYPE
+	APPEAL_REPRESENTATION_TYPE,
+	APPEAL_VIRUS_CHECK_STATUS
 } from '@planning-inspectorate/data-model';
 import { addDays } from 'date-fns';
 
@@ -2322,6 +2326,27 @@ describe('/appeals/:id/reps', () => {
 
 		describe('publish LPA statements', () => {
 			beforeEach(() => {
+				databaseConnector.$queryRaw.mockResolvedValue([
+					{
+						guid: '123',
+						name: 'document.pdf',
+						version: 1,
+						documentURI: 'https://example.com/document.pdf',
+						originalFilename: 'document.pdf',
+						size: 1024,
+						mime: 'application/pdf',
+						fileMD5: 'abc123',
+						virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+						stage: APPEAL_CASE_STAGE.LPA_STATEMENT,
+						documentType: APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION,
+						published: true,
+						datePublished: new Date(),
+						dateCreated: new Date(),
+						dateReceived: new Date(),
+						lastModified: new Date(),
+						representationType: APPEAL_REPRESENTATION_TYPE.STATEMENT
+					}
+				]);
 				mockAdvertAppeal.currentStatus = 'statements';
 				mockLdcAppeal.currentStatus = 'statements';
 				mockS78Appeal.currentStatus = 'statements';
@@ -3886,10 +3911,61 @@ describe('/appeals/:id/reps', () => {
 					templateName: 'publish-statements-inquiry-appellant'
 				});
 			});
+
+			test('broadcasts no redaction required docs', async () => {
+				databaseConnector.appeal.findUnique.mockResolvedValue(mockS78Appeal);
+				databaseConnector.appealStatus.create.mockResolvedValue({});
+				databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
+				databaseConnector.representation.findMany.mockResolvedValue([
+					{ representationType: 'lpa_statement' },
+					{ representationType: 'comment' }
+				]);
+				databaseConnector.representation.updateMany.mockResolvedValue([]);
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+				]);
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post('/appeals/1/reps/publish')
+					.query({ type: 'statements' })
+					.set('azureAdUserId', '732652365');
+
+				expect(response.status).toEqual(200);
+				expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
+					[
+						expect.objectContaining({
+							guid: '123'
+						})
+					],
+					EventType.Update
+				);
+			});
 		});
 
 		describe('publish final comments', () => {
 			beforeEach(() => {
+				databaseConnector.$queryRaw.mockResolvedValue([
+					{
+						guid: '123',
+						name: 'document.pdf',
+						version: 1,
+						documentURI: 'https://example.com/document.pdf',
+						originalFilename: 'document.pdf',
+						size: 1024,
+						mime: 'application/pdf',
+						fileMD5: 'abc123',
+						virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+						stage: APPEAL_CASE_STAGE.FINAL_COMMENTS,
+						documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_FINAL_COMMENT,
+						published: true,
+						datePublished: new Date(),
+						dateCreated: new Date(),
+						dateReceived: new Date(),
+						lastModified: new Date(),
+						representationType: APPEAL_REPRESENTATION_TYPE.FINAL_COMMENT
+					}
+				]);
 				mockAdvertAppeal.currentStatus = 'final_comments';
 				mockLdcAppeal.currentStatus = 'final_comments';
 				mockS78Appeal.currentStatus = 'final_comments';
@@ -4751,10 +4827,61 @@ describe('/appeals/:id/reps', () => {
 					templateName: 'final-comments-done-lpa'
 				});
 			});
+
+			test('broadcasts no redaction required documents', async () => {
+				databaseConnector.appeal.findUnique.mockResolvedValue(mockS78Appeal);
+				databaseConnector.appealStatus.create.mockResolvedValue({});
+				databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
+				databaseConnector.representation.findMany.mockResolvedValue([
+					{ representationType: 'appellant_final_comment' },
+					{ representationType: 'lpa_final_comment' }
+				]);
+				databaseConnector.representation.updateMany.mockResolvedValue([]);
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+				]);
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post('/appeals/1/reps/publish')
+					.query({ type: 'final_comments' })
+					.set('azureAdUserId', '732652365');
+
+				expect(response.status).toEqual(200);
+				expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
+					[
+						expect.objectContaining({
+							guid: '123'
+						})
+					],
+					EventType.Update
+				);
+			});
 		});
 
 		describe('publish proof of evidence', () => {
 			beforeEach(() => {
+				databaseConnector.$queryRaw.mockResolvedValue([
+					{
+						guid: '123',
+						name: 'document.pdf',
+						version: 1,
+						documentURI: 'https://example.com/document.pdf',
+						originalFilename: 'document.pdf',
+						size: 1024,
+						mime: 'application/pdf',
+						fileMD5: 'abc123',
+						virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+						stage: APPEAL_CASE_STAGE.PROOFS_EVIDENCE,
+						documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_PROOF_OF_EVIDENCE,
+						published: true,
+						datePublished: new Date(),
+						dateCreated: new Date(),
+						dateReceived: new Date(),
+						lastModified: new Date(),
+						representationType: APPEAL_REPRESENTATION_TYPE.PROOFS_EVIDENCE
+					}
+				]);
 				mockS78Appeal.currentStatus = 'evidence';
 				mockS20Appeal.currentStatus = 'evidence';
 			});
@@ -5412,6 +5539,54 @@ describe('/appeals/:id/reps', () => {
 					.set('azureAdUserId', '732652365');
 
 				expect(response.status).toEqual(200);
+			});
+
+			test('broadcasts no redaction required documents', async () => {
+				mockS78Appeal = {
+					...mockS78Appeal,
+					inquiry: {
+						id: 1,
+						inquiryStartTime: '2025-12-13 14:00',
+						estimatedDays: 8,
+						address: {
+							addressLine1: '10 Mole lane',
+							addressLine2: 'Test address 2',
+							addressTown: 'London',
+							addressCounty: 'London',
+							postcode: 'WL3 6GH',
+							addressCountry: 'United Kingdom'
+						}
+					}
+				};
+
+				databaseConnector.appeal.findUnique.mockResolvedValue(mockS78Appeal);
+				databaseConnector.appealStatus.create.mockResolvedValue({});
+				databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
+				databaseConnector.representation.findMany.mockResolvedValue([
+					{ representationType: 'appellant_proofs_evidence' },
+					{ representationType: 'lpa_proofs_evidence' }
+				]);
+				databaseConnector.representation.updateMany.mockResolvedValue([]);
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+				]);
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post('/appeals/1/reps/publish')
+					.query({ type: 'evidence' })
+					.set('azureAdUserId', '732652365');
+
+				expect(response.status).toEqual(200);
+
+				expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
+					[
+						expect.objectContaining({
+							guid: '123'
+						})
+					],
+					EventType.Update
+				);
 			});
 		});
 	});

--- a/appeals/api/src/server/endpoints/representations/representations.routes.js
+++ b/appeals/api/src/server/endpoints/representations/representations.routes.js
@@ -253,6 +253,7 @@ router.post(
 	*/
 	checkAppealExistsByIdAndAddPartialToRequest([
 		'appealStatus',
+		'appealType',
 		'representations',
 		'appealTimetable',
 		'childAppeals',

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -5,6 +5,7 @@ import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import addressRepository from '#repositories/address.repository.js';
+import commonRepository from '#repositories/common.repository.js';
 import * as documentRepository from '#repositories/document.repository.js';
 import neighbouringSitesRepository from '#repositories/neighbouring-sites.repository.js';
 import representationRepository from '#repositories/representation.repository.js';
@@ -36,7 +37,11 @@ import formatDate, {
 } from '@pins/appeals/utils/date-formatter.js';
 import { camelToScreamingSnake } from '@pins/appeals/utils/string-case.js';
 import { EventType } from '@pins/event-client';
-import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import {
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_STATUS,
+	APPEAL_REDACTED_STATUS
+} from '@planning-inspectorate/data-model';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.Representation} Representation */
@@ -431,16 +436,8 @@ export async function publishStatements(appeal, azureAdUserId, notifyClient) {
 		throw new BackOfficeAppError('appeal in incorrect state to publish statements', 409);
 	}
 
-	const latestDocumentVersionsUpdated = await documentRepository.setRedactionStatusOnValidation(
-		appeal.id
-	);
-	for (const documentUpdated of latestDocumentVersionsUpdated) {
-		await broadcasters.broadcastDocument(
-			documentUpdated.documentGuid,
-			documentUpdated.version,
-			EventType.Update
-		);
-	}
+	markUnredactedAsNotRequired(appeal.id, appeal.reference, appeal.appealType?.key ?? '');
+
 	const statementsToPublish = [APPEAL_REPRESENTATION_TYPE.LPA_STATEMENT];
 	if (isFeatureActive(FEATURE_FLAG_NAMES.APPELLANT_STATEMENT)) {
 		statementsToPublish.push(APPEAL_REPRESENTATION_TYPE.APPELLANT_STATEMENT);
@@ -739,16 +736,7 @@ export async function publishFinalComments(appeal, azureAdUserId, notifyClient) 
 		throw new BackOfficeAppError('appeal in incorrect state to publish final comments', 409);
 	}
 
-	const latestDocumentVersionsUpdated = await documentRepository.setRedactionStatusOnValidation(
-		appeal.id
-	);
-	for (const documentUpdated of latestDocumentVersionsUpdated) {
-		await broadcasters.broadcastDocument(
-			documentUpdated.documentGuid,
-			documentUpdated.version,
-			EventType.Update
-		);
-	}
+	markUnredactedAsNotRequired(appeal.id, appeal.reference, appeal.appealType?.key ?? '');
 
 	const result = await representationRepository.updateRepresentations(
 		[appeal.id],
@@ -798,16 +786,7 @@ export async function publishProofOfEvidence(appeal, azureAdUserId, notifyClient
 		throw new BackOfficeAppError('appeal in incorrect state to publish proof of evidence', 409);
 	}
 
-	const latestDocumentVersionsUpdated = await documentRepository.setRedactionStatusOnValidation(
-		appeal.id
-	);
-	for (const documentUpdated of latestDocumentVersionsUpdated) {
-		await broadcasters.broadcastDocument(
-			documentUpdated.documentGuid,
-			documentUpdated.version,
-			EventType.Update
-		);
-	}
+	markUnredactedAsNotRequired(appeal.id, appeal.reference, appeal.appealType?.key ?? '');
 
 	const representationTypes = [
 		APPEAL_REPRESENTATION_TYPE.LPA_PROOFS_EVIDENCE,
@@ -1181,3 +1160,23 @@ export const APPEAL_REPRESENTATION_LABEL_MAP = Object.freeze({
 	[APPEAL_REPRESENTATION_TYPE.APPELLANT_PROOFS_EVIDENCE]: 'Appellant proof of evidence',
 	[APPEAL_REPRESENTATION_TYPE.RULE_6_PARTY_PROOFS_EVIDENCE]: 'Rule 6 party proof of evidence'
 });
+
+/**
+ *
+ * @param {number} appealId
+ * @param {string} appealReference
+ * @param {string} appealType
+ */
+const markUnredactedAsNotRequired = async (appealId, appealReference, appealType) => {
+	const noRedactionRequiredStatus = await commonRepository.getLookupListValueByKey(
+		'documentRedactionStatus',
+		{ key: 'key', value: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+	);
+	const updatedDocuments = await documentRepository.setRedactionStatusOnValidation(
+		appealId,
+		appealReference,
+		appealType,
+		noRedactionRequiredStatus.id
+	);
+	await broadcasters.broadcastDocuments(updatedDocuments, EventType.Update);
+};

--- a/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
+++ b/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
@@ -325,14 +325,6 @@ describe('map-document-entity', () => {
 			expectedPublishedDocumentUri: testUri
 		},
 		{
-			desc: 'representationAttachments - unknown type',
-			documentType: internalRepDocType,
-			representationType: 'SOMETHING_UNKNOWN',
-			expectedDocumentType: APPEAL_DOCUMENT_TYPE.UNCATEGORISED,
-			expectedCaseStage: APPEAL_CASE_STAGE.THIRD_PARTY_COMMENTS,
-			expectedPublishedDocumentUri: testUri
-		},
-		{
 			desc: 'other documentType',
 			documentType: 'someOtherType',
 			representationType: null,
@@ -430,6 +422,35 @@ describe('map-document-entity', () => {
 			expect(result.publishedDocumentURI).toBe(expectedPublishedDocumentUri);
 		}
 	);
+
+	test('should handle unknown doc/rep type', () => {
+		const doc = {
+			guid: 'doc-123',
+			caseId: 'case-456',
+			name: '123e4567-e89b-12d3-a456-426614174000_test.pdf',
+			case: { reference: 'REF-1', appealType: { key: APPEAL_CASE_TYPE.D } },
+			versions: [
+				{
+					version: 1,
+					originalFilename: 'test.pdf',
+					size: 1000,
+					mime: 'application/pdf',
+					documentURI: testUri,
+					fileMD5: 'md5hash',
+					dateCreated: new Date('2025-01-01T10:00:00.000Z'),
+					dateReceived: new Date('2025-01-01T11:00:00.000Z'),
+					lastModified: new Date('2025-01-01T12:00:00.000Z'),
+					documentType: internalRepDocType,
+					published: true,
+					stage: APPEAL_CASE_STAGE.THIRD_PARTY_COMMENTS,
+					redactionStatus: { key: 'NOT_REDACTED' },
+					representation: { representation: { representationType: 'SOMETHING_UNKNOWN' } }
+				}
+			]
+		};
+		const result = mapDocumentEntity(doc);
+		expect(result).toBeNull();
+	});
 });
 
 describe('mapAppellantCaseIn', () => {

--- a/appeals/api/src/server/mappers/integration/map-document-entity.js
+++ b/appeals/api/src/server/mappers/integration/map-document-entity.js
@@ -11,16 +11,41 @@ import {
 	APPEAL_CASE_STAGE,
 	APPEAL_DOCUMENT_TYPE,
 	APPEAL_ORIGIN,
-	APPEAL_REDACTED_STATUS
+	APPEAL_REDACTED_STATUS,
+	APPEAL_VIRUS_CHECK_STATUS
 } from '@planning-inspectorate/data-model';
 
-/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
-/** @typedef {import('@pins/appeals.api').Schema.Document & {appeal:Appeal}} DocumentWithAppeal */
-/** @typedef {import('@pins/appeals.api').Schema.DocumentVersion} DocumentVersion */
-/** @typedef {import('@pins/appeals.api').Schema.DocumentRedactionStatus} DocumentRedactionStatus */
 /** @typedef {import('@planning-inspectorate/data-model').Schemas.AppealDocument} AppealDocument */
-/** @typedef {import('@planning-inspectorate/data-model').Schemas.AppellantSubmissionCommand['documents'][number]} AppellantSubmissionDocument */
-/** @typedef {import('@planning-inspectorate/data-model').Schemas.LPAQuestionnaireCommand['documents'][number]} LPAQuestionnaireCommandDocument */
+/** @typedef {import('#db-client/models.ts').DocumentModel} DocumentModel */
+/** @typedef {import('#db-client/models.ts').DocumentVersionModel} DocumentVersionModel */
+/**
+ * @typedef {{
+ *   documentURI: DocumentVersionModel['documentURI'],
+ *   redactionStatus?: { key: string } | null,
+ *   representation?: { representation: { representationType: String|Null } | Null } | null,
+ *   documentType: DocumentVersionModel['documentType'],
+ *   stage: DocumentVersionModel['stage'],
+ *   version: DocumentVersionModel['version'],
+ *   originalFilename: DocumentVersionModel['originalFilename'],
+ *   size: DocumentVersionModel['size'],
+ *   mime: DocumentVersionModel['mime'],
+ *   fileMD5: DocumentVersionModel['fileMD5'],
+ *   dateCreated: DocumentVersionModel['dateCreated'],
+ *   dateReceived: DocumentVersionModel['dateReceived'],
+ *   lastModified?: DocumentVersionModel['lastModified'],
+ * 	 datePublished?: DocumentVersionModel['datePublished'],
+ *   published: DocumentVersionModel['published'],
+ *   virusCheckStatus: DocumentVersionModel['virusCheckStatus']
+ * }} DocumentVersion
+ *
+ * @typedef {{
+ *  versions: DocumentVersion[],
+ *  name: DocumentModel['name'],
+ * 	guid: DocumentModel['guid'],
+ *  caseId: DocumentModel['caseId'],
+ *  case: { reference: string, appealType: { key: string } }
+ * }} DocumentWithAppeal
+ */
 
 /**
  *
@@ -68,9 +93,7 @@ export const mapDocumentEntity = (data) => {
 			documentInput.latestDocumentVersion.lastModified ||
 				documentInput.latestDocumentVersion.dateCreated
 		),
-		caseType: isValidAppealType(documentInput.case?.appealType?.key ?? '')
-			? documentInput.case?.appealType?.key
-			: null,
+		caseType: mapCaseType(documentInput),
 		redactedStatus,
 		documentType: mapDocumentType(documentInput.latestDocumentVersion),
 		sourceSystem: ODW_SYSTEM_ID,
@@ -83,14 +106,31 @@ export const mapDocumentEntity = (data) => {
 		...publishedFields
 	};
 
-	// @ts-ignore
+	// wait to broadcast representationAttachments if document type is not known
+	if (
+		documentInput.latestDocumentVersion?.documentType === REP_ATTACHMENT_DOCTYPE &&
+		doc.documentType === APPEAL_DOCUMENT_TYPE.UNCATEGORISED
+	) {
+		return null;
+	}
+
 	return doc;
 };
 
 /**
+ * @param {DocumentWithAppeal} documentInput
+ * @returns {AppealDocument['caseType']}
+ */
+const mapCaseType = (documentInput) =>
+	isValidAppealType(documentInput.case?.appealType?.key ?? '')
+		? //@ts-ignore
+			documentInput.case?.appealType?.key
+		: null;
+
+/**
  *
  * @param {DocumentVersion} documentVersion
- * @returns {'affected'|'not_scanned'|'scanned'}
+ * @returns {AppealDocument['virusCheckStatus']}
  */
 const mapVirusCheckStatus = (documentVersion) => {
 	const status = getAvScanStatus(documentVersion);
@@ -98,7 +138,7 @@ const mapVirusCheckStatus = (documentVersion) => {
 		return status;
 	}
 
-	return 'not_scanned';
+	return APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED;
 };
 
 /** @type {Set<string>} */
@@ -114,7 +154,7 @@ const documentTypesWithManagedPublishedStatuses = new Set([
 /**
  *
  * @param {DocumentVersion} documentVersion
- * @returns {{publishedDocumentURI: string | null, datePublished: string | null}}
+ * @returns {{publishedDocumentURI: AppealDocument['publishedDocumentURI'], datePublished: AppealDocument['datePublished']}}
  */
 const mapPublishedFields = (documentVersion) => {
 	// internal only docs are never meant to be marked published
@@ -148,22 +188,23 @@ const mapPublishedFields = (documentVersion) => {
 
 /**
  *
- * @param {DocumentRedactionStatus | null} status
- * @param {string | null} documentType
- * @returns {string}
+ * @param {DocumentVersion['redactionStatus']} status
+ * @param {DocumentVersion['documentType']} documentType
+ * @returns {AppealDocument['redactedStatus']}
  */
 const mapRedactionStatus = (status, documentType) => {
 	if (documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER) {
 		return APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED;
 	}
 
+	//@ts-ignore
 	return status?.key || APPEAL_REDACTED_STATUS.NOT_REDACTED;
 };
 
 /**
  *
- * @param {string | null} stage
- * @returns {string | null}
+ * @param {DocumentVersion['stage']} stage
+ * @returns {AppealDocument['origin']}
  */
 const mapOrigin = (stage) => {
 	if (stage === APPEAL_CASE_STAGE.APPELLANT_CASE) {
@@ -181,7 +222,7 @@ const mapOrigin = (stage) => {
 /**
  *
  * @param {DocumentVersion} doc
- * @returns {string}
+ * @returns {AppealDocument['documentType']}
  */
 const mapDocumentType = (doc) => {
 	if (doc.documentType === REP_ATTACHMENT_DOCTYPE) {
@@ -210,13 +251,14 @@ const mapDocumentType = (doc) => {
 		}
 	}
 
+	//@ts-ignore
 	return doc.documentType ?? APPEAL_DOCUMENT_TYPE.UNCATEGORISED;
 };
 
 /**
  *
  * @param {DocumentVersion} doc
- * @returns {string}
+ * @returns {AppealDocument['caseStage']}
  */
 const mapStage = (doc) => {
 	if (doc.documentType === REP_ATTACHMENT_DOCTYPE) {
@@ -238,5 +280,6 @@ const mapStage = (doc) => {
 		}
 	}
 
+	//@ts-ignore
 	return doc.stage ?? APPEAL_CASE_STAGE.INTERNAL;
 };

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -432,19 +432,24 @@ const checkAppealExistsById = async (id) => {
  * @deprecated too inefficient do not use, use getAppealById with specific includes only
  * @description DO NOT USE. Gets an appeal and all it's related entities
  * @param {number} id
+ * @param {{omitDocuments: boolean|undefined, omitRepresentations: boolean|undefined}} [options]
  * @returns {Promise<Appeal|undefined>}
  */
-const deprecatedGetAppealById = async (id) => {
+const deprecatedGetAppealById = async (id, options) => {
+	const massInclude = {
+		...appealDetailsInclude,
+		...(options?.omitRepresentations && { representations: false })
+	};
 	const appeal = await databaseConnector.appeal.findUnique({
 		where: {
 			id
 		},
-		include: appealDetailsInclude
+		include: massInclude
 	});
 	if (appeal) {
 		// @ts-ignore
 		if (!appeal.folders) {
-			if (process.env.NODE_ENV === 'test') {
+			if (process.env.NODE_ENV === 'test' || options?.omitDocuments) {
 				// @ts-ignore
 				appeal.folders = [];
 			} else {

--- a/appeals/api/src/server/repositories/document.repository.js
+++ b/appeals/api/src/server/repositories/document.repository.js
@@ -14,6 +14,11 @@ import {
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateDocumentsRequest} UpdateDocumentsRequest */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateDocumentRequest} UpdateDocumentRequest */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateDocumentAvCheckRequest} UpdateDocumentAvCheckRequest */
+/** @typedef {import('#db-client/models.ts').AppealModel} AppealModel */
+/** @typedef {import('#db-client/models.ts').AppealTypeModel} AppealTypeModel */
+/** @typedef {import('#db-client/models.ts').DocumentModel} DocumentModel */
+/** @typedef {import('#db-client/models.ts').DocumentVersionModel} DocumentVersionModel */
+/** @typedef {import('#db-client/models.ts').RepresentationModel} RepresentationModel */
 
 /**
  * @param {string} guid
@@ -216,61 +221,90 @@ export const updateDocument = (latestDocument, document) => {
 };
 
 /**
- * @param {number} appealId
- * @returns {Promise<{documentGuid: string, version: number}[]>}
+ * @typedef UpdateRedactionStatusResult
+ * @property {DocumentModel['guid']} guid
+ * @property {DocumentModel['name']} name
+ * @property {DocumentVersionModel['version']} version
+ * @property {DocumentVersionModel['documentURI']} documentURI
+ * @property {DocumentVersionModel['originalFilename']} originalFilename
+ * @property {DocumentVersionModel['size']} size
+ * @property {DocumentVersionModel['mime']} mime
+ * @property {DocumentVersionModel['fileMD5']} fileMD5
+ * @property {DocumentVersionModel['virusCheckStatus']} virusCheckStatus
+ * @property {DocumentVersionModel['stage']} stage
+ * @property {DocumentVersionModel['documentType']} documentType
+ * @property {DocumentVersionModel['published']} published
+ * @property {DocumentVersionModel['datePublished']} datePublished
+ * @property {DocumentVersionModel['dateCreated']} dateCreated
+ * @property {DocumentVersionModel['dateReceived']} dateReceived
+ * @property {DocumentVersionModel['lastModified']} lastModified
+ * @property {RepresentationModel['representationType']} representationType
+
+/**
+ * @param {AppealModel['id']} appealId
+ * @param {AppealModel['reference']} appealRef
+ * @param {AppealTypeModel['key']} appealType
+ * @param {{id: Number, key: String}|Null} redactionStatus
+ * @returns {Promise<import('#mappers/integration/map-document-entity.js').DocumentWithAppeal[]>}
  */
-export const setRedactionStatusOnValidation = async (appealId) => {
-	const documentsToUpdate = await databaseConnector.documentVersion.findMany({
-		where: {
-			redactionStatusId: null,
-			document: {
-				caseId: appealId,
-				isDeleted: false
-			}
+export const setRedactionStatusOnValidation = async (
+	appealId,
+	appealRef,
+	appealType,
+	redactionStatus
+) => {
+	// can be 1000+ updates followed by a subsequent broadcast that looks them up
+	// can be done in 1 action with $queryRaw
+	/** @type {UpdateRedactionStatusResult[]} */
+	const result = await databaseConnector.$queryRaw`UPDATE dv
+		SET redactionStatusId = ${redactionStatus ? redactionStatus.id : null}
+		OUTPUT 
+			 d.guid ,d.name
+			,inserted.version ,inserted.documentURI ,inserted.originalFilename 
+			,inserted.size ,inserted.mime ,inserted.fileMD5 ,inserted.virusCheckStatus
+			,inserted.stage	,inserted.documentType ,inserted.published
+			,inserted.datePublished	,inserted.dateCreated ,inserted.dateReceived ,inserted.lastModified
+			,r.representationType
+		FROM Document d
+		JOIN DocumentVersion dv ON dv.documentGuid = d.guid	AND dv.version = d.latestVersionId
+		LEFT JOIN RepresentationAttachment ra ON ra.documentGuid = dv.documentGuid AND ra.version = dv.version
+		LEFT JOIN Representation r ON r.id = ra.representationId
+		WHERE d.caseId = ${appealId} AND d.isDeleted = 0 AND dv.redactionStatusId IS NULL`;
+
+	return result.map((doc) => ({
+		guid: doc.guid,
+		name: doc.name,
+		caseId: appealId,
+		case: {
+			appealType: { key: appealType },
+			reference: appealRef
 		},
-		select: {
-			documentGuid: true,
-			version: true,
-			document: {
-				select: {
-					latestVersionId: true
-				}
+		versions: [
+			{
+				dateCreated: doc.dateCreated,
+				dateReceived: doc.dateReceived,
+				datePublished: doc.datePublished,
+				documentType: doc.documentType,
+				documentURI: doc.documentURI,
+				fileMD5: doc.fileMD5,
+				mime: doc.mime,
+				originalFilename: doc.originalFilename,
+				published: doc.published,
+				...(redactionStatus
+					? { redactionStatus: { key: redactionStatus.key } }
+					: { redactionStatus: null }),
+				stage: doc.stage,
+				size: doc.size,
+				version: doc.version,
+				virusCheckStatus: doc.virusCheckStatus,
+				lastModified: doc.lastModified,
+				representation:
+					doc.representationType !== null
+						? { representation: { representationType: doc.representationType } }
+						: null
 			}
-		}
-	});
-
-	const redactionStatuses =
-		await documentRedactionStatusRepository.getAllDocumentRedactionStatuses();
-	const noRedactionRequiredStatus = redactionStatuses.find(
-		(redaction) => redaction.key === APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
-	);
-
-	if (!noRedactionRequiredStatus) {
-		throw new Error('No redaction status found for no redaction required');
-	}
-
-	for (const documentToUpdate of documentsToUpdate) {
-		await databaseConnector.documentVersion.update({
-			where: {
-				documentGuid_version: {
-					documentGuid: documentToUpdate.documentGuid,
-					version: documentToUpdate.version
-				}
-			},
-			data: {
-				redactionStatusId: noRedactionRequiredStatus.id
-			}
-		});
-	}
-
-	const broadcastDocuments = documentsToUpdate
-		.filter((document) => document.document?.latestVersionId === document.version)
-		.map((document) => ({
-			documentGuid: document.documentGuid,
-			version: document.version
-		}));
-
-	return broadcastDocuments;
+		]
+	}));
 };
 
 /**

--- a/appeals/api/src/server/utils/update-personal-list.js
+++ b/appeals/api/src/server/utils/update-personal-list.js
@@ -7,6 +7,8 @@ import logger from '#utils/logger.js';
 import { CASE_RELATIONSHIP_LINKED } from '@pins/appeals/constants/support.js';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+
 /**
  * Updates the PersonalList for the specified appeal
  * @param {number} appealId
@@ -15,7 +17,12 @@ import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 export const updatePersonalList = async (appealId) => {
 	// TODO: performance
 	// is returning all data, return only needed data
-	const appeal = await appealRepository.deprecatedGetAppealById(appealId);
+	/** @type {Omit<Appeal, 'documents' | 'representations'> | undefined} */
+	const appeal = await appealRepository.deprecatedGetAppealById(appealId, {
+		omitDocuments: true,
+		omitRepresentations: true
+	});
+
 	if (!appeal) {
 		return;
 	}
@@ -41,7 +48,11 @@ export const updatePersonalList = async (appealId) => {
 			// TODO: performance
 			// is returning all data, return only needed data
 			const parentAppeal = await appealRepository.deprecatedGetAppealById(
-				linkedAppeals[0].parentId
+				linkedAppeals[0].parentId,
+				{
+					omitDocuments: true,
+					omitRepresentations: true
+				}
 			);
 			if (!parentAppeal) {
 				dueDate = null;


### PR DESCRIPTION
…nce (a2-7134)

## Describe your changes

- improves performance of broadcast appeal by avoiding returning all reps, just counts by type with DB index
- improves performance of marking docs as no redaction required
  - prev: findMany + looped update + looped lookup + looped broadcast
  - now:  single udpate+lookup + batched broadcast
- calls using deprecatedGetAppealById avoid returning rep + document lookups, most expensive - quick fix, (same idea can be applied elsewhere)

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-7134
