### PR TITLE
fix(appeals): remove refernce to undefined property on environmental …

### DIFF
--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -1409,6 +1409,7 @@ export const appealDetailsPageDisplaySelect = /** @type {Object} */ {
 					guid: true,
 					name: true,
 					isDeleted: true,
+					createdAt: true,
 					latestDocumentVersion: {
 						select: {
 							documentGuid: true,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/environmental-assessment.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/environmental-assessment.mapper.test.js
@@ -58,7 +58,7 @@ describe('environmental-assessment.mapper', () => {
 		data.appealDetails.environmentalAssessment.documentCount = 1;
 		data.appealDetails.environmentalAssessment.documents = [
 			{
-				latestDocumentVersion: { dateReceived: new Date('2025-02-01') }
+				createdAt: new Date('2025-02-01')
 			}
 		];
 		const mappedData = mapEnvironmentalAssessment(data);
@@ -88,13 +88,13 @@ describe('environmental-assessment.mapper', () => {
 		data.appealDetails.environmentalAssessment.documentCount = 3;
 		data.appealDetails.environmentalAssessment.documents = [
 			{
-				latestDocumentVersion: { dateReceived: new Date('2025-02-01') }
+				createdAt: new Date('2025-02-01')
 			},
 			{
-				latestDocumentVersion: { dateReceived: new Date('2025-01-01') }
+				createdAt: new Date('2025-01-01')
 			},
 			{
-				latestDocumentVersion: { dateReceived: new Date('2025-03-01') }
+				createdAt: new Date('2025-03-01')
 			}
 		];
 		const mappedData = mapEnvironmentalAssessment(data);

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/environmental-assessment.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/environmental-assessment.mapper.js
@@ -27,12 +27,11 @@ export const mapEnvironmentalAssessment = (data) => {
 				return currentDocument;
 			}
 
-			return latestReceivedDocument?.latestDocumentVersion?.dateReceived >
-				currentDocument.latestDocumentVersion?.dateReceived
+			return latestReceivedDocument?.createdAt > currentDocument.createdAt
 				? latestReceivedDocument
 				: currentDocument;
 		},
-		{ latestDocumentVersion: { dateReceived: '' } }
+		{ createdAt: '' }
 	);
 
 	const text = 'Environmental services team review';
@@ -44,8 +43,8 @@ export const mapEnvironmentalAssessment = (data) => {
 			? `${environmentalAssessment.documentCount} document${environmentalAssessment.documentCount === 1 ? '' : 's'}`
 			: 'No documents',
 		receivedText:
-			documents?.length && latestReceivedDocument?.latestDocumentVersion?.dateReceived
-				? dateISOStringToDisplayDate(latestReceivedDocument.latestDocumentVersion.dateReceived)
+			documents?.length && latestReceivedDocument?.createdAt
+				? dateISOStringToDisplayDate(latestReceivedDocument.createdAt)
 				: 'Not applicable',
 		actionHtml: actionsHtml({
 			id,


### PR DESCRIPTION
…assessment docs (A2-8953)

## Describe your changes

Bug raised in product support - some appeal detail pages not opening.
This PR changes the date time property referenced on EIA appeal docs to `createdAt` rather than  `latestDocumentVersion.dateReceived` as `latestDocumentVersion` data is only fetched for first 5 docs.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8953)
