### PR TITLE
feat(appeals): adding notify docs check to commit verify (no-ticket)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,4 @@
 npm run tscheck
 npx lint-staged
 ./packages/scripts/verify_openapi_docs.sh
+./packages/scripts/verify_notify_docs.sh

--- a/packages/scripts/verify_notify_docs.sh
+++ b/packages/scripts/verify_notify_docs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Function to verify that the notification and triggers doc contains all the notify templates
+verify_notify_docs() {
+  # Create a temporary file for a list of notify templates that are not documented
+  TMP_FILE=$(mktemp)
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+  REPO_ROOT="$SCRIPT_DIR/../.."
+  NOTIFY_TEMPLATES_DIR="$REPO_ROOT/appeals/api/src/server/notify/templates"
+  NOTIFICATIONS_AND_TRIGGERS_DOC="$REPO_ROOT/docs/notifications-and-triggers.md"
+
+  # Loop through all notify template files and check if they are documented in notifications-and-triggers.md
+  (cd "$NOTIFY_TEMPLATES_DIR" && \
+  for template_file in *.md; do
+  	if ! grep -q "$template_file" "$NOTIFICATIONS_AND_TRIGGERS_DOC"; then
+			echo "- $template_file" >> $TMP_FILE
+		fi
+  	done
+  )
+
+  # if the file is empty then all notify templates are documented
+  if [ ! -s $TMP_FILE ]; then
+		echo "All notify templates are documented in notifications-and-triggers.md."
+		# clean up temporary file
+		rm $TMP_FILE
+		return 0
+	fi
+
+  # the file is not empty, so some notify templates are not documented
+  echo "The following notify templates are not documented in notifications-and-triggers.md:"
+  cat $TMP_FILE
+  echo "Please make sure that you have added the new notify templates to the documentation."
+  echo "Documentation is in the docs folder: docs/notifications-and-triggers.md"
+
+  # clean up temporary file
+  rm $TMP_FILE
+  return 1
+}
+
+verify_notify_docs


### PR DESCRIPTION
## Describe your changes

- Adding a check to the commit verify that all the notify templates are included in the notifications-and-triggers doc

Note that this doesn't check that the list in the doc exactly matches the templates and so there may be templates in the doc which no longer exist in the folder. It also doesn't examine the content- just that the name of the template is in the document. These could be added in the future as improvements :)

## Issue ticket number and link

No ticket
