### PR TITLE
test(api): add query raw call tests for auto redaction (no-ticket)

### DIFF
--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -1013,10 +1013,14 @@ describe('appellant cases routes', () => {
 					databaseConnector.documentVersion.findMany.mockResolvedValue([]);
 					// @ts-ignore
 					databaseConnector.documentVersion.update.mockResolvedValue([]);
-					// @ts-ignore
+					const redactionStatusId = 123;
 					databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
-						{ id: 1, key: 'no_redaction_required' }
+						{ id: redactionStatusId, key: 'no_redaction_required' }
 					]);
+					databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+						id: redactionStatusId,
+						key: 'no_redaction_required'
+					});
 					databaseConnector.$queryRaw.mockResolvedValue([
 						{
 							guid: '123',
@@ -1038,10 +1042,6 @@ describe('appellant cases routes', () => {
 							representationType: null
 						}
 					]);
-					databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
-						id: 1,
-						key: 'no_redaction_required'
-					});
 					// @ts-ignore
 					databaseConnector.document.findUnique.mockResolvedValue(null);
 
@@ -1115,6 +1115,11 @@ describe('appellant cases routes', () => {
 					}
 
 					expect(response.status).toEqual(200);
+					expect(databaseConnector.$queryRaw).toHaveBeenCalledWith(
+						expect.arrayContaining([expect.stringContaining('SET redactionStatusId =')]),
+						redactionStatusId,
+						appeal.id
+					);
 					expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
 						[
 							expect.objectContaining({

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -234,10 +234,14 @@ describe('lpa questionnaires routes', () => {
 					id: 1,
 					azureAdUserId
 				});
-				// @ts-ignore
+				const redactionStatusId = 123;
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
-					{ id: 1, key: 'no_redaction_required' }
+					{ id: redactionStatusId, key: 'no_redaction_required' }
 				]);
+				databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+					id: redactionStatusId,
+					key: 'no_redaction_required'
+				});
 
 				const body = {
 					validationOutcome: 'complete'
@@ -281,6 +285,11 @@ describe('lpa questionnaires routes', () => {
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
 				expect(response.status).toEqual(200);
+				expect(databaseConnector.$queryRaw).toHaveBeenCalledWith(
+					expect.arrayContaining([expect.stringContaining('SET redactionStatusId =')]),
+					redactionStatusId,
+					householdAppeal.id
+				);
 				expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
 					[
 						expect.objectContaining({

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -4837,9 +4837,14 @@ describe('/appeals/:id/reps', () => {
 					{ representationType: 'lpa_final_comment' }
 				]);
 				databaseConnector.representation.updateMany.mockResolvedValue([]);
+				const redactionStatusId = 123;
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
-					{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+					{ id: redactionStatusId, key: 'no_redaction_required' }
 				]);
+				databaseConnector.documentRedactionStatus.findUnique.mockResolvedValue({
+					id: redactionStatusId,
+					key: 'no_redaction_required'
+				});
 				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
 
 				const response = await request
@@ -4848,6 +4853,11 @@ describe('/appeals/:id/reps', () => {
 					.set('azureAdUserId', '732652365');
 
 				expect(response.status).toEqual(200);
+				expect(databaseConnector.$queryRaw).toHaveBeenCalledWith(
+					expect.arrayContaining([expect.stringContaining('SET redactionStatusId =')]),
+					redactionStatusId,
+					mockS78Appeal.id
+				);
 				expect(mockBroadcasters.broadcastDocuments).toHaveBeenCalledWith(
 					[
 						expect.objectContaining({


### PR DESCRIPTION
## Describe your changes

Adds tests to cover how query raw is called in auto redact

