### PR TITLE
fix(api): common place for appeal detail keys, that test util reads f…

### DIFF
--- a/appeals/api/src/server/endpoints/test-utils/test-utils.controller.js
+++ b/appeals/api/src/server/endpoints/test-utils/test-utils.controller.js
@@ -453,7 +453,7 @@ export const simulateShareIpCommentsAndLpaStatement = async (req, res) => {
 	const { appealReference } = req.params;
 	const appeal = await databaseConnector.appeal.findUnique({
 		where: { reference: appealReference },
-		include: { appealStatus: true, lpa: true, appellant: true, agent: true }
+		include: { appealStatus: true, lpa: true, appellant: true, agent: true, procedureType: true }
 	});
 
 	if (!appeal) return res.status(400).send(false);


### PR DESCRIPTION
…rom (A2-8487)

## Describe your changes

- add in procedureType: true to prisma include

- Tested by running /appeals/{appealReference}/share-comments-and-statement locally, against an s20 Hearing appeal, sends correct notify.

## Issue ticket number and link

[Hearing -Incorrect notifies are sending out to Appellant & LPA upon sharing statements & IP comments.](https://pins-ds.atlassian.net.mcas.ms/browse/A2-8487)
