### PR TITLE
fix(appeals): default procedure type on personal list (A2-8927)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1856,6 +1856,7 @@ describe('appeals list routes', () => {
 								postCode: ''
 							},
 							appealStatus: '',
+							procedureType: 'Written',
 							completedStateList: householdAppeal.completedStateList,
 							localPlanningDepartment: '',
 							lpaQuestionnaireId: null,
@@ -1936,6 +1937,7 @@ describe('appeals list routes', () => {
 								postCode: ''
 							},
 							appealStatus: '',
+							procedureType: 'Written',
 							completedStateList: householdAppeal.completedStateList,
 							localPlanningDepartment: '',
 							lpaQuestionnaireId: null,

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -1,3 +1,4 @@
+import { mapProcedureType } from '#mappers/api/shared/map-procedure-type.js';
 import { completedStateList, currentStatus } from '#utils/current-status.js';
 import formatAddress from '#utils/format-address.js';
 import { formatCostsDecision } from '#utils/format-costs-decision.js';
@@ -109,7 +110,7 @@ const formatPersonalListItem = async ({
 		appealStatus,
 		completedStateList: completedStateList(appeal),
 		appealType: appealType?.type,
-		procedureType: procedureType?.name,
+		procedureType: mapProcedureType({ appeal: { procedureType: procedureType } }),
 		createdAt: appeal.caseCreatedDate,
 		localPlanningDepartment: appeal.lpa?.name || '',
 		lpaQuestionnaireId: lpaQuestionnaire?.id ?? null,

--- a/appeals/api/src/server/mappers/api/shared/map-procedure-type.js
+++ b/appeals/api/src/server/mappers/api/shared/map-procedure-type.js
@@ -3,7 +3,7 @@
 
 /**
  *
- * @param {MappingRequest} data
+ * @param {{appeal: { procedureType?: { name?: string } | null }}} data
  * @returns {string}
  */
 export const mapProcedureType = (data) => {


### PR DESCRIPTION
## Describe your changes

Defaults personal list mapping for procedure type to written as per appeal details
getNextStateOnStatementsComplete fails without a procedure type defined

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-8927
