### PR TITLE
feat(appeals): default to written part 1 for HAS and CAS adverts/appeals (A2-8876)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -665,6 +665,48 @@ describe('appeal timetables routes', () => {
 	});
 	describe('/appeals/:appealId/appeal-timetables', () => {
 		describe('POST', () => {
+			describe('post 1 April 2026 expedited appeals', () => {
+				test.each([
+					['HAS', houseAppealWithTimetable],
+					['CAS Planning', casPlanningAppealWithTimetable],
+					['CAS Advert', casAdvertAppealWithTimetable]
+				])(
+					'defaults %s appeal to writtenPart1 when application date is on or after 1 April 2026',
+					async (_, mockExpeditedAppeal) => {
+						const testAppeal = {
+							...mockExpeditedAppeal,
+							caseStartedDate: null,
+							procedureType: undefined,
+							appellantCase: {
+								...mockExpeditedAppeal.appellantCase,
+								applicationDate: '2026-04-01T00:00:00.000Z'
+							}
+						};
+						databaseConnector.appeal.findUnique.mockResolvedValue(testAppeal);
+						databaseConnector.user.upsert.mockResolvedValue({ id: 1, azureAdUserId });
+
+						const response = await request
+							.post(`/appeals/${testAppeal.id}/appeal-timetables/`)
+							.send()
+							.set('azureAdUserId', azureAdUserId);
+
+						expect(response.status).toEqual(201);
+						expect(mockNotifySend).toHaveBeenNthCalledWith(
+							1,
+							expect.objectContaining({
+								templateName: 'appeal-valid-start-case-appellant'
+							})
+						);
+						expect(mockNotifySend).toHaveBeenNthCalledWith(
+							2,
+							expect.objectContaining({
+								templateName: 'appeal-valid-start-case-lpa'
+							})
+						);
+					}
+				);
+			});
+
 			describe.each([
 				[
 					'householdAppeal',
@@ -738,200 +780,205 @@ describe('appeal timetables routes', () => {
 			])(
 				'updates a %s appeal timetable',
 				(_, appeal, expectedResponse, additionalPersonalisation) => {
-					test('when procedure type is written', async () => {
-						// @ts-ignore
-						databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
-						// @ts-ignore
-						databaseConnector.user.upsert.mockResolvedValue({
-							id: 1,
-							azureAdUserId
+					describe('when procedure type is written or undefined', () => {
+						test('when procedure type is written', async () => {
+							const appealCopy = { ...appeal };
+							// @ts-ignore
+							databaseConnector.appeal.findUnique.mockResolvedValue(appealCopy);
+							// @ts-ignore
+							databaseConnector.user.upsert.mockResolvedValue({
+								id: 1,
+								azureAdUserId
+							});
+
+							const { id } = appeal;
+							const response = await request
+								.post(`/appeals/${id}/appeal-timetables/`)
+								.send()
+								.set('azureAdUserId', azureAdUserId);
+
+							expect(response.status).toEqual(201);
+							expect(response.body).toEqual(expectedResponse);
+
+							expect(mockNotifySend).toHaveBeenCalledTimes(2);
+
+							expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
+								azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
+								notifyClient: expect.anything(),
+								personalisation: {
+									appeal_reference_number: appeal.reference,
+									inspector_name: null,
+									appeal_type: trimAppealType(appeal.appealType.type),
+									appellant_email_address: appeal.appellant.email,
+									child_appeals: [],
+									comment_deadline: '',
+									due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									final_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.finalCommentsDueDate || ''
+									),
+									ip_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.ipCommentsDueDate || ''
+									),
+									local_planning_authority: appeal.lpa.name,
+									lpa_reference: appeal.applicationReference,
+									lpa_statement_deadline: dateISOStringToDisplayDate(
+										expectedResponse.lpaStatementDueDate || ''
+									),
+									procedure_type: 'written representations',
+									questionnaire_due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
+									start_date: '5 June 2024',
+									site_visit: true,
+									costs_info: true,
+									statement_of_common_ground_deadline: '',
+									team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+								},
+								recipientEmail: appeal.appellant.email,
+								templateName: 'appeal-start-date-change-appellant'
+							});
+
+							expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
+								azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
+								notifyClient: expect.anything(),
+								personalisation: {
+									appeal_reference_number: appeal.reference,
+									inspector_name: null,
+									appeal_type: trimAppealType(appeal.appealType.type),
+									appellant_email_address: appeal.appellant.email,
+									child_appeals: [],
+									comment_deadline: '',
+									due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									final_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.finalCommentsDueDate || ''
+									),
+									ip_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.ipCommentsDueDate || ''
+									),
+									local_planning_authority: appeal.lpa.name,
+									lpa_reference: appeal.applicationReference,
+									lpa_statement_deadline: dateISOStringToDisplayDate(
+										expectedResponse.lpaStatementDueDate || ''
+									),
+									procedure_type: 'written representations',
+									questionnaire_due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
+									start_date: '5 June 2024',
+									statement_of_common_ground_deadline: '',
+									...additionalPersonalisation,
+									team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+								},
+								recipientEmail: appeal.lpa.email,
+								templateName: 'appeal-start-date-change-lpa'
+							});
 						});
 
-						const { id } = appeal;
-						const response = await request
-							.post(`/appeals/${id}/appeal-timetables/`)
-							.send()
-							.set('azureAdUserId', azureAdUserId);
+						test('when procedure type is undefined', async () => {
+							const appealCopy = {
+								...appeal,
+								procedureType: appeal.procedureType || { id: 3, name: 'Written', key: 'written' }
+							};
+							databaseConnector.appeal.findUnique.mockResolvedValue(appealCopy);
+							// @ts-ignore
+							databaseConnector.user.upsert.mockResolvedValue({
+								id: 1,
+								azureAdUserId
+							});
 
-						expect(response.status).toEqual(201);
-						expect(response.body).toEqual(expectedResponse);
+							const { id } = appeal;
+							const response = await request
+								.post(`/appeals/${id}/appeal-timetables/`)
+								.send()
+								.set('azureAdUserId', azureAdUserId);
 
-						expect(mockNotifySend).toHaveBeenCalledTimes(2);
+							expect(response.status).toEqual(201);
+							expect(response.body).toEqual(expectedResponse);
 
-						expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
-							azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
-							notifyClient: expect.anything(),
-							personalisation: {
-								appeal_reference_number: appeal.reference,
-								inspector_name: null,
-								appeal_type: trimAppealType(appeal.appealType.type),
-								appellant_email_address: appeal.appellant.email,
-								child_appeals: [],
-								comment_deadline: '',
-								due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								final_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.finalCommentsDueDate || ''
-								),
-								ip_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.ipCommentsDueDate || ''
-								),
-								local_planning_authority: appeal.lpa.name,
-								lpa_reference: appeal.applicationReference,
-								lpa_statement_deadline: dateISOStringToDisplayDate(
-									expectedResponse.lpaStatementDueDate || ''
-								),
-								procedure_type: 'written representations',
-								questionnaire_due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
-								start_date: '5 June 2024',
-								site_visit: true,
-								costs_info: true,
-								statement_of_common_ground_deadline: '',
-								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
-							},
-							recipientEmail: appeal.appellant.email,
-							templateName: 'appeal-start-date-change-appellant'
-						});
+							expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-						expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
-							azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
-							notifyClient: expect.anything(),
-							personalisation: {
-								appeal_reference_number: appeal.reference,
-								inspector_name: null,
-								appeal_type: trimAppealType(appeal.appealType.type),
-								appellant_email_address: appeal.appellant.email,
-								child_appeals: [],
-								comment_deadline: '',
-								due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								final_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.finalCommentsDueDate || ''
-								),
-								ip_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.ipCommentsDueDate || ''
-								),
-								local_planning_authority: appeal.lpa.name,
-								lpa_reference: appeal.applicationReference,
-								lpa_statement_deadline: dateISOStringToDisplayDate(
-									expectedResponse.lpaStatementDueDate || ''
-								),
-								procedure_type: 'written representations',
-								questionnaire_due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
-								start_date: '5 June 2024',
-								statement_of_common_ground_deadline: '',
-								...additionalPersonalisation,
-								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
-							},
-							recipientEmail: appeal.lpa.email,
-							templateName: 'appeal-start-date-change-lpa'
-						});
-					});
+							expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
+								azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
+								notifyClient: expect.anything(),
+								personalisation: {
+									appeal_reference_number: appeal.reference,
+									inspector_name: null,
+									appeal_type: trimAppealType(appeal.appealType.type),
+									appellant_email_address: appeal.appellant.email,
+									child_appeals: [],
+									comment_deadline: '',
+									due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									final_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.finalCommentsDueDate || ''
+									),
+									ip_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.ipCommentsDueDate || ''
+									),
+									local_planning_authority: appeal.lpa.name,
+									lpa_reference: appeal.applicationReference,
+									lpa_statement_deadline: dateISOStringToDisplayDate(
+										expectedResponse.lpaStatementDueDate || ''
+									),
+									procedure_type: 'written representations',
+									questionnaire_due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
+									start_date: '5 June 2024',
+									site_visit: true,
+									costs_info: true,
+									statement_of_common_ground_deadline: '',
+									team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+								},
+								recipientEmail: appeal.appellant.email,
+								templateName: 'appeal-start-date-change-appellant'
+							});
 
-					test('when procedure type is undefined', async () => {
-						// @ts-ignore
-						appeal.procedureType = undefined;
-						databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
-						// @ts-ignore
-						databaseConnector.user.upsert.mockResolvedValue({
-							id: 1,
-							azureAdUserId
-						});
-
-						const { id } = appeal;
-						const response = await request
-							.post(`/appeals/${id}/appeal-timetables/`)
-							.send()
-							.set('azureAdUserId', azureAdUserId);
-
-						expect(response.status).toEqual(201);
-						expect(response.body).toEqual(expectedResponse);
-
-						expect(mockNotifySend).toHaveBeenCalledTimes(2);
-
-						expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
-							azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
-							notifyClient: expect.anything(),
-							personalisation: {
-								appeal_reference_number: appeal.reference,
-								inspector_name: null,
-								appeal_type: trimAppealType(appeal.appealType.type),
-								appellant_email_address: appeal.appellant.email,
-								child_appeals: [],
-								comment_deadline: '',
-								due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								final_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.finalCommentsDueDate || ''
-								),
-								ip_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.ipCommentsDueDate || ''
-								),
-								local_planning_authority: appeal.lpa.name,
-								lpa_reference: appeal.applicationReference,
-								lpa_statement_deadline: dateISOStringToDisplayDate(
-									expectedResponse.lpaStatementDueDate || ''
-								),
-								procedure_type: 'written representations',
-								questionnaire_due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
-								start_date: '5 June 2024',
-								site_visit: true,
-								costs_info: true,
-								statement_of_common_ground_deadline: '',
-								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
-							},
-							recipientEmail: appeal.appellant.email,
-							templateName: 'appeal-start-date-change-appellant'
-						});
-
-						expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
-							azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
-							notifyClient: expect.anything(),
-							personalisation: {
-								appeal_reference_number: appeal.reference,
-								inspector_name: null,
-								appeal_type: trimAppealType(appeal.appealType.type),
-								appellant_email_address: appeal.appellant.email,
-								child_appeals: [],
-								comment_deadline: '',
-								due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								final_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.finalCommentsDueDate || ''
-								),
-								ip_comments_deadline: dateISOStringToDisplayDate(
-									expectedResponse.ipCommentsDueDate || ''
-								),
-								local_planning_authority: appeal.lpa.name,
-								lpa_reference: appeal.applicationReference,
-								lpa_statement_deadline: dateISOStringToDisplayDate(
-									expectedResponse.lpaStatementDueDate || ''
-								),
-								procedure_type: 'written representations',
-								questionnaire_due_date: dateISOStringToDisplayDate(
-									expectedResponse.lpaQuestionnaireDueDate || ''
-								),
-								site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
-								start_date: '5 June 2024',
-								statement_of_common_ground_deadline: '',
-								...additionalPersonalisation,
-								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
-							},
-							recipientEmail: appeal.lpa.email,
-							templateName: 'appeal-start-date-change-lpa'
+							expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
+								azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
+								notifyClient: expect.anything(),
+								personalisation: {
+									appeal_reference_number: appeal.reference,
+									inspector_name: null,
+									appeal_type: trimAppealType(appeal.appealType.type),
+									appellant_email_address: appeal.appellant.email,
+									child_appeals: [],
+									comment_deadline: '',
+									due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									final_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.finalCommentsDueDate || ''
+									),
+									ip_comments_deadline: dateISOStringToDisplayDate(
+										expectedResponse.ipCommentsDueDate || ''
+									),
+									local_planning_authority: appeal.lpa.name,
+									lpa_reference: appeal.applicationReference,
+									lpa_statement_deadline: dateISOStringToDisplayDate(
+										expectedResponse.lpaStatementDueDate || ''
+									),
+									procedure_type: 'written representations',
+									questionnaire_due_date: dateISOStringToDisplayDate(
+										expectedResponse.lpaQuestionnaireDueDate || ''
+									),
+									site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
+									start_date: '5 June 2024',
+									statement_of_common_ground_deadline: '',
+									...additionalPersonalisation,
+									team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+								},
+								recipientEmail: appeal.lpa.email,
+								templateName: 'appeal-start-date-change-lpa'
+							});
 						});
 					});
 				}

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/get-start-case-notify-params.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/get-start-case-notify-params.test.js
@@ -1,0 +1,257 @@
+// @ts-nocheck
+import { getStartCaseNotifyParams } from '#endpoints/appeal-timetables/appeal-timetables.service.js';
+import { fullPlanningAppeal } from '#tests/appeals/mocks.js';
+import { azureAdUserId } from '#tests/shared/mocks.js';
+import { expect, jest } from '@jest/globals';
+import { PROCEDURE_TYPE_KEY } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+
+const { databaseConnector } = await import('#utils/database-connector.js');
+
+describe('getStartCaseNotifyParams Unit Tests', () => {
+	const startDate = '2024-06-12T22:59:00.000Z';
+	const siteAddress = '123 Test Street, London';
+	const timetable = {
+		lpaQuestionnaireDueDate: '2024-06-19T22:59:00.000Z',
+		lpaStatementDueDate: '2024-07-17T22:59:00.000Z',
+		ipCommentsDueDate: '2024-07-17T22:59:00.000Z',
+		finalCommentsDueDate: '2024-07-31T22:59:00.000Z',
+		statementOfCommonGroundDueDate: '2024-07-17T22:59:00.000Z',
+		commentDeadline: '2024-07-17T22:59:00.000Z',
+		planningObligationDueDate: '2024-07-14T22:59:00.000Z',
+		proofOfEvidenceAndWitnessesDueDate: '2024-05-13T00:00:00.000Z',
+		caseManagementConferenceDueDate: '2024-05-15T00:00:00.000Z'
+	};
+	const notifyClient = {};
+	const inquiry = {
+		inquiryStartTime: '2024-06-12T12:00:00.000Z',
+		inquiryAddress: '123 Inquiry Place, London',
+		inquiryEstimationDays: 5,
+		timetable
+	};
+
+	const defaultAppeal = {
+		...fullPlanningAppeal,
+		appealType: { key: APPEAL_CASE_TYPE.W, type: 'W' },
+		appellant: { email: 'appellant@test.com' },
+		lpa: { email: 'lpa@test.com' }
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		databaseConnector.appeal.findUnique.mockResolvedValue(fullPlanningAppeal);
+	});
+
+	describe('Template Name Resolution', () => {
+		test.each([
+			[
+				'Inquiry (initial start)',
+				{ procedureType: APPEAL_CASE_PROCEDURE.INQUIRY, inquiry },
+				'appeal-valid-start-case-s78-inquiry',
+				'appeal-valid-start-case-s78-inquiry'
+			],
+			[
+				'Hearing without start time (initial start)',
+				{ procedureType: APPEAL_CASE_PROCEDURE.HEARING },
+				'appeal-valid-start-case-s78-appellant',
+				'appeal-valid-start-case-s78-lpa'
+			],
+			[
+				'Hearing with start time (initial start)',
+				{
+					procedureType: APPEAL_CASE_PROCEDURE.HEARING,
+					hearingStartTime: '2024-06-12T12:00:00.000Z'
+				},
+				'appeal-valid-start-case-s78-hearing-appellant',
+				'appeal-valid-start-case-s78-hearing-lpa'
+			],
+			[
+				'Written Part 1 (initial start)',
+				{ procedureType: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 },
+				'appeal-valid-start-case-s78-expedited-appellant',
+				'appeal-valid-start-case-s78-expedited-lpa'
+			],
+			[
+				'PROCEDURE_TYPE_KEY.WRITTEN_PART_1 (initial start)',
+				{ procedureType: PROCEDURE_TYPE_KEY.WRITTEN_PART_1 },
+				'appeal-valid-start-case-s78-expedited-appellant',
+				'appeal-valid-start-case-s78-expedited-lpa'
+			],
+			[
+				'Written (initial start)',
+				{ procedureType: APPEAL_CASE_PROCEDURE.WRITTEN },
+				'appeal-valid-start-case-s78-appellant',
+				'appeal-valid-start-case-s78-lpa'
+			],
+			[
+				'Inquiry (start date change)',
+				{
+					procedureType: APPEAL_CASE_PROCEDURE.INQUIRY,
+					inquiry,
+					caseStartedDate: '2024-06-01T22:59:00.000Z'
+				},
+				'appeal-start-date-change-inquiry',
+				'appeal-start-date-change-inquiry'
+			],
+			[
+				'Hearing (start date change)',
+				{
+					procedureType: APPEAL_CASE_PROCEDURE.HEARING,
+					hearingStartTime: '2024-06-12T12:00:00.000Z',
+					caseStartedDate: '2024-06-01T22:59:00.000Z'
+				},
+				'appeal-start-date-change-appellant',
+				'appeal-start-date-change-lpa'
+			],
+			[
+				'Written Part 1 (start date change)',
+				{
+					procedureType: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+					caseStartedDate: '2024-06-01T22:59:00.000Z'
+				},
+				'appeal-start-date-change-expedited-appellant',
+				'appeal-start-date-change-expedited-lpa'
+			],
+			[
+				'Written (start date change)',
+				{
+					procedureType: APPEAL_CASE_PROCEDURE.WRITTEN,
+					caseStartedDate: '2024-06-01T22:59:00.000Z'
+				},
+				'appeal-start-date-change-appellant',
+				'appeal-start-date-change-lpa'
+			]
+		])(
+			'resolves template names for %s',
+			async (_, params, expectedAppellantTemplate, expectedLpaTemplate) => {
+				const appeal = {
+					...defaultAppeal,
+					...(params.caseStartedDate && { caseStartedDate: params.caseStartedDate })
+				};
+
+				const result = await getStartCaseNotifyParams({
+					appeal,
+					startDate,
+					notifyClient,
+					siteAddress,
+					azureAdUserId,
+					timetable,
+					procedureType: params.procedureType,
+					hearingStartTime: params.hearingStartTime,
+					inquiry: params.inquiry
+				});
+
+				expect(result.appellant.templateName).toBe(expectedAppellantTemplate);
+				expect(result.lpa.templateName).toBe(expectedLpaTemplate);
+			}
+		);
+	});
+
+	describe('Recipient Email Filtering', () => {
+		test.each([
+			[
+				'appellant only when LPA email is missing',
+				{ appellant: { email: 'appellant@test.com' }, lpa: { email: null } },
+				{ hasAppellant: true, hasLpa: false, recipientEmail: 'appellant@test.com' }
+			],
+			[
+				'agent email when appellant email is missing',
+				{ appellant: { email: null }, agent: { email: 'agent@test.com' }, lpa: { email: null } },
+				{ hasAppellant: true, hasLpa: false, recipientEmail: 'agent@test.com' }
+			],
+			[
+				'LPA only when appellant/agent emails missing',
+				{ appellant: { email: null }, agent: { email: null }, lpa: { email: 'lpa@test.com' } },
+				{ hasAppellant: false, hasLpa: true }
+			],
+			[
+				'empty object when no emails are present',
+				{ appellant: { email: null }, agent: { email: null }, lpa: { email: null } },
+				{ hasAppellant: false, hasLpa: false }
+			]
+		])('returns %s', async (_, emailConfig, expected) => {
+			const appeal = {
+				...fullPlanningAppeal,
+				...emailConfig
+			};
+
+			const result = await getStartCaseNotifyParams({
+				appeal,
+				startDate,
+				notifyClient,
+				siteAddress,
+				azureAdUserId,
+				timetable,
+				procedureType: APPEAL_CASE_PROCEDURE.WRITTEN
+			});
+
+			expect(Boolean(result.appellant)).toBe(expected.hasAppellant);
+			expect(Boolean(result.lpa)).toBe(expected.hasLpa);
+			expect(result.appellant?.recipientEmail).toBe(expected.recipientEmail);
+		});
+	});
+
+	describe('Personalisation Logic & Flags', () => {
+		test.each([
+			[APPEAL_CASE_PROCEDURE.WRITTEN, true, true],
+			[APPEAL_CASE_PROCEDURE.WRITTEN_PART_1, true, true],
+			[APPEAL_CASE_PROCEDURE.HEARING, false, false],
+			[APPEAL_CASE_PROCEDURE.INQUIRY, false, false]
+		])(
+			'sets site_visit and costs_info correctly for procedure %s',
+			async (procedureType, expectedSiteVisit, expectedCostsInfo) => {
+				const result = await getStartCaseNotifyParams({
+					appeal: defaultAppeal,
+					startDate,
+					notifyClient,
+					siteAddress,
+					azureAdUserId,
+					timetable,
+					procedureType,
+					...(procedureType === APPEAL_CASE_PROCEDURE.INQUIRY && { inquiry })
+				});
+
+				expect(result.appellant.personalisation.site_visit).toBe(expectedSiteVisit);
+				expect(result.appellant.personalisation.costs_info).toBe(expectedCostsInfo);
+			}
+		);
+
+		test('includes S78 specific LPA deadlines when appeal type key is W', async () => {
+			const result = await getStartCaseNotifyParams({
+				appeal: defaultAppeal,
+				startDate,
+				notifyClient,
+				siteAddress,
+				azureAdUserId,
+				timetable,
+				procedureType: APPEAL_CASE_PROCEDURE.WRITTEN
+			});
+
+			expect(result.lpa.personalisation).toHaveProperty('statement_of_common_ground_deadline');
+			expect(result.lpa.personalisation).toHaveProperty('planning_obligation_deadline');
+		});
+
+		test('includes enforcement grounds and reference when case type is enforcement', async () => {
+			const appeal = {
+				...defaultAppeal,
+				appealType: { key: APPEAL_CASE_TYPE.C, type: 'C' },
+				appellantCase: { enforcementReference: 'ENF/123/456', planningObligation: true },
+				appealGrounds: [{ ground: { groundRef: 'a' } }, { ground: { groundRef: 'f' } }]
+			};
+
+			const result = await getStartCaseNotifyParams({
+				appeal,
+				startDate,
+				notifyClient,
+				siteAddress,
+				azureAdUserId,
+				timetable,
+				procedureType: APPEAL_CASE_PROCEDURE.WRITTEN
+			});
+
+			expect(result.appellant.personalisation.enforcement_reference).toBe('ENF/123/456');
+			expect(result.appellant.personalisation.appeal_grounds).toEqual(['a', 'f']);
+			expect(result.appellant.personalisation).toHaveProperty('planning_obligation_deadline');
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -30,7 +30,9 @@ import {
 	ERROR_NOT_FOUND
 } from '@pins/appeals/constants/support.js';
 import {
+	beforeExpeditedOriginalApplicationCutOff,
 	isEnforcementCaseType,
+	isExpeditedAppealType,
 	isS78ExpeditedAppealType
 } from '@pins/appeals/utils/appeal-type-checks.js';
 import {
@@ -91,6 +93,51 @@ const checkAppealTimetableExists = async (req, res, next) => {
 };
 
 /**
+ * @param {string | undefined} procedureType
+ * @param {string} appealTypeKey
+ * @param {string | undefined} hearingStartTime
+ * @param {boolean} caseIsStarted
+ * @returns {{ lpaTemplate: string, appellantTemplate: string }}
+ */
+const getNotifyTemplateNames = (procedureType, appealTypeKey, hearingStartTime, caseIsStarted) => {
+	const appealTypeNotifyTemplate = appealTypeMap(appealTypeKey);
+	const baseTemplate = caseIsStarted
+		? 'appeal-start-date-change-'
+		: `appeal-valid-start-case-${appealTypeNotifyTemplate}${appealTypeNotifyTemplate ? '-' : ''}`;
+
+	const getSuffixes = () => {
+		switch (procedureType) {
+			case APPEAL_CASE_PROCEDURE.INQUIRY:
+				return { lpa: APPEAL_CASE_PROCEDURE.INQUIRY, appellant: APPEAL_CASE_PROCEDURE.INQUIRY };
+
+			case APPEAL_CASE_PROCEDURE.HEARING: {
+				const hearingPrefix = !caseIsStarted && hearingStartTime ? 'hearing-' : '';
+				return { lpa: `${hearingPrefix}lpa`, appellant: `${hearingPrefix}appellant` };
+			}
+
+			case APPEAL_CASE_PROCEDURE.WRITTEN_PART_1:
+			case PROCEDURE_TYPE_KEY.WRITTEN_PART_1:
+				if (appealTypeNotifyTemplate) {
+					return { lpa: 'expedited-lpa', appellant: 'expedited-appellant' };
+				}
+				return { lpa: 'lpa', appellant: 'appellant' };
+
+			case APPEAL_CASE_PROCEDURE.WRITTEN_PART_2:
+			case PROCEDURE_TYPE_KEY.WRITTEN_PART_2:
+			default:
+				return { lpa: 'lpa', appellant: 'appellant' };
+		}
+	};
+
+	const { lpa, appellant } = getSuffixes();
+
+	return {
+		lpaTemplate: `${baseTemplate}${lpa}`,
+		appellantTemplate: `${baseTemplate}${appellant}`
+	};
+};
+
+/**
  * @param {Object} params
  * @param {Appeal} params.appeal
  * @param {string} params.startDate
@@ -120,40 +167,10 @@ const getStartCaseNotifyParams = async ({
 }) => {
 	const { type = '', key: appealTypeKey = APPEAL_CASE_TYPE.D } = appeal.appealType || {};
 	const appealType = trimAppealType(type);
-	const caseIsStarted = appeal.caseStartedDate;
-	const appealTypeNotifyTemplate = appealTypeMap(appealTypeKey);
-	let formattedLPATemplate;
-	let formattedAppellantTemplate;
-	let baseTemplate = caseIsStarted
-		? 'appeal-start-date-change-'
-		: `appeal-valid-start-case-${appealTypeNotifyTemplate}${appealTypeNotifyTemplate ? '-' : ''}`;
+	const caseIsStarted = Boolean(appeal.caseStartedDate);
 
-	switch (procedureType) {
-		case APPEAL_CASE_PROCEDURE.INQUIRY:
-			formattedLPATemplate = `${baseTemplate}${APPEAL_CASE_PROCEDURE.INQUIRY}`;
-			formattedAppellantTemplate = `${baseTemplate}${APPEAL_CASE_PROCEDURE.INQUIRY}`;
-			break;
-		case APPEAL_CASE_PROCEDURE.HEARING:
-			if (caseIsStarted) {
-				formattedLPATemplate = `${baseTemplate}lpa`;
-				formattedAppellantTemplate = `${baseTemplate}appellant`;
-			} else {
-				formattedLPATemplate = `${baseTemplate}${hearingStartTime ? 'hearing-' : ''}lpa`;
-				formattedAppellantTemplate = `${baseTemplate}${hearingStartTime ? 'hearing-' : ''}appellant`;
-			}
-			break;
-		case APPEAL_CASE_PROCEDURE.WRITTEN_PART_1:
-		case PROCEDURE_TYPE_KEY.WRITTEN_PART_1:
-			formattedLPATemplate = `${baseTemplate}expedited-lpa`;
-			formattedAppellantTemplate = `${baseTemplate}expedited-appellant`;
-			break;
-		case APPEAL_CASE_PROCEDURE.WRITTEN_PART_2:
-		case PROCEDURE_TYPE_KEY.WRITTEN_PART_2:
-		default:
-			formattedLPATemplate = `${baseTemplate}lpa`;
-			formattedAppellantTemplate = `${baseTemplate}appellant`;
-			break;
-	}
+	const { lpaTemplate: formattedLPATemplate, appellantTemplate: formattedAppellantTemplate } =
+		getNotifyTemplateNames(procedureType, appealTypeKey, hearingStartTime, caseIsStarted);
 
 	const appellantEmail = appeal.appellant?.email || appeal.agent?.email;
 	const lpaEmail = appeal.lpa?.email || '';
@@ -161,47 +178,44 @@ const getStartCaseNotifyParams = async ({
 	const teamEmail = await getTeamEmailFromAppealId(appeal.id);
 	const childEnforcementsWithGrounds = await getChildEnforcementsWithGrounds(appeal);
 
+	/** @param {string | Date | null | undefined} dateStr */
+	const formatDeadline = (dateStr) => (dateStr ? formatDate(new Date(dateStr), false) : '');
+
+	const isWrittenReps =
+		!procedureType ||
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN ||
+		procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1;
+
 	// Note that those properties not used within the specified template will be ignored
 	const commonEmailVariables = {
 		appeal_reference_number: appeal.reference,
 		inspector_name: inspectorName ? inspectorName : null,
 		lpa_reference: appeal.applicationReference || '',
 		site_address: siteAddress,
-		start_date: formatDate(new Date(startDate || ''), false),
+		start_date: formatDeadline(startDate),
 		appellant_email_address: appellantEmail || '',
 		appeal_type: appealType || '',
 		procedure_type: PROCEDURE_TYPE_MAP[procedureType || 'written'],
-		questionnaire_due_date: formatDate(new Date(timetable.lpaQuestionnaireDueDate || ''), false),
+		questionnaire_due_date: formatDeadline(timetable.lpaQuestionnaireDueDate),
 		local_planning_authority: appeal.lpa?.name || '',
-		due_date: formatDate(new Date(timetable.lpaQuestionnaireDueDate || ''), false),
-		comment_deadline: formatDate(new Date(timetable.commentDeadline || ''), false),
-		lpa_statement_deadline: formatDate(
-			new Date(timetable.lpaStatementDueDate || timetable.statementDueDate || ''),
-			false
+		due_date: formatDeadline(timetable.lpaQuestionnaireDueDate),
+		comment_deadline: formatDeadline(timetable.commentDeadline),
+		lpa_statement_deadline: formatDeadline(
+			timetable.lpaStatementDueDate || timetable.statementDueDate
 		),
-		ip_comments_deadline: formatDate(new Date(timetable.ipCommentsDueDate || ''), false),
-		final_comments_deadline: formatDate(new Date(timetable.finalCommentsDueDate || ''), false),
-		statement_of_common_ground_deadline: formatDate(
-			new Date(timetable.statementOfCommonGroundDueDate || ''),
-			false
-		),
+		ip_comments_deadline: formatDeadline(timetable.ipCommentsDueDate),
+		final_comments_deadline: formatDeadline(timetable.finalCommentsDueDate),
+		statement_of_common_ground_deadline: formatDeadline(timetable.statementOfCommonGroundDueDate),
 		...(inquiry && {
-			proof_of_evidence_and_witnesses_deadline: formatDate(
-				new Date(timetable.proofOfEvidenceAndWitnessesDueDate || ''),
-				false
+			proof_of_evidence_and_witnesses_deadline: formatDeadline(
+				timetable.proofOfEvidenceAndWitnessesDueDate
 			)
 		}),
 		...(inquiry && {
-			case_management_conference_deadline: formatDate(
-				new Date(timetable.caseManagementConferenceDueDate || ''),
-				false
-			)
+			case_management_conference_deadline: formatDeadline(timetable.caseManagementConferenceDueDate)
 		}),
 		...(inquiry && {
-			planning_obligation_deadline: formatDate(
-				new Date(timetable.planningObligationDueDate || ''),
-				false
-			)
+			planning_obligation_deadline: formatDeadline(timetable.planningObligationDueDate)
 		}),
 		child_appeals:
 			appeal.childAppeals
@@ -209,14 +223,14 @@ const getStartCaseNotifyParams = async ({
 				.map((appeal) => appeal.childRef) || [],
 		team_email_address: teamEmail,
 		...(hearingStartTime && {
-			hearing_date: formatDate(new Date(hearingStartTime), false),
+			hearing_date: formatDeadline(hearingStartTime),
 			hearing_time: formatTime12h(hearingStartTime)
 		}),
 		...(hearingEstimatedDays && {
 			hearing_expected_days: hearingEstimatedDays
 		}),
 		...(inquiry && {
-			inquiry_date: formatDate(new Date(inquiry.inquiryStartTime), false),
+			inquiry_date: formatDeadline(inquiry.inquiryStartTime),
 			inquiry_time: formatTime12h(inquiry.inquiryStartTime),
 			inquiry_address: inquiry.inquiryAddress,
 			inquiry_expected_days: inquiry.inquiryEstimationDays
@@ -238,20 +252,11 @@ const getStartCaseNotifyParams = async ({
 				personalisation: {
 					...commonEmailVariables,
 					...(inquiry && { is_lpa: false }),
-					site_visit:
-						procedureType === APPEAL_CASE_PROCEDURE.WRITTEN ||
-						procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
-						procedureType === undefined, //undefined procedure types are treated as written
-					costs_info:
-						procedureType === APPEAL_CASE_PROCEDURE.WRITTEN ||
-						procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
-						procedureType === undefined,
+					site_visit: isWrittenReps,
+					costs_info: isWrittenReps,
 					...(isEnforcementCaseType(appeal.appealType?.key) &&
 						appeal.appellantCase?.planningObligation && {
-							planning_obligation_deadline: formatDate(
-								new Date(timetable.planningObligationDueDate || ''),
-								false
-							)
+							planning_obligation_deadline: formatDeadline(timetable.planningObligationDueDate)
 						})
 				}
 			}
@@ -266,14 +271,10 @@ const getStartCaseNotifyParams = async ({
 					...commonEmailVariables,
 					...(inquiry && { is_lpa: true }),
 					...(appeal.appealType?.key === APPEAL_CASE_TYPE.W && {
-						statement_of_common_ground_deadline: formatDate(
-							new Date(timetable.statementOfCommonGroundDueDate || ''),
-							false
+						statement_of_common_ground_deadline: formatDeadline(
+							timetable.statementOfCommonGroundDueDate
 						),
-						planning_obligation_deadline: formatDate(
-							new Date(timetable.planningObligationDueDate || ''),
-							false
-						)
+						planning_obligation_deadline: formatDeadline(timetable.planningObligationDueDate)
 					})
 				}
 			}
@@ -394,6 +395,65 @@ const generateStartCaseNotifyPreviews = async (
 };
 
 /**
+ * @param {Appeal} appeal
+ * @param {string | undefined} procedureType
+ * @returns {string}
+ */
+const getEffectiveProcedureType = (appeal, procedureType) => {
+	if (procedureType) {
+		return procedureType;
+	}
+
+	const rawAppDate = appeal.appellantCase?.applicationDate;
+	const applicationDateStr = rawAppDate instanceof Date ? rawAppDate.toISOString() : rawAppDate;
+
+	const isHasOrCasPart1 =
+		isExpeditedAppealType(appeal.appealType?.key) &&
+		Boolean(applicationDateStr) &&
+		!beforeExpeditedOriginalApplicationCutOff(applicationDateStr);
+
+	return isHasOrCasPart1 ? APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 : (appeal.procedureType?.key ?? '');
+};
+
+/**
+ * @param {Object} params
+ * @param {number} params.appealId
+ * @param {string | undefined} params.azureAdUserId
+ * @param {string} params.procedureType
+ * @param {string} [params.hearingStartTime]
+ */
+const createStartCaseAuditTrails = async ({
+	appealId,
+	azureAdUserId,
+	procedureType,
+	hearingStartTime
+}) => {
+	await createAuditTrail({
+		appealId,
+		azureAdUserId,
+		details: AUDIT_TRAIL_CASE_TIMELINE_CREATED
+	});
+
+	await createAuditTrail({
+		appealId,
+		azureAdUserId,
+		details: stringTokenReplacement(AUDIT_TRAIL_CASE_STARTED, [
+			mapProcedureTypeForAudit(procedureType)
+		])
+	});
+
+	if (hearingStartTime) {
+		await createAuditTrail({
+			appealId,
+			azureAdUserId,
+			details: stringTokenReplacement(AUDIT_TRAIL_HEARING_SET_UP, [
+				dateISOStringToDisplayDate(hearingStartTime)
+			])
+		});
+	}
+};
+
+/**
  *
  * @param {Appeal} appeal
  * @param {string} startDate
@@ -403,7 +463,7 @@ const generateStartCaseNotifyPreviews = async (
  * @param {string} [hearingStartTime]
  * @param {string} [hearingEstimatedDays]
  * @param {string | null | undefined} inspectorName
- * @returns
+ * @returns {Promise<{ success: boolean, timetable?: any }>}
  */
 const startCase = async (
 	appeal,
@@ -416,6 +476,11 @@ const startCase = async (
 	inspectorName = null
 ) => {
 	try {
+		const appealType = appeal.appealType || null;
+		if (!appealType) {
+			throw new Error('Appeal type is required to start a case.');
+		}
+
 		const isChildAppeal =
 			isLinkedAppealsActive(appeal) &&
 			Boolean(
@@ -423,11 +488,6 @@ const startCase = async (
 					(parentAppeal) => parentAppeal.type === CASE_RELATIONSHIP_LINKED
 				).length
 			);
-
-		const appealType = appeal.appealType || null;
-		if (!appealType) {
-			throw new Error('Appeal type is required to start a case.');
-		}
 
 		const startedAt = await recalculateDateIfNotBusinessDay(startDate);
 		const isS78Expedited = isS78ExpeditedAppealType(
@@ -437,86 +497,72 @@ const startCase = async (
 			appeal.appellantCase?.typeOfPlanningApplication
 		);
 
+		const effectiveProcedureType = getEffectiveProcedureType(appeal, procedureType);
+
 		const timetable = await calculateTimetable(
 			appealType.key,
 			startedAt,
-			procedureType,
+			effectiveProcedureType,
 			null,
 			isS78Expedited
 		);
-		const startDateWithTimeCorrection = setTimeInTimeZone(startedAt, 0, 0);
 
-		const procedureTypeId = procedureType && PROCEDURE_TYPE_ID_MAP[procedureType];
-
-		if (timetable) {
-			await Promise.all([
-				// @ts-ignore
-				appealTimetableRepository.upsertAppealTimetableById(appeal.id, timetable),
-				appealRepository.updateAppealById(appeal.id, {
-					caseStartedDate: startDateWithTimeCorrection.toISOString(),
-					...(procedureTypeId && { procedureTypeId }),
-					...(hearingStartTime && { hearingStartTime }),
-					...(hearingEstimatedDays && { hearingEstimatedDays })
-				})
-			]);
-
-			await transitionState(
-				appeal.id,
-				azureAdUserId || AUDIT_TRAIL_SYSTEM_UUID,
-				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE
-			);
-
-			await createAuditTrail({
-				appealId: appeal.id,
-				azureAdUserId,
-				details: AUDIT_TRAIL_CASE_TIMELINE_CREATED
-			});
-
-			await createAuditTrail({
-				appealId: appeal.id,
-				azureAdUserId,
-				details: stringTokenReplacement(AUDIT_TRAIL_CASE_STARTED, [
-					mapProcedureTypeForAudit(procedureType)
-				])
-			});
-
-			if (hearingStartTime) {
-				await createAuditTrail({
-					appealId: appeal.id,
-					azureAdUserId,
-					details: stringTokenReplacement(AUDIT_TRAIL_HEARING_SET_UP, [
-						dateISOStringToDisplayDate(hearingStartTime)
-					])
-				});
-			}
-
-			if (!isChildAppeal) {
-				const siteAddress = appeal.address
-					? formatAddressSingleLine(appeal.address)
-					: 'Address not available';
-
-				await sendStartCaseNotifies(
-					appeal,
-					startDateWithTimeCorrection,
-					notifyClient,
-					siteAddress,
-					azureAdUserId,
-					timetable,
-					procedureType,
-					hearingStartTime,
-					hearingEstimatedDays,
-					inspectorName
-				);
-			}
-
-			await broadcasters.broadcastAppeal(appeal.id);
-			return { success: true, timetable };
+		if (!timetable) {
+			return { success: false };
 		}
+
+		const startDateWithTimeCorrection = setTimeInTimeZone(startedAt, 0, 0);
+		const procedureTypeId = effectiveProcedureType && PROCEDURE_TYPE_ID_MAP[effectiveProcedureType];
+
+		await Promise.all([
+			// @ts-ignore
+			appealTimetableRepository.upsertAppealTimetableById(appeal.id, timetable),
+			appealRepository.updateAppealById(appeal.id, {
+				caseStartedDate: startDateWithTimeCorrection.toISOString(),
+				...(procedureTypeId && { procedureTypeId }),
+				...(hearingStartTime && { hearingStartTime }),
+				...(hearingEstimatedDays && { hearingEstimatedDays })
+			})
+		]);
+
+		await transitionState(
+			appeal.id,
+			azureAdUserId || AUDIT_TRAIL_SYSTEM_UUID,
+			APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE
+		);
+
+		await createStartCaseAuditTrails({
+			appealId: appeal.id,
+			azureAdUserId,
+			procedureType: effectiveProcedureType,
+			hearingStartTime
+		});
+
+		if (!isChildAppeal) {
+			const siteAddress = appeal.address
+				? formatAddressSingleLine(appeal.address)
+				: 'Address not available';
+
+			await sendStartCaseNotifies(
+				appeal,
+				startDateWithTimeCorrection,
+				notifyClient,
+				siteAddress,
+				azureAdUserId,
+				timetable,
+				effectiveProcedureType,
+				hearingStartTime,
+				hearingEstimatedDays,
+				inspectorName
+			);
+		}
+
+		await broadcasters.broadcastAppeal(appeal.id);
+		return { success: true, timetable };
 	} catch (error) {
 		logger.error(`Error starting case for appeal ID ${appeal.id}: ${error}`);
+		return { success: false };
 	}
-
-	return { success: false };
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

Updates:
Sets HAS, CAS Adverts and CAS Planning to use Written Part 1 procedure type when starting case.
Also refactored some functions related to this to separate logic and reduce size of existing functions for readability


Testing:
Tested each appeal type in browser
Added unit tests to cover param generation for notifies to give more confidence
Added unit test to cover starting the different appeal types

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8876)
