### PR TITLE
fix(appeals): adding specific case history for new expedited appellan…

### DIFF
--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -44,6 +44,8 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { jest } from '@jest/globals';
 import { APPEAL_TYPE, FEEDBACK_FORM_LINKS } from '@pins/appeals/constants/common.js';
 import {
+	AUDIT_TRAIL_APPELLANT_CASE_UPDATED,
+	AUDIT_TRAIL_REASON_FOR_APPEAL_APPELLANT_UPDATED,
 	AUDIT_TRAIL_SITE_AREA_SQUARE_METRES_UPDATED,
 	AUDIT_TRAIL_SUBMISSION_INCOMPLETE,
 	CASE_RELATIONSHIP_LINKED,
@@ -293,6 +295,106 @@ describe('appellant cases routes', () => {
 
 				expect(response.status).toEqual(200);
 			});
+
+			test('updates appellant case- why are you appealing?', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(enforcementNoticeAppeal);
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue({
+					id: 1,
+					azureAdUserId
+				});
+
+				const patchBody = {
+					reasonForAppealAppellant: 'This is my reason for appealing'
+				};
+				const dataToSave = {
+					reasonForAppealAppellant: patchBody.reasonForAppealAppellant
+				};
+
+				const { appellantCase, id } = enforcementNoticeAppeal;
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
+					where: { id: appellantCase.id },
+					data: dataToSave
+				});
+
+				expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
+					data: {
+						appealId: enforcementNoticeAppeal.id,
+						details: stringTokenReplacement(AUDIT_TRAIL_REASON_FOR_APPEAL_APPELLANT_UPDATED, [
+							'This is my reason for appealing'
+						]),
+						loggedAt: expect.any(Date),
+						userId: enforcementNoticeAppeal.caseOfficer.id
+					}
+				});
+
+				expect(response.status).toEqual(200);
+			});
+
+			test('updates appellant case- Have there been any significant changes that would affect the application?', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(enforcementNoticeAppeal);
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue({
+					id: 1,
+					azureAdUserId
+				});
+
+				const patchBody = {
+					anySignificantChanges: 'Yes',
+					anySignificantChanges_localPlanSignificantChanges:
+						'There have been significant local plan changes',
+					anySignificantChanges_nationalPolicySignificantChanges: null,
+					anySignificantChanges_otherSignificantChanges: null,
+					anySignificantChanges_courtJudgementSignificantChanges: null
+				};
+				const dataToSave = {
+					anySignificantChanges: patchBody.anySignificantChanges,
+					anySignificantChanges_localPlanSignificantChanges:
+						patchBody.anySignificantChanges_localPlanSignificantChanges,
+					anySignificantChanges_nationalPolicySignificantChanges:
+						patchBody.anySignificantChanges_nationalPolicySignificantChanges,
+					anySignificantChanges_otherSignificantChanges:
+						patchBody.anySignificantChanges_otherSignificantChanges,
+					anySignificantChanges_courtJudgementSignificantChanges:
+						patchBody.anySignificantChanges_courtJudgementSignificantChanges
+				};
+
+				const { appellantCase, id } = enforcementNoticeAppeal;
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
+					where: { id: appellantCase.id },
+					data: dataToSave
+				});
+
+				expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
+					data: {
+						appealId: enforcementNoticeAppeal.id,
+						details: stringTokenReplacement(AUDIT_TRAIL_APPELLANT_CASE_UPDATED, [
+							'This is my reason for appealing'
+						]),
+						loggedAt: expect.any(Date),
+						userId: enforcementNoticeAppeal.caseOfficer.id
+					}
+				});
+
+				expect(response.status).toEqual(200);
+			});
+
 			test('updates appellant case when the validation outcome is Incomplete without reason text and with an appeal due date', async () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(
 					householdAppealAppellantCaseIncomplete
@@ -2486,7 +2588,7 @@ describe('appellant cases routes', () => {
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
 						appealId: id,
-						details: 'Case updated',
+						details: 'Appellant case updated',
 						loggedAt: expect.any(Date),
 						userId: 1
 					}
@@ -2642,7 +2744,7 @@ describe('appellant cases routes', () => {
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
 						appealId: id,
-						details: 'Case updated',
+						details: 'Appellant case updated',
 						loggedAt: expect.any(Date),
 						userId: 1
 					}
@@ -2775,7 +2877,7 @@ describe('appellant cases routes', () => {
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
 						appealId: id,
-						details: 'Case updated',
+						details: 'Appellant case updated',
 						loggedAt: expect.any(Date),
 						userId: 1
 					}
@@ -2895,7 +2997,7 @@ describe('appellant cases routes', () => {
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
 						appealId: id,
-						details: 'Case updated',
+						details: 'Appellant case updated',
 						loggedAt: expect.any(Date),
 						userId: 1
 					}
@@ -3020,7 +3122,7 @@ describe('appellant cases routes', () => {
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
 						appealId: id,
-						details: 'Case updated',
+						details: 'Appellant case updated',
 						loggedAt: expect.any(Date),
 						userId: 1
 					}
@@ -3038,7 +3140,7 @@ describe('appellant cases routes', () => {
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
 						appealId: id,
-						details: 'Case updated',
+						details: 'Appellant case updated',
 						loggedAt: expect.any(Date),
 						userId: 1
 					}

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -801,7 +801,8 @@ export function renderAuditTrailDetail(data) {
 				/** @type {string} */ (data.applicationMadeUnderActSection || '').replaceAll('-', ' ')
 			),
 		AUDIT_TRAIL_SCREENING_OPINION_INDICATES_EIA_REQUIRED_UPDATED: () =>
-			data.screeningOpinionIndicatesEiaRequired ? 'Yes' : 'No'
+			data.screeningOpinionIndicatesEiaRequired ? 'Yes' : 'No',
+		AUDIT_TRAIL_REASON_FOR_APPEAL_APPELLANT_UPDATED: () => data.reasonForAppealAppellant
 	};
 
 	if (!auditTrailParameters[constantKey]) {

--- a/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
@@ -337,12 +337,12 @@ describe.skip('Net residences', () => {
 				happyPathHelper.addNetResidences('Net gain', '4');
 				(caseDetailsPage.validateBannerMessage('Success', 'Number of residential units added'),
 					caseDetailsPage.clickViewCaseHistory());
-				caseHistoryPage.verifyCaseHistoryValue('Case updated');
+				caseHistoryPage.verifyCaseHistoryValue('Appellant case updated');
 
 				//child appeal
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				caseDetailsPage.clickViewCaseHistory();
-				caseHistoryPage.verifyCaseHistoryValue('Case updated', false);
+				caseHistoryPage.verifyCaseHistoryValue('Appellant case updated', false);
 			});
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
@@ -134,7 +134,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:52am</span>
                         </td>
-                        <td class="govuk-table__cell">Case updated</td>
+                        <td class="govuk-table__cell">Appellant case updated</td>
                         <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">

--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
@@ -200,11 +200,15 @@ describe('audit', () => {
 			expect(unprettifiedHtml).toContain(
 				'<td class="govuk-table__cell">The <a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1">LPA questionnaire</a> was received</td>'
 			);
-			expect(unprettifiedHtml).toContain('<td class="govuk-table__cell">Case updated</td>');
+			expect(unprettifiedHtml).toContain(
+				'<td class="govuk-table__cell">Appellant case updated</td>'
+			);
 			expect(unprettifiedHtml).toContain(
 				'<td class="govuk-table__cell">The case timeline was created</td>'
 			);
-			expect(unprettifiedHtml).toContain('<td class="govuk-table__cell">Case updated</td>');
+			expect(unprettifiedHtml).toContain(
+				'<td class="govuk-table__cell">Appellant case updated</td>'
+			);
 			expect(unprettifiedHtml).toContain(
 				'<td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">LPA questionnaire</strong></td>'
 			);

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -5339,7 +5339,7 @@ export const caseAuditLog = [
 	},
 	{
 		azureAdUserId: activeDirectoryUsersData[0].id,
-		details: 'Case updated',
+		details: 'Appellant case updated',
 		loggedDate: '2025-05-27T09:52:23.680Z'
 	},
 	{

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -160,7 +160,7 @@ export const AUDIT_TRAIL_SERVICE_USER_ADDRESS_UPDATED =
 	"The {replacement0}'s address details were updated";
 export const AUDIT_TRAIL_SERVICE_USER_REMOVED = 'The {replacement0} was removed';
 export const AUDIT_TRAIL_ADDRESS_UPDATED = 'Site address updated to\n{replacement0}';
-export const AUDIT_TRAIL_APPELLANT_CASE_UPDATED = 'Case updated';
+export const AUDIT_TRAIL_APPELLANT_CASE_UPDATED = 'Appellant case updated';
 export const AUDIT_TRAIL_DEVELOPMENT_TYPE_UPDATED = 'Development type updated to {replacement0}';
 export const AUDIT_TRAIL_SITE_AREA_SQUARE_METRES_UPDATED = 'Site area updated to {replacement0} m²';
 export const AUDIT_TRAIL_HIGHWAY_LAND_UPDATED =
@@ -295,6 +295,10 @@ export const AUDIT_TRAIL_HORIZON_REFERENCE_UPDATED = 'Horizon reference updated'
 
 export const AUDIT_TRAIL_ASSIGNED_TEAM_UPDATED = 'Case team {replacement0} assigned';
 export const BANK_HOLIDAY_FEED_DIVISION_ENGLAND = 'england-and-wales';
+
+// Expedited - appellant case
+export const AUDIT_TRAIL_REASON_FOR_APPEAL_APPELLANT_UPDATED =
+	"'Why are you appealing?' updated to {replacement0}";
 
 // Enforcement notice - appellant case
 export const AUDIT_TRAIL_ENFORCEMENT_NOTICE_UPDATED =


### PR DESCRIPTION
…t case question (A2-8025)

and updating the generic appellant case audit message

## Describe your changes

- Adding the specific case history message for 'Why are you appealing?'
- Updating the generic case history message for appellant case to 'Appellant case updated' in order to match with 'LPA questionnaire updated'
- Updated tests for new wording
- Added tests for the two questions in the ticket

### Tested locally

<img width="1692" height="575" alt="image" src="https://github.com/user-attachments/assets/eb2bf666-af5b-4aa3-bc36-b90a523b51b3" />


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8025)
