### PR TITLE
feat(appeals): adding new timetable updated notify for enforcement he…

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -14,6 +14,7 @@ import {
 	advertisementAppealWithTimetable,
 	casAdvertAppealWithTimetable,
 	casPlanningAppealWithTimetable,
+	enforcementNoticeHearingAppealWithTimetable,
 	fullPlanningAppealExpediteWithTimetable,
 	fullPlanningAppealWithTimetable,
 	fullPlanningHearingAppealWithTimetable,
@@ -76,6 +77,11 @@ describe('appeal timetables routes', () => {
 				lpaQuestionnaireDueDate: utcDate.toISOString(),
 				lpaStatementDueDate: utcDate.toISOString()
 			};
+			const enforcementNoticeAppealRequestBody = {
+				lpaQuestionnaireDueDate: utcDate.toISOString(),
+				lpaStatementDueDate: utcDate.toISOString(),
+				finalCommentsDueDate: utcDate.toISOString()
+			};
 
 			const householdAppealResponseBody = {
 				lpaQuestionnaireDueDate: responseDateSet
@@ -83,6 +89,11 @@ describe('appeal timetables routes', () => {
 			const fullPlanningAppealResponseBody = {
 				lpaQuestionnaireDueDate: responseDateSet,
 				lpaStatementDueDate: responseDateSet
+			};
+			const enforcementNoticeAppealResponseBody = {
+				lpaQuestionnaireDueDate: responseDateSet,
+				lpaStatementDueDate: responseDateSet,
+				finalCommentsDueDate: responseDateSet
 			};
 
 			test.each([
@@ -156,7 +167,8 @@ describe('appeal timetables routes', () => {
 							proof_of_evidence_and_witnesses_due_date: '',
 							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
 							statement_of_common_ground_due_date: '',
-							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk',
+							appellant: true
 						},
 						recipientEmail: appealWithTimetable.agent.email,
 						templateName: 'has-appeal-timetable-updated'
@@ -181,7 +193,8 @@ describe('appeal timetables routes', () => {
 							proof_of_evidence_and_witnesses_due_date: '',
 							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
 							statement_of_common_ground_due_date: '',
-							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk',
+							appellant: false
 						},
 						recipientEmail: appealWithTimetable.lpa.email,
 						templateName: 'has-appeal-timetable-updated'
@@ -264,7 +277,8 @@ describe('appeal timetables routes', () => {
 							proof_of_evidence_and_witnesses_due_date: '',
 							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
 							statement_of_common_ground_due_date: '',
-							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk',
+							appellant: true
 						},
 						recipientEmail: appealWithTimetable.agent.email,
 						templateName: expectedTemplateName
@@ -289,7 +303,99 @@ describe('appeal timetables routes', () => {
 							proof_of_evidence_and_witnesses_due_date: '',
 							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
 							statement_of_common_ground_due_date: '',
-							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk',
+							appellant: false
+						},
+						recipientEmail: appealWithTimetable.lpa.email,
+						templateName: expectedTemplateName
+					});
+
+					expect(response.status).toEqual(200);
+					expect(response.body).toEqual(requestBody);
+				}
+			);
+
+			test.each([
+				[
+					'notice hearing',
+					enforcementNoticeHearingAppealWithTimetable,
+					enforcementNoticeAppealRequestBody,
+					enforcementNoticeAppealResponseBody,
+					'appeal-timetable-updated-enforcement-hearing'
+				]
+			])(
+				'updates a enforcement %s appeal timetable and sends notify',
+				async (_, appealWithTimetable, requestBody, responseBody, expectedTemplateName) => {
+					// @ts-ignore
+					databaseConnector.appeal.findUnique.mockResolvedValue(appealWithTimetable);
+					// @ts-ignore
+					databaseConnector.user.upsert.mockResolvedValue({
+						id: 1,
+						azureAdUserId
+					});
+
+					const { appealTimetable, id } = appealWithTimetable;
+					const response = await request
+						.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
+						.send(requestBody)
+						.set('azureAdUserId', azureAdUserId);
+
+					expect(databaseConnector.appealTimetable.update).toHaveBeenCalledWith({
+						data: responseBody,
+						where: {
+							appealId: appealWithTimetable.id
+						}
+					});
+
+					expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
+						azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
+						notifyClient: expect.any(Object),
+						personalisation: {
+							appeal_reference_number: appealWithTimetable.reference,
+							case_management_conference_due_date: '',
+							final_comments_due_date: dateISOStringToDisplayDate(
+								responseBody?.finalCommentsDueDate
+							),
+							ip_comments_due_date: dateISOStringToDisplayDate(responseBody?.ipCommentsDueDate),
+							lpa_questionnaire_due_date: dateISOStringToDisplayDate(
+								responseBody?.lpaQuestionnaireDueDate
+							),
+							lpa_reference: appealWithTimetable.applicationReference,
+							lpa_statement_due_date: dateISOStringToDisplayDate(responseBody?.lpaStatementDueDate),
+							planning_obligation_due_date: '',
+							proof_of_evidence_and_witnesses_due_date: '',
+							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
+							statement_of_common_ground_due_date: '',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk',
+							enforcement_reference: 'Reference',
+							appellant: true
+						},
+						recipientEmail: appealWithTimetable.agent.email,
+						templateName: expectedTemplateName
+					});
+
+					expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
+						azureAdUserId: '6f930ec9-7f6f-448c-bb50-b3b898035959',
+						notifyClient: expect.any(Object),
+						personalisation: {
+							appeal_reference_number: appealWithTimetable.reference,
+							case_management_conference_due_date: '',
+							final_comments_due_date: dateISOStringToDisplayDate(
+								responseBody?.finalCommentsDueDate
+							),
+							ip_comments_due_date: dateISOStringToDisplayDate(responseBody?.ipCommentsDueDate),
+							lpa_questionnaire_due_date: dateISOStringToDisplayDate(
+								responseBody?.lpaQuestionnaireDueDate
+							),
+							lpa_reference: appealWithTimetable.applicationReference,
+							lpa_statement_due_date: dateISOStringToDisplayDate(responseBody?.lpaStatementDueDate),
+							planning_obligation_due_date: '',
+							proof_of_evidence_and_witnesses_due_date: '',
+							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
+							statement_of_common_ground_due_date: '',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk',
+							enforcement_reference: 'Reference',
+							appellant: false
 						},
 						recipientEmail: appealWithTimetable.lpa.email,
 						templateName: expectedTemplateName

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
@@ -128,7 +128,8 @@ router.patch(
 		'appellant',
 		'agent',
 		'lpa',
-		'appealRule6Parties'
+		'appealRule6Parties',
+		'appellantCase'
 	]),
 	checkAppealTimetableExists,
 	patchAppealTimetableValidator,

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -8,6 +8,7 @@ import { notifySend, renderTemplate } from '#notify/notify-send.js';
 import appealTimetableRepository from '#repositories/appeal-timetable.repository.js';
 import appealRepository from '#repositories/appeal.repository.js';
 import transitionState from '#state/transition-state.js';
+import { getEnforcementReference } from '#utils/get-enforcement-reference.js';
 import { isLinkedAppealsActive } from '#utils/is-linked-appeal.js';
 import { getChildEnforcementsWithGrounds } from '#utils/link-appeals.js';
 import logger from '#utils/logger.js';
@@ -38,6 +39,7 @@ import {
 	recalculateDateIfNotBusinessDay,
 	setTimeInTimeZone
 } from '@pins/appeals/utils/business-days.js';
+import { displayPlanningObligation } from '@pins/appeals/utils/business-rules.js';
 import formatDate, {
 	dateISOStringToDisplayDate,
 	formatTime12h
@@ -711,6 +713,8 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 		return formatDate(new Date(isoDate), false) || '';
 	};
 
+	const enforcementReference = await getEnforcementReference(appeal);
+
 	const personalisation = {
 		appeal_reference_number: appeal.reference,
 		lpa_reference: appeal.applicationReference || '',
@@ -761,9 +765,14 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 		),
 		// @ts-ignore
 		planning_obligation_due_date: optionalDate(
-			// @ts-ignore
-			processedBody['planningObligationDueDate'] ||
-				appeal.appealTimetable?.planningObligationDueDate
+			displayPlanningObligation(
+				appeal.appealType?.type ?? undefined,
+				appeal.procedureType?.key ?? undefined,
+				appeal.appellantCase?.planningObligation ?? undefined
+			) &&
+				// @ts-ignore
+				(processedBody['planningObligationDueDate'] ||
+					appeal.appealTimetable?.planningObligationDueDate)
 		),
 		// @ts-ignore
 		case_management_conference_due_date: optionalDate(
@@ -771,7 +780,8 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 			processedBody['caseManagementConferenceDueDate'] ||
 				appeal.appealTimetable?.caseManagementConferenceDueDate
 		),
-		team_email_address: await getTeamEmailFromAppealId(appeal.id)
+		team_email_address: await getTeamEmailFromAppealId(appeal.id),
+		...(enforcementReference && { enforcement_reference: enforcementReference })
 	};
 
 	const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
@@ -787,7 +797,7 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 			templateName,
 			notifyClient,
 			recipientEmail,
-			personalisation
+			personalisation: { ...personalisation, appellant: true }
 		});
 	}
 
@@ -797,7 +807,7 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 			templateName,
 			notifyClient,
 			recipientEmail: lpaEmail,
-			personalisation
+			personalisation: { ...personalisation, appellant: false }
 		});
 	}
 
@@ -809,7 +819,7 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 					templateName,
 					notifyClient,
 					recipientEmail: party.serviceUser.email,
-					personalisation
+					personalisation: { ...personalisation, appellant: false }
 				});
 			}
 		});
@@ -865,6 +875,14 @@ const getTimetableUpdatedTemplateName = (appealTypeKey, procedureType) => {
 		case APPEAL_CASE_TYPE.ZP:
 		case APPEAL_CASE_TYPE.ZA:
 			return 'has-appeal-timetable-updated';
+		case APPEAL_CASE_TYPE.C:
+			if (procedureType === APPEAL_CASE_PROCEDURE.INQUIRY) {
+				return 'appeal-timetable-updated-inquiry';
+			}
+			if (procedureType === APPEAL_CASE_PROCEDURE.HEARING) {
+				return 'appeal-timetable-updated-enforcement-hearing';
+			}
+			return 'appeal-timetable-updated';
 
 		default:
 			if (procedureType === APPEAL_CASE_PROCEDURE.INQUIRY) {

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-timetable-updated-enforcement-hearing.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-timetable-updated-enforcement-hearing.test.js
@@ -1,0 +1,218 @@
+import { notifySend } from '#notify/notify-send.js';
+import { jest } from '@jest/globals';
+
+describe('appeal-timetable-updated-enforcement-hearing.content.md', () => {
+	const basePersonalisation = {
+		appeal_reference_number: '134526',
+		lpa_reference: '48269/APP/2021/1482',
+		site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+		lpa_questionnaire_due_date: '01 January 2025',
+		lpa_statement_due_date: '10 January 2025',
+		ip_comments_due_date: '20 January 2025',
+		team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+	};
+
+	test('should render all conditional sections when all optional values are present', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'appeal-timetable-updated-enforcement-hearing',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				...basePersonalisation,
+				appellant: true,
+				planning_obligation_due_date: '23 January 2025',
+				final_comments_due_date: '24 January 2025',
+				statement_of_common_ground_due_date: '25 January 2025',
+				proof_of_evidence_and_witnesses_due_date: '26 January 2025'
+			}
+		};
+
+		const expectedContent = [
+			'We have updated your timetable.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: 134526',
+			'Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+			'Planning application reference: 48269/APP/2021/1482',
+			'',
+			'# Timetable',
+			'',
+			'## Local planning authority questionnaire',
+			'Due by 01 January 2025.',
+			'',
+			'## Statements',
+			'Due by 10 January 2025.',
+			'',
+			'## Interested party comments',
+			'Due by 20 January 2025.',
+			'',
+			'## Planning obligation',
+			'Send to caseofficers@planninginspectorate.gov.uk by 23 January 2025.',
+			'',
+			'## Final comments',
+			'Due by 24 January 2025.',
+			'',
+			'## Statement of common ground',
+			'Send to caseofficers@planninginspectorate.gov.uk by 25 January 2025.',
+			'',
+			'## Proof of evidence and witnesses',
+			'Due by 26 January 2025.',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'We have updated your timetable: 134526'
+			}
+		);
+	});
+
+	test('should not render planning obligation when appellant is not set', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'appeal-timetable-updated-enforcement-hearing',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				...basePersonalisation,
+				planning_obligation_due_date: '23 January 2025',
+				final_comments_due_date: '',
+				statement_of_common_ground_due_date: '',
+				proof_of_evidence_and_witnesses_due_date: ''
+			}
+		};
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			'test@136s7.com',
+			expect.objectContaining({
+				subject: 'We have updated your timetable: 134526',
+				content: expect.not.stringContaining('## Planning obligation')
+			})
+		);
+	});
+
+	test('should render only required sections when optional values are empty', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'appeal-timetable-updated-enforcement-hearing',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				...basePersonalisation,
+				appellant: true,
+				planning_obligation_due_date: '',
+				final_comments_due_date: '',
+				statement_of_common_ground_due_date: '',
+				proof_of_evidence_and_witnesses_due_date: ''
+			}
+		};
+
+		const expectedContent = [
+			'We have updated your timetable.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: 134526',
+			'Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+			'Planning application reference: 48269/APP/2021/1482',
+			'',
+			'# Timetable',
+			'',
+			'## Local planning authority questionnaire',
+			'Due by 01 January 2025.',
+			'',
+			'## Statements',
+			'Due by 10 January 2025.',
+			'',
+			'## Interested party comments',
+			'Due by 20 January 2025.',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'We have updated your timetable: 134526'
+			}
+		);
+	});
+
+	test('should render enforcement notice reference text and only required sections when optional values are empty and we have enforcement ref', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'appeal-timetable-updated-enforcement-hearing',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				...basePersonalisation,
+				appellant: true,
+				enforcement_reference: 'ENF123456',
+				planning_obligation_due_date: '',
+				final_comments_due_date: '',
+				statement_of_common_ground_due_date: '',
+				proof_of_evidence_and_witnesses_due_date: ''
+			}
+		};
+
+		const expectedContent = [
+			'We have updated your timetable.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: 134526',
+			'Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+			'Enforcement notice reference: ENF123456',
+			'',
+			'# Timetable',
+			'',
+			'## Local planning authority questionnaire',
+			'Due by 01 January 2025.',
+			'',
+			'## Statements',
+			'Due by 10 January 2025.',
+			'',
+			'## Interested party comments',
+			'Due by 20 January 2025.',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'We have updated your timetable: 134526'
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/notify/templates/appeal-timetable-updated-enforcement-hearing.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-timetable-updated-enforcement-hearing.content.md
@@ -1,0 +1,39 @@
+We have updated your timetable.
+
+{% include 'parts/appeal-details.md' %}
+
+# Timetable
+
+## Local planning authority questionnaire
+Due by {{lpa_questionnaire_due_date}}.
+
+## Statements
+Due by {{lpa_statement_due_date}}.
+
+## Interested party comments
+Due by {{ip_comments_due_date}}.
+
+{% if appellant and planning_obligation_due_date -%}
+## Planning obligation
+Send to {{team_email_address}} by {{planning_obligation_due_date}}.
+
+{% endif -%}
+{% if final_comments_due_date -%}
+## Final comments
+Due by {{final_comments_due_date}}.
+
+{% endif -%}
+
+{% if statement_of_common_ground_due_date -%}
+## Statement of common ground
+Send to {{team_email_address}} by {{statement_of_common_ground_due_date}}.
+
+{% endif -%}
+{% if proof_of_evidence_and_witnesses_due_date -%}
+## Proof of evidence and witnesses
+Due by {{proof_of_evidence_and_witnesses_due_date}}.
+
+{% endif -%}
+
+Planning Inspectorate
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-timetable-updated-enforcement-hearing.subject.md
+++ b/appeals/api/src/server/notify/templates/appeal-timetable-updated-enforcement-hearing.subject.md
@@ -1,0 +1,1 @@
+We have updated your timetable: {{appeal_reference_number}}

--- a/appeals/api/src/server/tests/appeals/timetableMocks.js
+++ b/appeals/api/src/server/tests/appeals/timetableMocks.js
@@ -4,6 +4,7 @@ import {
 	appealS78Expedite,
 	casAdvertAppeal,
 	casPlanningAppeal,
+	enforcementNoticeAppeal,
 	fullPlanningAppeal,
 	householdAppeal,
 	ldcAppeal,
@@ -132,6 +133,25 @@ const fullPlanningHearingAppealWithTimetable = {
 	}
 };
 
+const enforcementNoticeHearingAppealWithTimetable = {
+	...enforcementNoticeAppeal,
+	procedureType: {
+		id: 3,
+		key: 'hearing',
+		name: 'Hearing'
+	},
+	caseStartedDate: new Date(2022, 4, 22),
+	caseValidationDate: new Date(2022, 4, 20),
+	caseValidDate: new Date(2022, 4, 20),
+	appealTimetable: {
+		appealId: 2,
+		id: 101,
+		lpaQuestionnaireDueDate: new Date('2023-05-16T01:00:00.000Z'),
+		lpaStatementDueDate: null,
+		finalCommentsDueDate: null
+	}
+};
+
 const listedBuildingAppealWithTimetable = {
 	...listedBuildingAppeal,
 	caseStartedDate: new Date(2022, 4, 22),
@@ -149,6 +169,7 @@ export {
 	advertisementAppealWithTimetable,
 	casAdvertAppealWithTimetable,
 	casPlanningAppealWithTimetable,
+	enforcementNoticeHearingAppealWithTimetable,
 	fullPlanningAppealExpediteWithTimetable,
 	fullPlanningAppealWithTimetable,
 	fullPlanningHearingAppealWithTimetable,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/planning-obligation-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/planning-obligation-due-date.mapper.js
@@ -1,8 +1,7 @@
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
-import { isAnyEnforcementAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
-import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { displayPlanningObligation } from '@pins/appeals/utils/business-rules.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapPlanningObligationDueDate = ({
@@ -15,12 +14,11 @@ export const mapPlanningObligationDueDate = ({
 
 	if (
 		!appealDetails.startedAt ||
-		(!isAnyEnforcementAppealType(appealDetails.appealType) &&
-			![APPEAL_CASE_PROCEDURE.HEARING, APPEAL_CASE_PROCEDURE.INQUIRY].includes(
-				// @ts-ignore
-				appealDetails.procedureType?.toLowerCase() ?? ''
-			)) ||
-		!appellantCase?.planningObligation?.hasObligation
+		!displayPlanningObligation(
+			appealDetails.appealType ?? undefined,
+			appealDetails.procedureType ?? undefined,
+			appellantCase?.planningObligation?.hasObligation ?? undefined
+		)
 	) {
 		return { id, display: {} };
 	}

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -390,6 +390,15 @@ these [Notify Templates](../appeals/api/src/server/notify/templates):
 - **Notify Content Template:** [advertisement-appeal-timetable-updated](../appeals/api/src/server/notify/templates/advertisement-appeal-timetable-updated.content.md)
 - **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent and LPA.
 
+### Timetable updated - enforcement hearing
+
+- **Appeal type:** enforcement
+- **Procedure:** Hearing
+- **Notify Subject Template:** [appeal-timetable-updated-enforcement-hearing](../appeals/api/src/server/notify/templates/appeal-timetable-updated-enforcement-hearing.subject.md)
+- **Notify Content Template:** [appeal-timetable-updated-enforcement-hearing](../appeals/api/src/server/notify/templates/appeal-timetable-updated-enforcement-hearing.content.md)
+- **GOV notify template:** [Timetable updated - GOV.UK notify](https://www.notifications.service.gov.uk/services/c46d894e-d10e-4c46-a467-019576cd906a/templates/53cb5239-a431-4db9-b88e-9d93686cce4c)
+- **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent and LPA.
+
 ## Appeal start date change
 
 ### Appeal start date change - appellant

--- a/packages/appeals/utils/__tests__/business-rules.test.js
+++ b/packages/appeals/utils/__tests__/business-rules.test.js
@@ -6,6 +6,7 @@ import {
 import { APPEAL_TYPE } from '../../constants/common';
 import {
 	displayFinalComments,
+	displayPlanningObligation,
 	targetStateOnLpaqComplete,
 	targetStateOnStatementsComplete
 } from '../business-rules.js';
@@ -42,6 +43,66 @@ describe('displayFinalComments', () => {
 			'returns false for %s',
 			(procedureType) => {
 				expect(displayFinalComments(appealType, procedureType)).toBe(false);
+			}
+		);
+	});
+});
+
+describe('displayPlanningObligation', () => {
+	describe.each([APPEAL_TYPE.ENFORCEMENT_NOTICE, APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING])(
+		'appeal type: %s',
+		(appealType) => {
+			it.each([
+				APPEAL_CASE_PROCEDURE.WRITTEN,
+				APPEAL_CASE_PROCEDURE.HEARING,
+				APPEAL_CASE_PROCEDURE.INQUIRY
+			])('returns true for %s when hasObligation = true', (procedureType) => {
+				expect(displayPlanningObligation(appealType, procedureType, true)).toBe(true);
+			});
+
+			it.each([
+				APPEAL_CASE_PROCEDURE.WRITTEN,
+				APPEAL_CASE_PROCEDURE.HEARING,
+				APPEAL_CASE_PROCEDURE.INQUIRY
+			])('returns true for %s when hasObligation = false', (procedureType) => {
+				expect(displayPlanningObligation(appealType, procedureType, false)).toBe(false);
+			});
+		}
+	);
+
+	describe.each([
+		APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE,
+		APPEAL_TYPE.DISCONTINUANCE_NOTICE,
+		APPEAL_TYPE.HOUSEHOLDER,
+		APPEAL_TYPE.S78,
+		APPEAL_TYPE.ADVERTISEMENT,
+		APPEAL_TYPE.PLANNED_LISTED_BUILDING,
+		APPEAL_TYPE.CAS_PLANNING,
+		APPEAL_TYPE.CAS_ADVERTISEMENT
+	])('appeal type: %s', (appealType) => {
+		it('returns false for written when hasObligation = true', () => {
+			expect(displayPlanningObligation(appealType, APPEAL_CASE_PROCEDURE.WRITTEN, true)).toBe(
+				false
+			);
+		});
+
+		it('returns false for written when hasObligation = false', () => {
+			expect(displayPlanningObligation(appealType, APPEAL_CASE_PROCEDURE.WRITTEN, false)).toBe(
+				false
+			);
+		});
+
+		it.each([APPEAL_CASE_PROCEDURE.HEARING, APPEAL_CASE_PROCEDURE.INQUIRY])(
+			'returns true for %s when hasObligation = true',
+			(procedureType) => {
+				expect(displayPlanningObligation(appealType, procedureType, true)).toBe(true);
+			}
+		);
+
+		it.each([APPEAL_CASE_PROCEDURE.HEARING, APPEAL_CASE_PROCEDURE.INQUIRY])(
+			'returns false for %s when hasObligation = false',
+			(procedureType) => {
+				expect(displayPlanningObligation(appealType, procedureType, false)).toBe(false);
 			}
 		);
 	});

--- a/packages/appeals/utils/business-rules.js
+++ b/packages/appeals/utils/business-rules.js
@@ -1,3 +1,4 @@
+import { isAnyEnforcementAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
 import {
 	APPEAL_CASE_PROCEDURE,
 	APPEAL_CASE_STATUS,
@@ -22,6 +23,22 @@ export const displayFinalComments = (appealType, procedureType) =>
 	isLdcOrDiscontinuanceOrEnforcementAppealType(appealType) ||
 	(procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.HEARING &&
 		procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.INQUIRY);
+
+// display planning obligation when it 'hasObligation' for any procedure type for enforcement appeal types
+// and only hearing and inquiry otherwise
+/**
+ * @param {string | undefined} appealType
+ * @param {string | undefined} procedureType
+ * @param {boolean | undefined} hasObligation
+ * @returns {boolean}
+ */
+export const displayPlanningObligation = (appealType, procedureType, hasObligation) =>
+	(isAnyEnforcementAppealType(appealType) ||
+		[APPEAL_CASE_PROCEDURE.HEARING, APPEAL_CASE_PROCEDURE.INQUIRY].includes(
+			// @ts-ignore
+			procedureType?.toLowerCase() ?? ''
+		)) &&
+	hasObligation;
 
 /**
  * Determines the next state after the LPAQ is complete based on the appeal type and procedure type.


### PR DESCRIPTION
…aring (A2-8908)

## Describe your changes

- Creating new notify subject and content
- Tests for the new notify content
- Creating business rules function for displayPlanningObligation and adding tests for it
- Using that function in the timetable section and to determine whether to show the planning obligation section in the new notify
- Adding logic to pass in whether the notify is going to an appellant or not
- Updating tests for the above
- Added the new notify to the notifications and triggers doc

### Tested locally

Appellant w/ planning obl
<img width="542" height="1285" alt="image" src="https://github.com/user-attachments/assets/784e852b-e196-43a5-bf1b-65a8dc4ea5cb" />

LPA w/ planning obl
<img width="652" height="1157" alt="image" src="https://github.com/user-attachments/assets/9819e55e-c6f7-4f15-a6da-451d7dd5aebd" />

Appellant w/o planning obl
<img width="550" height="1157" alt="image" src="https://github.com/user-attachments/assets/62a0291a-ebfc-42cd-90d2-562badebff75" />


LPA w/o planning obl
<img width="545" height="1127" alt="image" src="https://github.com/user-attachments/assets/7bfd077e-64bf-413c-b0c6-5c068b8e9437" />


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8908)