### PR TITLE
feat(web): remove 'redation status' column from view for inspectors (…

### DIFF
--- a/appeals/web/environment/permissions.js
+++ b/appeals/web/environment/permissions.js
@@ -32,7 +32,8 @@ export const calculatePermissions = (currentUserGroups) => {
 		setStageOutcome: isCaseOfficer,
 		setCaseOutcome: isCaseOfficer || isInspector,
 		setEvents: isCaseOfficer || isInspector,
-		reIssueDecisionLetter: isCaseOfficer || isCqtTeam
+		reIssueDecisionLetter: isCaseOfficer || isCqtTeam,
+		viewRedactionStatusColumn: !isInspector || isCaseOfficer
 	};
 
 	return perms;
@@ -47,5 +48,6 @@ export const permissionNames = {
 	setStageOutcome: 'setStageOutcome',
 	setCaseOutcome: 'setCaseOutcome',
 	setEvents: 'setEvents',
-	reIssueDecisionLetter: 'reIssueDecisionLetter'
+	reIssueDecisionLetter: 'reIssueDecisionLetter',
+	viewRedactionStatusColumn: 'viewRedactionStatusColumn'
 };

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -1,6 +1,7 @@
 import usersService from '#appeals/appeal-users/users-service.js';
 import { gigabyte, kilobyte, megabyte } from '#appeals/appeal.constants.js';
 import { isFeatureActive } from '#common/feature-flags.js';
+import { permissionNames } from '#environment/permissions.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import {
 	dateISOStringToDayMonthYearHourMinute,
@@ -12,7 +13,8 @@ import { folderIsAdditionalDocuments } from '#lib/documents.js';
 import {
 	createNotificationBanner,
 	documentDateInput,
-	mapNotificationBannersFromSession
+	mapNotificationBannersFromSession,
+	userHasPermission
 } from '#lib/mappers/index.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { surnameFirstToFullName } from '#lib/person-name-formatter.js';
@@ -961,6 +963,11 @@ export function manageFolderPage({
 			classes: 'govuk-button--secondary'
 		}
 	};
+	// Inspectors should not see redaction status column
+	const canViewRedactionColumn = userHasPermission(
+		permissionNames.viewRedactionStatusColumn,
+		request.session
+	);
 	const tableHead = [
 		{
 			text: 'Name'
@@ -968,9 +975,13 @@ export function manageFolderPage({
 		{
 			text: dateColumnLabelTextOverride || 'Date received'
 		},
-		{
-			text: 'Redaction status'
-		},
+		...(canViewRedactionColumn
+			? [
+					{
+						text: 'Redaction status'
+					}
+				]
+			: []),
 		...(editable
 			? [
 					{
@@ -1043,9 +1054,9 @@ export function manageFolderPage({
 							: {
 									text: dateISOStringToDisplayDate(document?.latestDocumentVersion?.dateReceived)
 								},
-						{
-							text: document?.latestDocumentVersion?.redactionStatus
-						},
+						...(canViewRedactionColumn
+							? [{ text: document?.latestDocumentVersion?.redactionStatus }]
+							: []),
 						...(editable
 							? [mapFolderDocumentActionsHtmlProperty(folder, document, viewAndEditUrl, isCosts)]
 							: [])


### PR DESCRIPTION
…A2-8856)

## Describe your changes

Created new permission, only gets satisfied if user is only in the inspector group. Being a case officer overrides this.

Render 'Redaction status' column when permission satisfied.

## Issue ticket number and link

[A2-8856](https://pins-ds.atlassian.net.mcas.ms/browse/A2-8856)


[A2-8856]: https://pins-ds.atlassian.net/browse/A2-8856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ