### PR TITLE
feat(api): ensure that the correct fields broadcast for CAS adverts (A2-8973)

### DIFF
--- a/appeals/api/src/server/mappers/__tests__/mapper-factory.test.js
+++ b/appeals/api/src/server/mappers/__tests__/mapper-factory.test.js
@@ -533,4 +533,76 @@ describe('appeals integration mappers', () => {
 			'anySignificantChangesLpa_courtJudgementSignificantChanges'
 		);
 	});
+
+	test('should map expedited fields in broadcast context for CAS Advert (ZA) post 1 April 2026', async () => {
+		const appealPostCutoff = {
+			...mocks.casAdvertExpediteAppeal,
+			appealType: { key: APPEAL_CASE_TYPE.ZA, type: 'CAS advert' },
+			appellantCase: { applicationDate: new Date('2026-04-02') },
+			lpaQuestionnaire: {
+				listOfDocumentsBeforeDecision: 'doc1, doc2',
+				anySignificantChangesLpa: 'Yes',
+				anySignificantChangesLpa_localPlanSignificantChanges: 'plan change'
+			},
+			folders: []
+		};
+
+		const broadcastOutput = mapCase({
+			// @ts-ignore
+			appeal: appealPostCutoff,
+			context: contextEnum.broadcast
+		});
+
+		expect(broadcastOutput).toHaveProperty('listOfDocumentsBeforeDecision', 'doc1, doc2');
+		expect(broadcastOutput).toHaveProperty('significantChangesAffectingApplicationLpa', [
+			{ value: 'adopted-a-new-local-plan', comment: 'plan change' }
+		]);
+	});
+
+	test('should not map expedited fields in broadcast context for CAS Advert (ZA) pre 1 April 2026', async () => {
+		const appealPreCutoff = {
+			...mocks.casAdvertExpediteAppeal,
+			appealType: { key: APPEAL_CASE_TYPE.ZA, type: 'CAS advert' },
+			appellantCase: { applicationDate: new Date('2026-03-30') },
+			lpaQuestionnaire: {
+				listOfDocumentsBeforeDecision: 'doc1, doc2',
+				anySignificantChangesLpa: 'Yes',
+				anySignificantChangesLpa_localPlanSignificantChanges: 'plan change'
+			},
+			folders: []
+		};
+
+		const broadcastOutput = mapCase({
+			// @ts-ignore
+			appeal: appealPreCutoff,
+			context: contextEnum.broadcast
+		});
+
+		expect(broadcastOutput).not.toHaveProperty('listOfDocumentsBeforeDecision');
+		expect(broadcastOutput).not.toHaveProperty('significantChangesAffectingApplicationLpa');
+	});
+
+	test('should map significantChangesAffectingApplicationLpa in broadcast context for CAS Planning (ZP)', async () => {
+		const casPlanningAppeal = {
+			...mocks.casPlanningAppeal,
+			appealType: { key: APPEAL_CASE_TYPE.ZP, type: 'CAS planning' },
+			lpaQuestionnaire: {
+				listOfDocumentsBeforeDecision: 'doc1, doc2',
+				anySignificantChangesLpa: 'Yes',
+				anySignificantChangesLpa_localPlanSignificantChanges: 'plan change'
+			},
+			folders: []
+		};
+
+		const broadcastOutput = mapCase({
+			// @ts-ignore
+			appeal: casPlanningAppeal,
+			context: contextEnum.broadcast
+		});
+
+		expect(broadcastOutput).toHaveProperty('listOfDocumentsBeforeDecision', 'doc1, doc2');
+		expect(broadcastOutput).toHaveProperty('significantChangesAffectingApplicationLpa', [
+			{ value: 'adopted-a-new-local-plan', comment: 'plan change' }
+		]);
+	});
 });

--- a/appeals/api/src/server/mappers/integration/cas-planning/map-lpa-questionnaire.js
+++ b/appeals/api/src/server/mappers/integration/cas-planning/map-lpa-questionnaire.js
@@ -52,6 +52,6 @@ export const mapLpaQuestionnaire = (data) => {
 				.map((lb) => lb.listEntry) || null,
 		reasonForNeighbourVisits: casedata?.reasonForNeighbourVisits,
 		listOfDocumentsBeforeDecision: casedata?.listOfDocumentsBeforeDecision ?? null,
-		anySignificantChangesAffectingApplicationLpa: significantChanges
+		significantChangesAffectingApplicationLpa: significantChanges
 	};
 };

--- a/appeals/api/src/server/mappers/mapper-factory.js
+++ b/appeals/api/src/server/mappers/mapper-factory.js
@@ -149,13 +149,13 @@ function createIntegrationMap(mappingRequest) {
 		}
 		case APPEAL_CASE_TYPE.ZA: {
 			if (!beforeExpeditedOriginalApplicationCutOff(appeal.appellantCase?.applicationDate)) {
-				const casAdvert = createMap(integrationMappers.integrationCasAdvertMappers, mappingRequest);
-				return mergeMaps(caseData, casAdvert);
-			} else {
 				const casAdvert = createMap(
 					integrationMappers.integrationCasAdvertExpeditedMappers,
 					mappingRequest
 				);
+				return mergeMaps(caseData, casAdvert);
+			} else {
+				const casAdvert = createMap(integrationMappers.integrationCasAdvertMappers, mappingRequest);
 				return mergeMaps(caseData, casAdvert);
 			}
 		}


### PR DESCRIPTION
## Describe your changes

Updates:
- Use the corresponding mapper for the beforeExpeditedOriginalApplicationCutOff function  so that expedited fields are sent with the 
- Rename significant changes field

Tests:
- Added unit tests to cover broadcast
- Manually tested output broadcast


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8973)
