### PR TITLE
fix(web): remove display for unneeded due dates for writtenPart1 procedure type (A2-8946)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -5301,6 +5301,37 @@ describe('appeal-details', () => {
 					expect(caseTimeTable).toMatchSnapshot();
 				});
 
+				it('should not render LPA statement, IP comments, Statement of common ground, or Final comments due dates for S78 Part 1 procedureType appeals', async () => {
+					nock('http://test/')
+						.get(`/appeals/${appealId}/page-details`)
+						.reply(200, {
+							...appealDataFullPlanning,
+							caseOfficer: '2cb7735e-c4cf-410b-b773-5ec4cf110b87',
+							appealId,
+							procedureType: 'Part 1',
+							appealTimetable: {
+								lpaQuestionnaireDueDate: '2026-04-10T23:59:00.000Z',
+								lpaStatementDueDate: '2026-04-20T23:59:00.000Z',
+								ipCommentsDueDate: '2026-04-20T23:59:00.000Z',
+								statementOfCommonGroundDueDate: '2026-04-20T23:59:00.000Z',
+								finalCommentsDueDate: '2026-04-30T23:59:00.000Z'
+							}
+						});
+					const response = await request.get(`${baseUrl}/${appealId}`);
+					expect(response.statusCode).toBe(200);
+
+					const caseTimeTable = parseHtml(response.text, {
+						rootElement: '.appeal-case-timetable',
+						skipPrettyPrint: true
+					}).innerHTML;
+
+					expect(caseTimeTable).toContain('LPA questionnaire due');
+					expect(caseTimeTable).not.toContain('LPA statement due');
+					expect(caseTimeTable).not.toContain('Interested party comments due');
+					expect(caseTimeTable).not.toContain('Statement of common ground due');
+					expect(caseTimeTable).not.toContain('Final comments due');
+				});
+
 				it('should render a "Timetable" with all rows with the IP comments due date and change link displaying when published IP comments count equals zero', async () => {
 					nock('http://test/')
 						.get(`/appeals/${appealId}/page-details`)

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/ip-comments-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/ip-comments-due-date.mapper.test.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { mapIpCommentsDueDate } from '#lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common';
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 describe.each([
 	['S78', APPEAL_TYPE.S78],
@@ -120,27 +121,9 @@ describe.each([
 			id: 'ip-comments-due-date'
 		});
 	});
-});
-describe('S78 expedited appeal - ip-comments-due-date.mapper', () => {
-	let data;
-	beforeEach(() => {
-		data = {
-			currentRoute: '/test',
-			appealDetails: {
-				startedAt: '2026-04-01',
-				appealTimetable: { ipCommentsDueDate: '' },
-				documentationSummary: { ipComments: { counts: { published: 0 } } },
-				appealType: APPEAL_TYPE.S78
-			},
-			appellantCase: {
-				applicationDate: '2026-04-01',
-				applicationDecision: 'refused',
-				typeOfPlanningApplication: 'full-appeal'
-			},
-			userHasUpdateCasePermission: true
-		};
-	});
-	it(`should not display IP Comments due date`, () => {
+
+	it('should not display IP Comments due date for writtenPart1 procedure type', () => {
+		data.appealDetails.procedureType = APPEAL_CASE_PROCEDURE.WRITTEN_PART_1;
 		const mappedData = mapIpCommentsDueDate(data);
 		expect(mappedData).toEqual({
 			display: {},

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
@@ -2,26 +2,21 @@ import { isStatePassed } from '#lib/appeal-status.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
-import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapIpCommentsDueDate = ({
 	appealDetails,
 	currentRoute,
-	userHasUpdateCasePermission,
-	appellantCase
+	userHasUpdateCasePermission
 }) => {
 	const id = 'ip-comments-due-date';
 
 	if (
 		!appealDetails.startedAt ||
-		isS78ExpeditedAppealType(
-			appealDetails.appealType,
-			appellantCase?.applicationDate,
-			appellantCase?.applicationDecision,
-			appellantCase?.typeOfPlanningApplication
-		)
+		appealDetails.procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
+		appealDetails.procedureType === PROCEDURE_TYPE_NAME.WRITTEN_PART_1
 	) {
 		return { id, display: {} };
 	}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
@@ -2,27 +2,21 @@ import { isStatePassed } from '#lib/appeal-status.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
-import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
-import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapLpaStatementDueDate = ({
 	appealDetails,
 	currentRoute,
-	userHasUpdateCasePermission,
-	appellantCase
+	userHasUpdateCasePermission
 }) => {
 	const id = 'lpa-statement-due-date';
 
 	if (
 		!appealDetails.startedAt ||
-		isS78ExpeditedAppealType(
-			appealDetails.appealType,
-			appellantCase?.applicationDate,
-			appellantCase?.applicationDecision,
-			appellantCase?.typeOfPlanningApplication
-		)
+		appealDetails.procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
+		appealDetails.procedureType === PROCEDURE_TYPE_NAME.WRITTEN_PART_1
 	) {
 		return { id, display: {} };
 	}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/statement-of-common-ground-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/statement-of-common-ground-due-date.mapper.js
@@ -1,30 +1,23 @@
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
-import {
-	isLdcOrDiscontinuanceOrEnforcementAppealType,
-	isS78ExpeditedAppealType
-} from '@pins/appeals/utils/appeal-type-checks.js';
+import { PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
+import { isLdcOrDiscontinuanceOrEnforcementAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapStatementOfCommonGroundDueDate = ({
 	appealDetails,
 	currentRoute,
-	userHasUpdateCasePermission,
-	appellantCase
+	userHasUpdateCasePermission
 }) => {
 	const id = 'statement-of-common-ground-due-date';
 
 	if (
 		!appealDetails.startedAt ||
+		appealDetails.procedureType === APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 ||
+		appealDetails.procedureType === PROCEDURE_TYPE_NAME.WRITTEN_PART_1 ||
 		appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN ||
-		isS78ExpeditedAppealType(
-			appealDetails.appealType,
-			appellantCase?.applicationDate,
-			appellantCase?.applicationDecision,
-			appellantCase?.typeOfPlanningApplication
-		) ||
 		(appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING &&
 			isLdcOrDiscontinuanceOrEnforcementAppealType(appealDetails.appealType))
 	) {

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -522,12 +522,6 @@ const s78timetable = {
 const s78ExpeditedTimetable = {
 	lpaQuestionnaireDueDate: {
 		daysFromStartDate: 5
-	},
-	finalCommentsDueDate: {
-		daysFromStartDate: 35
-	},
-	s106ObligationDueDate: {
-		daysFromStartDate: 35
 	}
 };
 const advertTimetable = {

--- a/packages/appeals/utils/__tests__/business-rules.test.js
+++ b/packages/appeals/utils/__tests__/business-rules.test.js
@@ -44,6 +44,13 @@ describe('displayFinalComments', () => {
 				expect(displayFinalComments(appealType, procedureType)).toBe(false);
 			}
 		);
+
+		it.each([APPEAL_CASE_PROCEDURE.WRITTEN_PART_1, 'Part 1'])(
+			'returns false for writtenPart1 / Part 1 procedure: %s',
+			(procedureType) => {
+				expect(displayFinalComments(appealType, procedureType)).toBe(false);
+			}
+		);
 	});
 });
 

--- a/packages/appeals/utils/business-rules.js
+++ b/packages/appeals/utils/business-rules.js
@@ -3,6 +3,7 @@ import {
 	APPEAL_CASE_STATUS,
 	APPEAL_CASE_TYPE
 } from '@planning-inspectorate/data-model';
+import { PROCEDURE_TYPE_NAME } from '../constants/common.js';
 import { isLdcOrDiscontinuanceOrEnforcementAppealType } from './appeal-type-checks.js';
 import { normaliseProcedureType } from './procedure-type.js';
 
@@ -21,7 +22,9 @@ import { normaliseProcedureType } from './procedure-type.js';
 export const displayFinalComments = (appealType, procedureType) =>
 	isLdcOrDiscontinuanceOrEnforcementAppealType(appealType) ||
 	(procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.HEARING &&
-		procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.INQUIRY);
+		procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.INQUIRY &&
+		procedureType !== APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 &&
+		procedureType !== PROCEDURE_TYPE_NAME.WRITTEN_PART_1);
 
 /**
  * Determines the next state after the LPAQ is complete based on the appeal type and procedure type.


### PR DESCRIPTION
## Describe your changes

### Updates:
Remove the final comments row for writtenPart1 procedure type.
Prevent generation of unneeded due dates for S78 expedited
remove check of s78 expedited appeal type as it doesn't cover the display of rows as required

### Tests:
Added unit test for the row display of S78 expedited appeals.
Manually tested in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8946)
