### PR TITLE
fix(appeals): default procedure type on personal list (A2-8927)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1809,6 +1809,7 @@ describe('appeals list routes', () => {
 					items: [
 						{
 							appealId: 3,
+							procedureType: 'Written',
 							completedStateList: householdAppeal.completedStateList,
 							lpaQuestionnaireId: null,
 							documentationSummary: {
@@ -1882,6 +1883,7 @@ describe('appeals list routes', () => {
 						},
 						{
 							appealId: 4,
+							procedureType: 'Written',
 							completedStateList: householdAppeal.completedStateList,
 							lpaQuestionnaireId: null,
 							documentationSummary: {

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -1,3 +1,4 @@
+import { mapProcedureType } from '#mappers/api/shared/map-procedure-type.js';
 import { completedStateList } from '#utils/current-status.js';
 import formatAddress from '#utils/format-address.js';
 import { formatCostsDecision } from '#utils/format-costs-decision.js';
@@ -101,7 +102,7 @@ const formatPersonalListItem = async ({
 		appealStatus,
 		completedStateList: completedStateList(appeal),
 		appealType: appealType?.type,
-		procedureType: procedureType?.name,
+		procedureType: mapProcedureType({ appeal: { procedureType: procedureType } }),
 		lpaQuestionnaireId: lpaQuestionnaire?.id ?? null,
 		documentationSummary: formatDocumentationSummary(appeal),
 		dueDate,

--- a/appeals/api/src/server/mappers/api/shared/map-procedure-type.js
+++ b/appeals/api/src/server/mappers/api/shared/map-procedure-type.js
@@ -2,8 +2,7 @@
 /** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
 
 /**
- *
- * @param {MappingRequest} data
+ * @param {{appeal: { procedureType?: { name?: string } | null }}} data
  * @returns {string}
  */
 export const mapProcedureType = (data) => {


### PR DESCRIPTION
## Describe your changes

Defaults personal list mapping for procedure type to written as per appeal details
getNextStateOnStatementsComplete fails without a procedure type defined

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-8927
