### PR TITLE
test(appeals): reduce e2e pipelines agents (A2-8955)

### DIFF
--- a/azure-pipelines-e2e-appeals.yml
+++ b/azure-pipelines-e2e-appeals.yml
@@ -6,7 +6,7 @@ parameters:
 
   - name: RunParallel
     type: boolean
-    default: true
+    default: false
 
 variables:
   - name: APP


### PR DESCRIPTION
## Describe your changes

Reduce the number of parallel agents running on the nightly pipeline.
We are currently receiving flaky test results during the nightly build. Assuming the database can’t handle the load it’s put under with 3 agents.

## Issue ticket number and link

[A2-8955](https://pins-ds.atlassian.net/browse/A2-8955)


[A2-8955]: https://pins-ds.atlassian.net/browse/A2-8955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ