### PR TITLE
feat(appeals): add notify for enforseenmt hearing - Statements and IP comments to share (A2-8842)

### DIFF
--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -435,6 +435,26 @@ const newS78Appeals = [
 		agent: false
 	}),
 	appealFactory({
+		typeShorthand: APPEAL_CASE_TYPE.C,
+		procedureType: APPEAL_CASE_PROCEDURE.HEARING,
+		status: { status: APPEAL_CASE_STATUS.STATEMENTS, createdAt: getPastDate({ months: 6 }) },
+		lpaQuestionnaire: true,
+		startedAt: getPastDate({ months: 2 }),
+		validAt: getPastDate({ months: 6 }),
+		assignCaseOfficer: true,
+		agent: false
+	}),
+	appealFactory({
+		typeShorthand: APPEAL_CASE_TYPE.X,
+		procedureType: APPEAL_CASE_PROCEDURE.HEARING,
+		status: { status: APPEAL_CASE_STATUS.STATEMENTS, createdAt: getPastDate({ months: 6 }) },
+		lpaQuestionnaire: true,
+		startedAt: getPastDate({ months: 2 }),
+		validAt: getPastDate({ months: 6 }),
+		assignCaseOfficer: true,
+		agent: false
+	}),
+	appealFactory({
 		typeShorthand: APPEAL_CASE_TYPE.W,
 		status: { status: APPEAL_CASE_STATUS.STATEMENTS, createdAt: getPastDate({ months: 6 }) },
 		lpaQuestionnaire: true,

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -3419,6 +3419,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: null,
 						team_email_address: expect.any(String)
 					},
@@ -3433,6 +3434,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: null,
 						team_email_address: expect.any(String)
 					},
@@ -3497,6 +3499,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: null,
 						team_email_address: expect.any(String)
 					},
@@ -3511,6 +3514,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: null,
 						team_email_address: expect.any(String)
 					},
@@ -3577,11 +3581,17 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: null,
+						hearing_time: null,
+						hearing_expected_days: '',
+						inspector_name: undefined,
+						hearing_address: '',
+						final_comments_due_date: expect.any(String),
 						team_email_address: expect.any(String)
 					},
 					recipientEmail: mockLdcAppeal.lpa.email,
-					templateName: 'publish-statements-hearing-lpa'
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
 				});
 
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
@@ -3591,11 +3601,17 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: null,
+						hearing_time: null,
+						hearing_expected_days: '',
+						inspector_name: undefined,
+						hearing_address: '',
+						final_comments_due_date: expect.any(String),
 						team_email_address: expect.any(String)
 					},
-					recipientEmail: mockLdcAppeal.agent.email,
-					templateName: 'publish-statements-hearing-appellant'
+					recipientEmail: 'test@136s7.com',
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
 				});
 			});
 
@@ -3661,6 +3677,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						team_email_address: expect.any(String)
 					},
 					recipientEmail: appealS78.lpa.email,
@@ -3674,6 +3691,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						team_email_address: expect.any(String)
 					},
 					recipientEmail: appealS78.appellant.email,
@@ -3741,6 +3759,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						team_email_address: expect.any(String)
 					},
 					recipientEmail: appealS78.lpa.email,
@@ -3754,6 +3773,7 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						team_email_address: expect.any(String)
 					},
 					recipientEmail: appealS78.appellant.email,
@@ -3821,11 +3841,17 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: '31 January 2025',
+						hearing_time: '12:00am',
+						hearing_expected_days: '',
+						inspector_name: undefined,
+						hearing_address: '',
+						final_comments_due_date: expect.any(String),
 						team_email_address: expect.any(String)
 					},
 					recipientEmail: mockLdcAppeal.lpa.email,
-					templateName: 'publish-statements-hearing-lpa'
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
 				});
 
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
@@ -3835,11 +3861,235 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_lpa_statement: true,
+						front_office_url: expect.any(String),
 						hearing_date: '31 January 2025',
+						hearing_time: '12:00am',
+						hearing_expected_days: '',
+						inspector_name: undefined,
+						hearing_address: '',
+						final_comments_due_date: expect.any(String),
 						team_email_address: expect.any(String)
 					},
-					recipientEmail: mockLdcAppeal.agent.email,
-					templateName: 'publish-statements-hearing-appellant'
+					recipientEmail: 'test@136s7.com',
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
+				});
+			});
+
+			test('send notify comments and statements (hearing) enforcement appeal', async () => {
+				const expectedSiteAddress = [
+					'addressLine1',
+					'addressLine2',
+					'addressTown',
+					'addressCounty',
+					'postcode',
+					'addressCountry'
+				]
+					.map((key) => mockEnforcementNoticeAppeal.address[key])
+					.filter((value) => value)
+					.join(', ');
+
+				const expectedEmailPayload = {
+					lpa_reference: '',
+					enforcement_reference: 'ENF-12345',
+					appeal_reference_number: mockEnforcementNoticeAppeal.reference,
+					final_comments_due_date: '29 December 2019',
+					site_address: expectedSiteAddress
+				};
+
+				const appeal = {
+					...mockEnforcementNoticeAppeal,
+					currentStatus: 'statements',
+					procedureType: {
+						id: 1,
+						key: 'hearing',
+						name: 'Hearing'
+					},
+					appealTimetable: {
+						ipCommentsDueDate: new Date('2019-12-29T23:59:00.000Z'),
+						lpaStatementDueDate: new Date('2019-12-29T23:59:00.000Z'),
+						finalCommentsDueDate: new Date('2019-12-29T23:59:00.000Z')
+					},
+					appealRule6Parties: [],
+					appellantCase: {
+						...mockEnforcementNoticeAppeal.appellantCase,
+						enforcementReference: 'ENF-12345'
+					},
+					applicationReference: undefined,
+					hearing: {
+						hearingStartTime: new Date('2025-01-31T10:00:00.000Z'),
+						estimatedDays: 2,
+						address: mockEnforcementNoticeAppeal.address
+					},
+					inspector: {
+						id: 1,
+						name: 'Smith, John'
+					}
+				};
+
+				databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
+				databaseConnector.appealStatus.create.mockResolvedValue({});
+				databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
+				databaseConnector.representation.findMany.mockResolvedValue([
+					{ representationType: 'lpa_statement' },
+					{ representationType: 'comment' }
+				]);
+				databaseConnector.representation.updateMany.mockResolvedValue([]);
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+				]);
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post('/appeals/1/reps/publish')
+					.query({ type: 'statements' })
+					.set('azureAdUserId', '732652365');
+
+				expect(response.status).toEqual(200);
+
+				expect(mockNotifySend).toHaveBeenCalledTimes(2);
+
+				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
+					azureAdUserId: expect.anything(),
+					notifyClient: expect.anything(),
+					personalisation: {
+						...expectedEmailPayload,
+						has_ip_comments: true,
+						has_lpa_statement: true,
+						front_office_url: expect.any(String),
+						hearing_date: '31 January 2025',
+						hearing_time: '10:00am',
+						hearing_expected_days: 2,
+						inspector_name: undefined,
+						hearing_address: expectedSiteAddress,
+						team_email_address: expect.any(String)
+					},
+					recipientEmail: mockEnforcementNoticeAppeal.lpa.email,
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
+				});
+
+				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
+					azureAdUserId: expect.anything(),
+					notifyClient: expect.anything(),
+					personalisation: {
+						...expectedEmailPayload,
+						has_ip_comments: true,
+						has_lpa_statement: true,
+						front_office_url: expect.any(String),
+						hearing_date: '31 January 2025',
+						hearing_time: '10:00am',
+						hearing_expected_days: 2,
+						inspector_name: undefined,
+						hearing_address: expectedSiteAddress,
+						team_email_address: expect.any(String)
+					},
+					recipientEmail: 'test@136s7.com',
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
+				});
+			});
+
+			test('sends notify emails to LPA and appellant for LDC appeal when ip comments and statements are received (hearing)', async () => {
+				const expectedSiteAddress = [
+					'addressLine1',
+					'addressLine2',
+					'addressTown',
+					'addressCounty',
+					'postcode',
+					'addressCountry'
+				]
+					.map((key) => ldcAppeal.address[key])
+					.filter((value) => value)
+					.join(', ');
+
+				const expectedEmailPayload = {
+					lpa_reference: ldcAppeal.applicationReference,
+					appeal_reference_number: ldcAppeal.reference,
+					final_comments_due_date: '29 December 2019',
+					site_address: expectedSiteAddress
+				};
+
+				const appeal = {
+					...ldcAppeal,
+					currentStatus: 'statements',
+					procedureType: {
+						id: 1,
+						key: 'hearing',
+						name: 'Hearing'
+					},
+					appealTimetable: {
+						ipCommentsDueDate: new Date('2019-12-29T23:59:00.000Z'),
+						lpaStatementDueDate: new Date('2019-12-29T23:59:00.000Z'),
+						finalCommentsDueDate: new Date('2019-12-29T23:59:00.000Z')
+					},
+					appealRule6Parties: [],
+					hearing: {
+						hearingStartTime: new Date('2025-01-31T10:00:00.000Z'),
+						estimatedDays: 2,
+						address: ldcAppeal.address
+					},
+					inspector: {
+						id: 1,
+						name: 'Smith, John'
+					}
+				};
+
+				databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
+				databaseConnector.appealStatus.create.mockResolvedValue({});
+				databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
+				databaseConnector.representation.findMany.mockResolvedValue([
+					{ representationType: 'lpa_statement' },
+					{ representationType: 'comment' }
+				]);
+				databaseConnector.representation.updateMany.mockResolvedValue([]);
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+				]);
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post('/appeals/1/reps/publish')
+					.query({ type: 'statements' })
+					.set('azureAdUserId', '732652365');
+
+				expect(response.status).toEqual(200);
+
+				expect(mockNotifySend).toHaveBeenCalledTimes(2);
+
+				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
+					azureAdUserId: expect.anything(),
+					notifyClient: expect.anything(),
+					personalisation: {
+						...expectedEmailPayload,
+						has_ip_comments: true,
+						has_lpa_statement: true,
+						front_office_url: expect.any(String),
+						hearing_date: '31 January 2025',
+						hearing_time: '10:00am',
+						hearing_expected_days: 2,
+						inspector_name: undefined,
+						hearing_address: expectedSiteAddress,
+						team_email_address: expect.any(String)
+					},
+					recipientEmail: ldcAppeal.lpa.email,
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
+				});
+
+				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
+					azureAdUserId: expect.anything(),
+					notifyClient: expect.anything(),
+					personalisation: {
+						...expectedEmailPayload,
+						has_ip_comments: true,
+						has_lpa_statement: true,
+						front_office_url: expect.any(String),
+						hearing_date: '31 January 2025',
+						hearing_time: '10:00am',
+						hearing_expected_days: 2,
+						inspector_name: undefined,
+						hearing_address: expectedSiteAddress,
+						team_email_address: expect.any(String)
+					},
+					recipientEmail: 'test@136s7.com',
+					templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments'
 				});
 			});
 

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -615,42 +615,59 @@ const sendPublishedStatementNotifiesForHearing = async (
 		(rep) => rep.representationType === APPEAL_REPRESENTATION_TYPE.COMMENT
 	);
 
+	const isEnforcementOrLdc = isLdcOrEnforcementCaseType(appeal.appealType?.key);
+	const isEnforcementYesStatementsYesComments =
+		isEnforcementOrLdc && hasLpaStatement && hasIpComments;
+	const isEnforcementNoStatementsNoComments =
+		isEnforcementOrLdc && !hasLpaStatement && !hasIpComments;
+	const includeFrontOfficeUrl = !isEnforcementNoStatementsNoComments;
+
 	const lpaPath = `${config.frontOffice.url}/manage-appeals/${appeal.reference}`;
 	const appellantPath = `${config.frontOffice.url}/appeals/${appeal.reference}`;
 
 	const hearingDate = appeal.hearing?.hearingStartTime
 		? dateISOStringToDisplayDate(appeal.hearing.hearingStartTime)
 		: null;
-
 	const hearingTime = appeal.hearing?.hearingStartTime
-		? formatTime12h(appeal.hearing.hearingStartTime)
+		? formatTime12h(
+				typeof appeal.hearing.hearingStartTime === 'string'
+					? new Date(appeal.hearing.hearingStartTime)
+					: appeal.hearing.hearingStartTime
+			)
 		: null;
-
+	const hearingExpectedDays = appeal.hearing?.estimatedDays ?? '';
 	const hearingAddress = appeal.hearing?.address
 		? formatAddressSingleLine(appeal.hearing.address)
 		: '';
 
-	const hearingExpectedDays = appeal.hearing?.estimatedDays?.toString() || '';
+	const finalCommentsDueDate = formatDate(
+		new Date(appeal.appealTimetable?.finalCommentsDueDate || ''),
+		false
+	);
 
 	let lpaTemplate = '';
 	let appellantTemplate = '';
-	const appealTypeKey = /** @type {any} */ (appeal?.appealType?.key ?? '');
 	let additionalEmailValues = {};
 
-	if (isLdcOrEnforcementCaseType(appealTypeKey)) {
-		if (!hasLpaStatement && !hasIpComments) {
-			lpaTemplate = 'publish-statements-enforcement-hearing-no-statements-no-comments';
-			appellantTemplate = 'publish-statements-enforcement-hearing-no-statements-no-comments';
-			additionalEmailValues = {
-				hearing_address: hearingAddress,
-				inspector_name: inspectorName,
-				hearing_expected_days: hearingExpectedDays,
-				hearing_time: hearingTime
-			};
-		} else {
-			lpaTemplate = 'publish-statements-hearing-lpa';
-			appellantTemplate = 'publish-statements-hearing-appellant';
-		}
+	if (isEnforcementYesStatementsYesComments) {
+		lpaTemplate = 'publish-statements-enforcement-hearing-yes-statements-yes-comments';
+		appellantTemplate = 'publish-statements-enforcement-hearing-yes-statements-yes-comments';
+		additionalEmailValues = {
+			hearing_time: hearingTime,
+			hearing_expected_days: hearingExpectedDays,
+			inspector_name: inspectorName,
+			hearing_address: hearingAddress,
+			final_comments_due_date: finalCommentsDueDate
+		};
+	} else if (isEnforcementNoStatementsNoComments) {
+		lpaTemplate = 'publish-statements-enforcement-hearing-no-statements-no-comments';
+		appellantTemplate = 'publish-statements-enforcement-hearing-no-statements-no-comments';
+		additionalEmailValues = {
+			hearing_address: hearingAddress,
+			inspector_name: inspectorName,
+			hearing_expected_days: hearingExpectedDays,
+			hearing_time: hearingTime
+		};
 	} else {
 		lpaTemplate = 'publish-statements-hearing-lpa';
 		appellantTemplate = 'publish-statements-hearing-appellant';
@@ -689,6 +706,7 @@ const sendPublishedStatementNotifiesForHearing = async (
 				site_address: siteAddress,
 				...(enforcementReference && { enforcement_reference: enforcementReference }),
 				lpa_reference: lpaReference || '',
+				...(includeFrontOfficeUrl && { front_office_url: contact.url }),
 				hearing_date: hearingDate,
 				team_email_address,
 				...additionalEmailValues

--- a/appeals/api/src/server/notify/templates/__tests__/publish-statements-enforcement-hearing-yes-statements-yes-comments.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/publish-statements-enforcement-hearing-yes-statements-yes-comments.test.js
@@ -1,0 +1,201 @@
+import { notifySend } from '#notify/notify-send.js';
+import { jest } from '@jest/globals';
+
+describe('publish-statements-enforcement-hearing-yes-statements-yes-comments.md', () => {
+	const basePersonalisation = {
+		appeal_reference_number: 'ABC45678',
+		site_address: '10, Test Street',
+		lpa_reference: '12345XYZ',
+		front_office_url: '/mock-front-office-url/appeals/ABC45678',
+		final_comments_due_date: '15 April 2026',
+		team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+	};
+
+	const notifyClient = { sendEmail: jest.fn() };
+	const recipientEmail = 'test@example.com';
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render correctly with hearing details and enforcement reference', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments',
+			notifyClient,
+			recipientEmail,
+			personalisation: {
+				...basePersonalisation,
+				enforcement_reference: 'ENF-12345',
+				hearing_date: '15 March 2025',
+				hearing_time: '10:00am',
+				hearing_expected_days: 2,
+				inspector_name: 'J Smith',
+				hearing_address: '10, Test Street'
+			}
+		};
+
+		const expectedContent = [
+			'# Documents received',
+			'',
+			'- appellant’s statement',
+			'- local planning authority’s statement',
+			'- comments from interested parties',
+			'',
+			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: ABC45678',
+			'Address: 10, Test Street',
+			'Enforcement notice reference: ENF-12345',
+			'',
+			'# Hearing details',
+			'',
+			'^Date: 15 March 2025',
+			'Time: 10:00am',
+			'Expected days: 2',
+			'Inspector: J Smith',
+			'Venue address: 10, Test Street',
+			'',
+			'',
+			'We will contact you if we make any changes to the hearing.',
+			'',
+			'',
+			'# What happens next',
+			'',
+			'You need to submit your final comments by 15 April 2026.',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		// @ts-ignore
+		await notifySend(notifySendData);
+
+		expect(notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			recipientEmail,
+			{
+				content: expectedContent,
+				subject: 'New information: comments and statements on ABC45678'
+			}
+		);
+	});
+
+	test('should render correctly with planning application reference for LDC appeal', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments',
+			notifyClient,
+			recipientEmail,
+			personalisation: {
+				...basePersonalisation,
+				hearing_date: '15 March 2025',
+				hearing_time: '10:00am',
+				hearing_expected_days: 2,
+				inspector_name: 'J Smith',
+				hearing_address: '10, Test Street'
+			}
+		};
+
+		const expectedContent = [
+			'# Documents received',
+			'',
+			'- appellant’s statement',
+			'- local planning authority’s statement',
+			'- comments from interested parties',
+			'',
+			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: ABC45678',
+			'Address: 10, Test Street',
+			'Planning application reference: 12345XYZ',
+			'',
+			'# Hearing details',
+			'',
+			'^Date: 15 March 2025',
+			'Time: 10:00am',
+			'Expected days: 2',
+			'Inspector: J Smith',
+			'Venue address: 10, Test Street',
+			'',
+			'',
+			'We will contact you if we make any changes to the hearing.',
+			'',
+			'',
+			'# What happens next',
+			'',
+			'You need to submit your final comments by 15 April 2026.',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		// @ts-ignore
+		await notifySend(notifySendData);
+
+		expect(notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			recipientEmail,
+			{
+				content: expectedContent,
+				subject: 'New information: comments and statements on ABC45678'
+			}
+		);
+	});
+
+	test('should render correctly when hearing date is not set up', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'publish-statements-enforcement-hearing-yes-statements-yes-comments',
+			notifyClient,
+			recipientEmail,
+			personalisation: {
+				...basePersonalisation,
+				enforcement_reference: 'ENF-12345',
+				hearing_date: null
+			}
+		};
+
+		const expectedContent = [
+			'# Documents received',
+			'',
+			'- appellant’s statement',
+			'- local planning authority’s statement',
+			'- comments from interested parties',
+			'',
+			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: ABC45678',
+			'Address: 10, Test Street',
+			'Enforcement notice reference: ENF-12345',
+			'',
+			'We will contact you by email when we set up the hearing.',
+			'',
+			'',
+			'# What happens next',
+			'',
+			'You need to submit your final comments by 15 April 2026.',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		// @ts-ignore
+		await notifySend(notifySendData);
+
+		expect(notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			recipientEmail,
+			{
+				content: expectedContent,
+				subject: 'New information: comments and statements on ABC45678'
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/notify/templates/publish-statements-enforcement-hearing-yes-statements-yes-comments.content.md
+++ b/appeals/api/src/server/notify/templates/publish-statements-enforcement-hearing-yes-statements-yes-comments.content.md
@@ -1,0 +1,44 @@
+# Documents received
+
+- appellant’s statement
+- local planning authority’s statement
+- comments from interested parties
+
+You can [view this information in the appeals service]({{front_office_url}}).
+
+# Appeal details
+
+^Appeal reference number: {{appeal_reference_number}}
+Address: {{site_address}}
+{% if enforcement_reference -%}
+Enforcement notice reference: {{enforcement_reference}}
+{%- else -%}
+Planning application reference: {{lpa_reference}}
+{%- endif %}
+
+{% if hearing_date -%}
+# Hearing details
+
+^Date: {{hearing_date}}
+Time: {{hearing_time}}
+{% if hearing_expected_days -%}
+Expected days: {{hearing_expected_days}}
+{% endif -%}
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif -%}
+{% if hearing_address -%}
+Venue address: {{hearing_address}}
+{% endif %}
+
+We will contact you if we make any changes to the hearing.
+{% else -%}
+We will contact you by email when we set up the hearing.
+{% endif %}
+
+# What happens next
+
+You need to submit your final comments by {{final_comments_due_date}}.
+
+Planning Inspectorate
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/publish-statements-enforcement-hearing-yes-statements-yes-comments.subject.md
+++ b/appeals/api/src/server/notify/templates/publish-statements-enforcement-hearing-yes-statements-yes-comments.subject.md
@@ -1,0 +1,1 @@
+New information: comments and statements on {{appeal_reference_number}}

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -523,6 +523,15 @@ these [Notify Templates](../appeals/api/src/server/notify/templates):
 - **Notify Content Template:** [publish-statements-hearing-appellant](../appeals/api/src/server/notify/templates/publish-statements-hearing-appellant.content.md)
 - **Trigger:** Publish representations when the appeal is in the statements stage. Sent to appellant/agent.
 
+### Statements published - enforcement hearing yes statements yes comments
+
+- **Appeal type:** Enforcement, Enforcement Listed Building, Lawful Development Certificate
+- **Procedure:** Hearing
+- **Notify Subject Template:** [publish-statements-enforcement-hearing-yes-statements-yes-comments](../appeals/api/src/server/notify/templates/publish-statements-enforcement-hearing-yes-statements-yes-comments.subject.md)
+- **Notify Content Template:** [publish-statements-enforcement-hearing-yes-statements-yes-comments](../appeals/api/src/server/notify/templates/publish-statements-enforcement-hearing-yes-statements-yes-comments.content.md)
+- **GOV notify template:** [Enf Hearing - Yes all statements, Yes comments] (https://www.notifications.service.gov.uk/services/c46d894e-d10e-4c46-a467-019576cd906a/templates/dea23a30-cc67-4ed9-8809-32e419089210)
+- **Trigger:** Publish representations when the appeal is in the statements stage and both statements and IP comments exist. Sent to appellant/agent and LPA.
+
 ### Statements published - inquiry lpa
 
 - **Appeal type:** All

--- a/packages/appeals/utils/appeal-type-checks.js
+++ b/packages/appeals/utils/appeal-type-checks.js
@@ -147,3 +147,11 @@ export const isLdcOrEnforcementCaseType = (caseType) =>
  * @returns {boolean}
  */
 export const isLdcCaseType = (caseType) => caseType === APPEAL_CASE_TYPE.X;
+
+/**
+ *
+ * @param {string|undefined} appealType
+ * @returns {boolean}
+ */
+export const isLdcOrEnforcementAppealType = (appealType) =>
+	isLdcOrEnforcementCaseType(appealTypeToAppealCaseTypeMapper(appealType));


### PR DESCRIPTION
## Describe your changes

### Changes:
Add notify for sharing IP comments and statements for Enforcement hearing.
Add seed data for testing

### Tests:
Added new unit tests to cover sending scenarios and new notify template 
Manually tested in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8842)
