### PR TITLE
feat(appeals): updating case decision date for reissued decision (A2-…

### DIFF
--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -1312,6 +1312,57 @@ describe('decision routes', () => {
 		});
 	});
 
+	describe('PATCH /appeals/:appealId/decision/caseDecisionOutcomeDate', () => {
+		test('returns 200 and updates the caseDecisionOutcomeDate', async () => {
+			const caseDecisionOutcomeDate = '2024-06-15T00:00:00.000Z';
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue({
+				id: householdAppeal.id,
+				reference: householdAppeal.reference
+			});
+			// @ts-ignore
+			databaseConnector.inspectorDecision.update.mockResolvedValue({
+				appealId: householdAppeal.id,
+				caseDecisionOutcomeDate
+			});
+
+			const response = await request
+				.patch(`/appeals/${householdAppeal.id}/decision/caseDecisionOutcomeDate`)
+				.send({ caseDecisionOutcomeDate })
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toBe(200);
+			expect(databaseConnector.inspectorDecision.update).toHaveBeenCalledWith({
+				where: { appealId: householdAppeal.id },
+				data: {
+					caseDecisionOutcomeDate: new Date(caseDecisionOutcomeDate)
+				}
+			});
+		});
+
+		test('returns 400 when caseDecisionOutcomeDate is in the future', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue({
+				id: householdAppeal.id,
+				reference: householdAppeal.reference
+			});
+			const tomorrow = add(new Date(), { days: 1 });
+			const utcDate = setTimeInTimeZone(tomorrow, 0, 0);
+
+			const response = await request
+				.patch(`/appeals/${householdAppeal.id}/decision/caseDecisionOutcomeDate`)
+				.send({ caseDecisionOutcomeDate: utcDate.toISOString() })
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toBe(400);
+			expect(response.body).toEqual({
+				errors: {
+					caseDecisionOutcomeDate: ERROR_MUST_NOT_BE_IN_FUTURE
+				}
+			});
+		});
+	});
+
 	describe('sendNewDecisionLetter', () => {
 		let mockNotifyClient;
 		let correctAppealState;

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -1,5 +1,7 @@
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import appealRepository from '#repositories/appeal.repository.js';
+import { updateAppealCaseDecisionOutcomeDate } from '#repositories/decision.repository.js';
 import { isCurrentStatus } from '#utils/current-status.js';
 import {
 	DECISION_TYPE_APPELLANT_COSTS,
@@ -129,4 +131,26 @@ export const postInspectorDecision = async (req, res) => {
 	const decision = results.find((result) => !!result?.documentType) ?? null;
 
 	return res.status(201).send(decision);
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const patchCaseDecisionOutcomeDate = async (req, res) => {
+	const {
+		params: { appealId },
+		body: { caseDecisionOutcomeDate }
+	} = req;
+
+	const decision = await updateAppealCaseDecisionOutcomeDate(
+		Number(appealId),
+		new Date(caseDecisionOutcomeDate)
+	);
+
+	// update the decision date on FO too (appeal broadcast includes the inspector decision)
+	await broadcasters.broadcastAppeal(Number(appealId));
+
+	return res.status(200).send(decision);
 };

--- a/appeals/api/src/server/endpoints/decision/decision.routes.js
+++ b/appeals/api/src/server/endpoints/decision/decision.routes.js
@@ -1,8 +1,16 @@
-import { checkAppealExistsByIdAndAddPartialToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
+import {
+	checkAppealExistsById,
+	checkAppealExistsByIdAndAddPartialToRequest
+} from '#middleware/check-appeal-exists-and-add-to-request.js';
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
-import { postDecisionPreview, postInspectorDecision } from './decision.controller.js';
 import {
+	patchCaseDecisionOutcomeDate,
+	postDecisionPreview,
+	postInspectorDecision
+} from './decision.controller.js';
+import {
+	getCaseDecisionOutcomeDateValidator,
 	getDateValidator,
 	getDecisionsValidator,
 	getDecisionTypeValidator,
@@ -95,6 +103,35 @@ router.post(
 	getDocumentValidator,
 	getInvalidDecisionReasonValidator,
 	asyncHandler(postInspectorDecision)
+);
+
+router.patch(
+	/*
+	#swagger.tags = ['Decision']
+	#swagger.path = '/appeals/{appealId}/decision/caseDecisionOutcomeDate'
+	#swagger.description = Updates the caseDecisionOutcomeDate on an appeal decision
+	#swagger.parameters['azureAdUserId'] = {
+		in: 'header',
+		required: true,
+		example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+	}
+	#swagger.requestBody = {
+		in: 'body',
+		description: 'caseDecisionOutcomeDate',
+		schema: { $ref: '#/components/schemas/caseDecisionOutcomeDateChangeRequest' },
+		required: true
+	}
+	#swagger.responses[201] = {
+		description: 'Gets the decision info or null',
+		schema: { $ref: '#/components/schemas/DecisionInfo' }
+	}
+	#swagger.responses[400] = {}
+	#swagger.responses[404] = {}
+ */
+	'/:appealId/decision/caseDecisionOutcomeDate',
+	checkAppealExistsById,
+	getCaseDecisionOutcomeDateValidator,
+	asyncHandler(patchCaseDecisionOutcomeDate)
 );
 
 export { router as decisionRoutes };

--- a/appeals/api/src/server/endpoints/decision/decision.validator.js
+++ b/appeals/api/src/server/endpoints/decision/decision.validator.js
@@ -42,6 +42,14 @@ const getDateValidator = composeMiddleware(
 	})
 );
 
+const getCaseDecisionOutcomeDateValidator = composeMiddleware(
+	validateDateParameter({
+		parameterName: 'caseDecisionOutcomeDate',
+		mustBeNotBeFutureDate: true
+	}),
+	validationErrorHandler
+);
+
 const getDocumentValidator = composeMiddleware(
 	body('decisions.*.documentGuid').optional().isUUID().withMessage(ERROR_MUST_BE_UUID),
 	validationErrorHandler
@@ -53,6 +61,7 @@ const getInvalidDecisionReasonValidator = composeMiddleware(
 );
 
 export {
+	getCaseDecisionOutcomeDateValidator,
 	getDateValidator,
 	getDecisionsValidator,
 	getDecisionTypeValidator,

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -372,6 +372,11 @@ export interface DecisionInfo {
 	}[];
 }
 
+export interface CaseDecisionOutcomeDateChangeRequest {
+	/** @example "2024-11-10T00:00:00.000Z" */
+	caseDecisionOutcomeDate?: string;
+}
+
 export interface OldDecisionInfo {
 	/** @example "allowed" */
 	outcome?: string;

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -3099,6 +3099,71 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/decision/caseDecisionOutcomeDate": {
+			"patch": {
+				"tags": ["Decision"],
+				"description": "Updates the caseDecisionOutcomeDate on an appeal decision",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Gets the decision info or null",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DecisionInfo"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/DecisionInfo"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "caseDecisionOutcomeDate",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/caseDecisionOutcomeDateChangeRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/caseDecisionOutcomeDateChangeRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/appellant-cases/{appellantCaseId}": {
 			"get": {
 				"tags": ["Appellant Cases"],
@@ -9678,6 +9743,18 @@
 				},
 				"xml": {
 					"name": "DecisionInfo"
+				}
+			},
+			"caseDecisionOutcomeDateChangeRequest": {
+				"type": "object",
+				"properties": {
+					"caseDecisionOutcomeDate": {
+						"type": "string",
+						"example": "2024-11-10T00:00:00.000Z"
+					}
+				},
+				"xml": {
+					"name": "caseDecisionOutcomeDateChangeRequest"
 				}
 			},
 			"OldDecisionInfo": {

--- a/appeals/api/src/server/repositories/decision.repository.js
+++ b/appeals/api/src/server/repositories/decision.repository.js
@@ -19,3 +19,17 @@ export const updateAppealDecisionLetter = (appealId, documentGuid) => {
 		}
 	});
 };
+
+/**
+ * @param {number} appealId
+ * @param {Date} caseDecisionOutcomeDate
+ * @returns {PrismaPromise<InspectorDecision>}
+ */
+export const updateAppealCaseDecisionOutcomeDate = (appealId, caseDecisionOutcomeDate) => {
+	return databaseConnector.inspectorDecision.update({
+		where: { appealId },
+		data: {
+			caseDecisionOutcomeDate
+		}
+	});
+};

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -116,6 +116,9 @@ export const spec = {
 				}
 			]
 		},
+		caseDecisionOutcomeDateChangeRequest: {
+			caseDecisionOutcomeDate: '2024-11-10T00:00:00.000Z'
+		},
 		//ToDo: Remove once the new version of issue decisions is released
 		OldDecisionInfo: {
 			outcome: 'allowed',

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -6043,7 +6043,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
     <div class="govuk-inset-text">
         <ul class="govuk-list">
             <li>Decision: Dismissed</li>
-            <li>Decision issued on 4 August 2023 (reissued on 11 October 2023)</li>
+            <li>Decision issued on 25 December 2023</li>
             <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a>
             </li>
         </ul>
@@ -6402,7 +6402,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
     <div class="govuk-inset-text">
         <ul class="govuk-list">
             <li>Decision: Dismissed</li>
-            <li>Decision issued on 4 August 2023 (reissued on 11 October 2023)</li>
+            <li>Decision issued on 25 December 2023</li>
             <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a>
             </li>
         </ul>
@@ -8556,7 +8556,7 @@ exports[`appeal-details GET /:appealId should render the view decision page 1`] 
                         <dd class="govuk-summary-list__value">Dismissed</dd>
                     </div>
                     <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Decision issue date</dt>
-                        <dd class="govuk-summary-list__value">4 August 2023 (reissued on 11 October 2023)</dd>
+                        <dd class="govuk-summary-list__value">25 December 2023</dd>
                     </div>
                     <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
                         <dd class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/1/download/e1e90a49-fab3-44b8-a21a-bb73af089f6b/decision-letter.pdf"

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2777,9 +2777,7 @@ describe('appeal-details', () => {
 				rootElement: '.govuk-inset-text'
 			}).innerHTML;
 			expect(insetTextElementHTML).toContain('<li>Decision: Dismissed</li>');
-			expect(insetTextElementHTML).toContain(
-				'<li>Decision issued on 4 August 2023 (reissued on 11 October 2023)</li>'
-			);
+			expect(insetTextElementHTML).toContain('<li>Decision issued on 25 December 2023</li>');
 			expect(insetTextElementHTML).toContain(
 				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a></li>'
 			);
@@ -2809,9 +2807,7 @@ describe('appeal-details', () => {
 				rootElement: '.govuk-inset-text'
 			}).innerHTML;
 			expect(insetTextElementHTML).toContain('<li>Decision: Dismissed</li>');
-			expect(insetTextElementHTML).toContain(
-				'<li>Decision issued on 4 August 2023 (reissued on 11 October 2023)</li>'
-			);
+			expect(insetTextElementHTML).toContain('<li>Decision issued on 25 December 2023</li>');
 			expect(insetTextElementHTML).toContain(
 				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a></li>'
 			);
@@ -2896,7 +2892,7 @@ describe('appeal-details', () => {
 
 			const innerHTML = parseHtml(response.text).innerHTML;
 			expect(innerHTML).toContain('Dismissed');
-			expect(innerHTML).toContain('4 August 2023 (reissued on 11 October 2023)');
+			expect(innerHTML).toContain('25 December 2023');
 			expect(innerHTML).toContain(
 				'download href="/documents/1/download/e1e90a49-fab3-44b8-a21a-bb73af089f6b/decision-letter.pdf'
 			);

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
@@ -1926,9 +1926,7 @@ describe('issue-decision', () => {
 
 			expect(unprettifiedElement.innerHTML).toContain('LPA costs decision letter</dt>');
 			expect(unprettifiedElement.innerHTML).toContain('lpa-costs-decision-letter.pdf</a>');
-			expect(unprettifiedElement.innerHTML).toContain(
-				'4 August 2023 (reissued on 11 October 2023)'
-			);
+			expect(unprettifiedElement.innerHTML).toContain('25 December 2023');
 		});
 
 		it('should render the view decision page for a linked lead appeal', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -31,7 +31,7 @@ import {
 } from '#appeals/appeal-documents/appeal.documents.service.js';
 import { isFeatureActive } from '#common/feature-flags.js';
 import { isStatePassed } from '#lib/appeal-status.js';
-import { getOriginalAndLatestLetterDatesObject, getTodaysISOString } from '#lib/dates.js';
+import { dateISOStringToDisplayDate, getTodaysISOString } from '#lib/dates.js';
 import { detailsComponent } from '#lib/mappers/components/page-components/details.js';
 import { preHeadingText } from '#lib/mappers/utils/appeal-preheading.js';
 import { mapFileUploadInfoToMappedDocuments } from '#lib/mappers/utils/file-upload-info-to-documents.js';
@@ -890,18 +890,26 @@ export const renderViewDecision = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
-	let letterDateObject = await getOriginalAndLatestLetterDatesObject(
-		apiClient,
-		currentAppeal.decision.documentId || '',
-		currentAppeal
-	);
+	// the following commented out logic has been left here in case it is useful when work around slip rules
+	// and showing reissued dates is done
+
+	// let letterDateObject = await getOriginalAndLatestLetterDatesObject(
+	// 	apiClient,
+	// 	currentAppeal.decision.documentId || '',
+	// 	currentAppeal
+	// );
 	let latestDecisionDocumentText;
 
 	if (currentAppeal.decision?.outcome) {
-		latestDecisionDocumentText =
-			letterDateObject.latestFileVersion && letterDateObject.latestFileVersion?.version > 1
-				? `${letterDateObject.originalLetterDate} (reissued on ${letterDateObject.latestLetterDate})`
-				: `${letterDateObject.originalLetterDate}`;
+		latestDecisionDocumentText = `${dateISOStringToDisplayDate(currentAppeal.decision.letterDate)}`;
+
+		// the following commented out logic has been left here in case it is useful when work around slip rules
+		// and showing reissued dates is done
+
+		// latestDecisionDocumentText =
+		// 	letterDateObject.latestFileVersion && letterDateObject.latestFileVersion?.version > 1
+		// 		? `${letterDateObject.originalLetterDate} (reissued on ${letterDateObject.latestLetterDate})`
+		// 		: `${letterDateObject.originalLetterDate}`;
 	}
 
 	if (currentAppeal.isChildAppeal) {

--- a/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
@@ -1,6 +1,6 @@
 import { mapVirusCheckStatus } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { isStatePassed } from '#lib/appeal-status.js';
-import { dateISOStringToDisplayDate, getOriginalAndLatestLetterDatesObject } from '#lib/dates.js';
+import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { isLinkedAppealsActive } from '#lib/mappers/utils/is-linked-appeal.js';
 import { renderPageComponentsToHtml } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
@@ -66,11 +66,14 @@ export const generateStatusTags = async (mappedData, appealDetails, request) => 
 				appealDetails.costs.appellantDecisionFolder?.documents?.length ||
 				appealDetails.costs.lpaDecisionFolder?.documents?.length))
 	) {
-		let letterDateObject = await getOriginalAndLatestLetterDatesObject(
-			request.apiClient,
-			appealDetails.decision.documentId || '',
-			appealDetails
-		);
+		// the following commented out logic has been left here in case it is useful when work around slip rules
+		// and showing reissued dates is done
+
+		// let letterDateObject = await getOriginalAndLatestLetterDatesObject(
+		// 	request.apiClient,
+		// 	appealDetails.decision.documentId || '',
+		// 	appealDetails
+		// );
 
 		const insetTextRows = [];
 
@@ -79,9 +82,14 @@ export const generateStatusTags = async (mappedData, appealDetails, request) => 
 				`Decision: ${decisionOutcomeToDisplayText(appealDetails.decision.outcome, appealDetails.appealType)}`
 			);
 			insetTextRows.push(
-				letterDateObject.latestFileVersion && letterDateObject.latestFileVersion?.version > 1
-					? `Decision issued on ${letterDateObject.originalLetterDate} (reissued on ${letterDateObject.latestLetterDate})`
-					: `Decision issued on ${letterDateObject.latestLetterDate}`
+				`Decision issued on ${dateISOStringToDisplayDate(appealDetails.decision.letterDate)}`
+
+				// the following commented out logic has been left here in case it is useful when work around slip rules
+				// and showing reissued dates is done
+
+				// letterDateObject.latestFileVersion && letterDateObject.latestFileVersion?.version > 1
+				// 	? `Decision issued on ${letterDateObject.originalLetterDate} (reissued on ${letterDateObject.latestLetterDate})`
+				// 	: `Decision issued on ${letterDateObject.latestLetterDate}`
 			);
 		} else if (isAppealInvalid) {
 			const invalidDate = await getInvalidStatusCreatedDate(

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
@@ -331,10 +331,17 @@ describe('update-decision-letter', () => {
 			expect(correctionNoticeResponse.statusCode).toBe(302);
 
 			let capturedApiBody;
+			let capturedCaseDecisionOutcomeDateBody;
 			nock('http://test/')
 				.post('/appeals/1/documents/e1e90a49-fab3-44b8-a21a-bb73af089f6b')
 				.reply(200, function (_, body) {
 					capturedApiBody = body;
+					return { success: true };
+				});
+			nock('http://test/')
+				.patch('/appeals/1/decision/caseDecisionOutcomeDate')
+				.reply(200, function (_, body) {
+					capturedCaseDecisionOutcomeDateBody = body;
 					return { success: true };
 				});
 
@@ -344,6 +351,9 @@ describe('update-decision-letter', () => {
 
 			expect(response.statusCode).toBe(302);
 			expect(capturedApiBody.document.receivedDate).toBe('2026-01-02T00:00:00.000Z');
+			expect(capturedCaseDecisionOutcomeDateBody.caseDecisionOutcomeDate).toBe(
+				'2026-01-02T00:00:00.000Z'
+			);
 		});
 
 		it('should render the view-decision page after submit', async () => {
@@ -352,6 +362,9 @@ describe('update-decision-letter', () => {
 
 			nock('http://test/')
 				.post('/appeals/1/documents/e1e90a49-fab3-44b8-a21a-bb73af089f6b')
+				.reply(200, { success: true });
+			nock('http://test/')
+				.patch('/appeals/1/decision/caseDecisionOutcomeDate')
 				.reply(200, { success: true });
 
 			const response = await request

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
@@ -15,6 +15,7 @@ import config from '@pins/appeals.web/environment/config.js';
 import { FEEDBACK_FORM_LINKS } from '@pins/appeals/constants/common.js';
 import { getTeamFromAppealId } from '../update-case-team/update-case-team.service.js';
 import { correctionNoticePage } from './update-decision-letter.mapper.js';
+import { updateCaseDecisionOutcomeDate } from './update-decision-letter.service.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getCorrectionNotice = async (request, response) => {
@@ -250,6 +251,8 @@ export const postUpdateDocumentCheckDetails = async (request, response) => {
 			currentDecision.documentId,
 			addDocumentVersionRequestPayload
 		);
+
+		await updateCaseDecisionOutcomeDate(request.apiClient, appealId, uploadInfo.receivedDate);
 
 		addNotificationBannerToSession({
 			session: request.session,

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.service.js
@@ -1,0 +1,14 @@
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} caseDecisionOutcomeDate
+ * @returns {Promise<{}>}
+ */
+export function updateCaseDecisionOutcomeDate(apiClient, appealId, caseDecisionOutcomeDate) {
+	return apiClient
+		.patch(`appeals/${appealId}/decision/caseDecisionOutcomeDate`, {
+			json: { caseDecisionOutcomeDate }
+		})
+		.json()
+		.catch((error) => error?.response?.body || error);
+}


### PR DESCRIPTION
…8607) (A2-8653)

## Describe your changes

- Adding new endpoint to change the `caseDecisionOutcomeDate`
- Using the endpoint when reissuing a decision
- Changing the logic on the display to remove the 'reissued' date section (left in and commented as it has been indicated that it may want to be added back in in the future)
- Tests for the above (note that the slightly odd date change in the appeal-details test is due to that being the value of letterDate which is set in the mock data)

### Tested locally

- Tested that reissuing the decision updates the date
- Checked that an appeal with a decision previously reissued shows the correct decision date on BO

### Tested in dev
- Checked that reissuing the decision updates the date in both FO and BO

## Issue ticket number and link

[Broadcasting the correct date to FO ticket](https://pins-ds.atlassian.net/browse/A2-8653)
[Changing display on BO ticket](https://pins-ds.atlassian.net/browse/A2-8607)
