### PR TITLE
Fix/a2 8974 rows missing from a full advert appeal

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,3 +5,4 @@ npm run tscheck
 npx lint-staged
 ./packages/scripts/verify_openapi_docs.sh
 ./packages/scripts/verify_notify_docs.sh
+./packages/scripts/verify_appellant_case_docs.sh

--- a/appeals/web/jsconfig.json
+++ b/appeals/web/jsconfig.json
@@ -3,7 +3,8 @@
 	"include": [
 		"**/*.js",
 		"src/server/appeals/validation/validation.types.d.ts",
-		"src/server/appeals/appeal-documents/appeal-documents.types.d.ts"
+		"src/server/appeals/appeal-documents/appeal-documents.types.d.ts",
+		"src/server/appeals/appeal-details/appeal-details.types.d.ts"
 	],
 	"exclude": ["src/server/static", "scripts", "coverage"],
 	"files": ["typings.d.ts", "types-session.d.ts"],

--- a/appeals/web/package.json
+++ b/appeals/web/package.json
@@ -13,6 +13,7 @@
     "clean": "rimraf .turbo node_modules dist",
     "clean:dev": "rimraf dist src/server/static/scripts src/server/static/styles",
     "dev": "cross-env NODE_ENV=local npm-run-all --silent clean:dev sass rollup --parallel --race watch:** nodemon",
+    "generate-docs:appellant-case": "node --experimental-vm-modules src/server/appeals/appeal-details/appellant-case/page-components/scripts/generate-docs.js",
     "lint:js": "npx eslint .",
     "lint:js:fix": "npx eslint . --fix",
     "nodemon": "nodemon --config ./nodemon.json ./src/server/server.js",

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-contracts.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case-contracts.test.js
@@ -1,0 +1,633 @@
+// @ts-nocheck
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { generateAdvertComponents } from '../page-components/adverts.mapper.js';
+import { generateCASAdvertComponents } from '../page-components/cas-advert.mapper.js';
+import { generateCASComponents } from '../page-components/cas.mapper.js';
+import { generateEnforcementListedComponents } from '../page-components/enforcement-listed.mapper.js';
+import { generateEnforcementNoticeComponents } from '../page-components/enforcement-notice.mapper.js';
+import { generateHASComponents } from '../page-components/has.mapper.js';
+import { generateLdcComponents } from '../page-components/ldc.mapper.js';
+import { generateS20Components } from '../page-components/s20.mapper.js';
+import { generateS78ExpeditedComponents } from '../page-components/s78-expedited.mapper.js';
+import { generateS78Components } from '../page-components/s78.mapper.js';
+
+describe('Appellant Case Page Component Mapper Contracts', () => {
+	const mockAppeal = {
+		appealId: 1,
+		appealType: APPEAL_TYPE.S78,
+		agent: { name: 'Test Agent' }
+	};
+
+	const mockAppellantCaseData = {
+		applicationDate: '2025-01-01T00:00:00.000Z',
+		reasonForAppealAppellant: 'My reason for appeal',
+		documents: {}
+	};
+
+	const createMockRow = (keyText) => ({
+		display: {
+			summaryListItem: {
+				key: { text: keyText },
+				value: { text: 'Mock Value' }
+			}
+		}
+	});
+
+	const mockMappedData = {
+		localPlanningAuthority: createMockRow('Local planning authority'),
+		applicationType: createMockRow('Application type'),
+		applicationDecision: createMockRow('Application decision'),
+		applicationDecisionDate: createMockRow('Application decision date'),
+		applicationReference: createMockRow('LPA application reference number'),
+		appellant: createMockRow('Appellant name'),
+		agent: createMockRow('Agent name'),
+		siteAddress: createMockRow('Site address'),
+		siteArea: createMockRow('Site area'),
+		inGreenBelt: createMockRow('Green belt'),
+		inspectorAccess: createMockRow('Inspector access'),
+		healthAndSafetyIssues: createMockRow('Safety risks'),
+		developmentDescription: createMockRow('Development description'),
+		developmentDescriptionOriginal: createMockRow('Original development description'),
+		developmentDescriptionChanged: createMockRow('Changed development description'),
+		developmentDescriptionChangedEvidence: createMockRow(
+			'Evidence of agreement to change description'
+		),
+		procedurePreference: createMockRow('Procedure preference'),
+		procedurePreferenceDetails: createMockRow('Procedure preference details'),
+		procedurePreferenceDuration: createMockRow('Procedure preference duration'),
+		inquiryNumberOfWitnesses: createMockRow('Inquiry number of witnesses'),
+		applicationForm: createMockRow('Application form'),
+		changedDevelopmentDescriptionDocument: createMockRow(
+			'Evidence of agreement to change development description'
+		),
+		decisionLetter: createMockRow('Decision letter'),
+		statusPlanningObligation: createMockRow('Status of planning obligation'),
+		planningObligation: createMockRow('Planning obligation'),
+		statementCommonGround: createMockRow('Draft statement of common ground'),
+		ownershipCertificate: createMockRow('Ownership certificate'),
+		ownershipCertificateExpedited: createMockRow(
+			'Ownership certificate and agricultural land declaration'
+		),
+		costsDocument: createMockRow('Application for a award of costs'),
+		designAccessStatement: createMockRow('Design and access statement'),
+		appealStatement: createMockRow('Appeal statement'),
+		supportingDocuments: createMockRow('Other new supporting documents'),
+		plansDrawings: createMockRow('Plans, drawings and list of plans'),
+		newPlansDrawings: createMockRow('New plans or drawings'),
+		otherNewDocuments: createMockRow('Other new supporting documents'),
+		environmentalStatement: createMockRow('Environmental statement'),
+		applicationDate: createMockRow('Application date'),
+		relatedAppeals: createMockRow('Related appeals'),
+		siteOwnership: createMockRow('Site ownership'),
+		ownersKnown: createMockRow('Owners known'),
+		siteUseAtTimeOfApplication: createMockRow('Site use at time of application'),
+		applicationMadeUnderActSection: createMockRow('Application made under act section'),
+		reasonForAppealAppellant: createMockRow('Why are you appealing?'),
+		anySignificantChanges: createMockRow('Significant changes'),
+		factsForGrounds: createMockRow('Facts for grounds'),
+		supportingDocumentsForGrounds: createMockRow('Supporting documents for grounds'),
+		highwayLand: createMockRow('Highway land'),
+		advertisementInPosition: createMockRow('Advertisement in position'),
+		landownerPermission: createMockRow('Landowner permission'),
+		advertisementDescription: createMockRow('Advertisement description'),
+		changedAdvertisementDescriptionDocument: createMockRow(
+			'Evidence of agreement to change advertisement description'
+		),
+		developmentType: createMockRow('Development type'),
+		otherAppellants: createMockRow('Other appellants'),
+		contactAddress: createMockRow('Contact address'),
+		interestInLand: createMockRow('Interest in land'),
+		writtenOrVerbalPermission: createMockRow('Written or verbal permission'),
+		enforcementNotice: createMockRow('Enforcement notice'),
+		enforcementIssueDate: createMockRow('Enforcement notice date'),
+		enforcementEffectiveDate: createMockRow('Effective date of enforcement notice'),
+		contactPlanningInspectorateDate: createMockRow('Date planning inspectorate contacted'),
+		enforcementReference: createMockRow('Enforcement reference'),
+		additionalDocuments: {
+			display: {
+				summaryListItems: [createMockRow('Additional documents').display.summaryListItem]
+			}
+		}
+	};
+
+	const extractCardTitles = (components) =>
+		components.filter(Boolean).map((c) => c.parameters?.card?.title?.text);
+
+	const extractRowKeysForCard = (components, cardId) => {
+		const card = components.filter(Boolean).find((c) => c.parameters?.attributes?.id === cardId);
+		if (!card) return [];
+		return card.parameters.rows.map((r) => r.key?.text);
+	};
+
+	it('Full Advert mapper produces exact section cards and field/document row contracts', () => {
+		const components = generateAdvertComponents(mockAppeal, mockAppellantCaseData, mockMappedData);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Appeal details',
+			'Upload documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Highway land',
+			'Advertisement in position',
+			'Green belt',
+			'Site ownership',
+			'Owners known',
+			'Inspector access',
+			'Safety risks',
+			'Landowner permission',
+			'Significant changes'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Advertisement description',
+			'Evidence of agreement to change advertisement description',
+			'Related appeals',
+			'Decision letter'
+		]);
+		expect(extractRowKeysForCard(components, 'appeal-summary')).toEqual([
+			'Procedure preference',
+			'Procedure preference details',
+			'Procedure preference duration',
+			'Inquiry number of witnesses'
+		]);
+		expect(extractRowKeysForCard(components, 'uploaded-documents')).toEqual([
+			'Application form',
+			'Appeal statement',
+			'Application for a award of costs',
+			'Other new supporting documents'
+		]);
+	});
+
+	it('CAS Advert mapper produces exact section cards and field/document row contracts (pre-cut-off)', () => {
+		const components = generateCASAdvertComponents(
+			{ ...mockAppeal, appealType: APPEAL_TYPE.CAS_ADVERTISEMENT },
+			mockAppellantCaseData,
+			mockMappedData
+		);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Upload documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Highway land',
+			'Advertisement in position',
+			'Green belt',
+			'Site ownership',
+			'Owners known',
+			'Inspector access',
+			'Safety risks',
+			'Landowner permission',
+			'Significant changes'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Advertisement description',
+			'Evidence of agreement to change advertisement description',
+			'Related appeals',
+			'Decision letter'
+		]);
+		expect(extractRowKeysForCard(components, 'uploaded-documents')).toEqual([
+			'Application form',
+			'Appeal statement',
+			'Application for a award of costs',
+			'Other new supporting documents'
+		]);
+	});
+
+	it('Householder mapper produces exact section cards and field/document row contracts (pre-cut-off)', () => {
+		const components = generateHASComponents(
+			{ ...mockAppeal, appealType: APPEAL_TYPE.HOUSEHOLDER },
+			mockAppellantCaseData,
+			mockMappedData
+		);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Upload documents',
+			'Additional documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Site area',
+			'Green belt',
+			'Site ownership',
+			'Owners known',
+			'Inspector access',
+			'Safety risks',
+			'Significant changes'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Development description',
+			'Related appeals',
+			'Decision letter'
+		]);
+		expect(extractRowKeysForCard(components, 'uploaded-documents')).toEqual([
+			'Application form',
+			'Evidence of agreement to change development description',
+			'Appeal statement',
+			'Application for a award of costs'
+		]);
+	});
+
+	it('S78 mapper produces exact section cards and field/document row contracts', () => {
+		const components = generateS78Components(mockAppeal, mockAppellantCaseData, mockMappedData);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Appeal details',
+			'Upload documents',
+			'Additional documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Site area',
+			'Green belt',
+			'Site ownership',
+			'Owners known',
+			'Inspector access',
+			'Safety risks'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Development description',
+			'Related appeals',
+			'Development type'
+		]);
+		expect(extractRowKeysForCard(components, 'appeal-summary')).toEqual([
+			'Procedure preference',
+			'Procedure preference details',
+			'Procedure preference duration',
+			'Inquiry number of witnesses'
+		]);
+		expect(extractRowKeysForCard(components, 'uploaded-documents')).toEqual([
+			'Application form',
+			'Evidence of agreement to change development description',
+			'Decision letter',
+			'Appeal statement',
+			'Status of planning obligation',
+			'Planning obligation',
+			'Draft statement of common ground',
+			'Ownership certificate',
+			'Application for a award of costs',
+			'Design and access statement',
+			'Other new supporting documents',
+			'New plans or drawings',
+			'Other new supporting documents'
+		]);
+	});
+
+	it('S78 Expedited mapper produces exact section cards and field/document row contracts (post-cut-off)', () => {
+		const components = generateS78ExpeditedComponents(
+			mockAppeal,
+			{ applicationDate: '2026-04-02T00:00:00.000Z', reasonForAppealAppellant: 'My reason' }, // post-cut-off date
+			mockMappedData
+		);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Appeal details',
+			'Upload documents',
+			'Additional documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Site area',
+			'Green belt',
+			'Site ownership',
+			'Owners known',
+			'Inspector access',
+			'Safety risks'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Development description',
+			'Related appeals',
+			'Development type'
+		]);
+		expect(extractRowKeysForCard(components, 'appeal-summary')).toEqual([
+			'Procedure preference',
+			'Procedure preference details',
+			'Procedure preference duration',
+			'Inquiry number of witnesses',
+			'Why are you appealing?'
+		]);
+		expect(extractRowKeysForCard(components, 'uploaded-documents')).toEqual([
+			'Application form',
+			'Evidence of agreement to change development description',
+			'Decision letter',
+			'Status of planning obligation',
+			'Planning obligation',
+			'Draft statement of common ground',
+			'Ownership certificate',
+			'Application for a award of costs',
+			'Design and access statement',
+			'Other new supporting documents',
+			'New plans or drawings',
+			'Other new supporting documents'
+		]);
+	});
+
+	it('CAS planning mapper produces exact section cards and field/document row contracts', () => {
+		const components = generateCASComponents(
+			{ ...mockAppeal, appealType: APPEAL_TYPE.CAS_PLANNING },
+			mockAppellantCaseData,
+			mockMappedData
+		);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Upload documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Site area',
+			'Green belt',
+			'Site ownership',
+			'Owners known',
+			'Inspector access',
+			'Safety risks',
+			'Significant changes'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Development description',
+			'Related appeals',
+			'Decision letter'
+		]);
+	});
+
+	it('LDC mapper produces exact section cards and field/document row contracts', () => {
+		const components = generateLdcComponents(mockAppeal, mockAppellantCaseData, mockMappedData);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Appeal details',
+			'Upload documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Inspector access',
+			'Safety risks'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Site use at time of application',
+			'Application made under act section',
+			'Development description',
+			'Evidence of agreement to change development description',
+			'Related appeals'
+		]);
+		expect(extractRowKeysForCard(components, 'appeal-summary')).toEqual([
+			'Procedure preference',
+			'Procedure preference details',
+			'Procedure preference duration',
+			'Inquiry number of witnesses'
+		]);
+	});
+
+	it('S20 mapper produces exact section cards and field/document row contracts', () => {
+		const components = generateS20Components(mockAppeal, mockAppellantCaseData, mockMappedData);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Site details',
+			'Application details',
+			'Appeal details',
+			'Upload documents',
+			'Additional documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Application decision',
+			'Application decision date',
+			'LPA application reference number'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Site area',
+			'Green belt',
+			'Site ownership',
+			'Owners known',
+			'Inspector access',
+			'Safety risks'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual([
+			'Application date',
+			'Development description',
+			'Related appeals',
+			'Development type'
+		]);
+		expect(extractRowKeysForCard(components, 'appeal-summary')).toEqual([
+			'Procedure preference',
+			'Procedure preference details',
+			'Procedure preference duration',
+			'Inquiry number of witnesses'
+		]);
+	});
+
+	it('Enforcement Notice mapper produces exact section cards and field/document row contracts', () => {
+		const components = generateEnforcementNoticeComponents(
+			mockAppeal,
+			mockAppellantCaseData,
+			mockMappedData
+		);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Land',
+			'Grounds and facts',
+			'Application details',
+			'Appeal details',
+			'Upload documents',
+			'Additional documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Enforcement notice date',
+			'Effective date of enforcement notice',
+			'Date planning inspectorate contacted',
+			'Enforcement reference'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name',
+			'Other appellants'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Contact address',
+			'Interest in land',
+			'Written or verbal permission',
+			'Inspector access',
+			'Safety risks'
+		]);
+		expect(extractRowKeysForCard(components, 'grounds-and-facts')).toEqual([
+			'Facts for grounds',
+			'Supporting documents for grounds',
+			'LPA application reference number',
+			'Application date',
+			'Development description',
+			'Application decision',
+			'Application decision date'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual(['Related appeals']);
+		expect(extractRowKeysForCard(components, 'appeal-summary')).toEqual([
+			'Procedure preference',
+			'Procedure preference details',
+			'Procedure preference duration',
+			'Inquiry number of witnesses'
+		]);
+	});
+
+	it('Enforcement Listed mapper produces exact section cards and field/document row contracts', () => {
+		const components = generateEnforcementListedComponents(
+			mockAppeal,
+			mockAppellantCaseData,
+			mockMappedData
+		);
+		expect(extractCardTitles(components)).toEqual([
+			'Before you start',
+			'Appellant details',
+			'Land',
+			'Grounds and facts',
+			'Application details',
+			'Appeal details',
+			'Upload documents',
+			'Additional documents'
+		]);
+		expect(extractRowKeysForCard(components, 'before-you-start')).toEqual([
+			'Local planning authority',
+			'Application type',
+			'Enforcement notice date',
+			'Effective date of enforcement notice',
+			'Date planning inspectorate contacted',
+			'Enforcement reference'
+		]);
+		expect(extractRowKeysForCard(components, 'appellant-details')).toEqual([
+			'Appellant name',
+			'Agent name',
+			'Other appellants'
+		]);
+		expect(extractRowKeysForCard(components, 'site-details')).toEqual([
+			'Site address',
+			'Contact address',
+			'Interest in land',
+			'Written or verbal permission',
+			'Inspector access',
+			'Safety risks'
+		]);
+		expect(extractRowKeysForCard(components, 'grounds-and-facts')).toEqual([
+			'Facts for grounds',
+			'Supporting documents for grounds'
+		]);
+		expect(extractRowKeysForCard(components, 'application-summary')).toEqual(['Related appeals']);
+		expect(extractRowKeysForCard(components, 'appeal-summary')).toEqual([
+			'Procedure preference',
+			'Procedure preference details',
+			'Procedure preference duration',
+			'Inquiry number of witnesses'
+		]);
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -207,9 +207,14 @@ export async function appellantCasePage(
 
 	const shortAppealReference = appealShortReference(appealDetails.appealReference);
 
+	const validAppealTypeComponents = appealTypeSpecificComponents.filter(
+		/** @type {(c: PageComponent|null) => c is PageComponent} */
+		(c) => Boolean(c)
+	);
+
 	// Add section numbers to the start of each card title other than before you start and additional documents
-	appealTypeSpecificComponents.forEach((component, index) => {
-		const { title } = component?.parameters?.card || {};
+	validAppealTypeComponents.forEach((component, index) => {
+		const { title } = component.parameters?.card || {};
 		switch (component.parameters.attributes.id) {
 			case 'before-you-start':
 				break;
@@ -232,7 +237,8 @@ export async function appellantCasePage(
 			...errorSummaryPageComponents,
 			...notificationBanners,
 			appellantCaseSummary,
-			...appealTypeSpecificComponents,
+			...validAppealTypeComponents,
+
 			...reviewOutcomeComponents
 		]
 	};
@@ -849,7 +855,7 @@ const isExpeditedAppealsActive = isFeatureActive(FEATURE_FLAG_NAMES.EXPEDITED_AP
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
  * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 function generateCaseTypeSpecificComponents(
 	appealDetails,
@@ -901,26 +907,11 @@ function generateCaseTypeSpecificComponents(
 				userHasUpdateCasePermission
 			);
 		case APPEAL_TYPE.CAS_PLANNING:
-			return generateCASComponents(
-				appealDetails,
-				appellantCaseData,
-				mappedAppellantCaseData,
-				userHasUpdateCasePermission
-			);
+			return generateCASComponents(appealDetails, appellantCaseData, mappedAppellantCaseData);
 		case APPEAL_TYPE.CAS_ADVERTISEMENT:
-			return generateCASAdvertComponents(
-				appealDetails,
-				appellantCaseData,
-				mappedAppellantCaseData,
-				userHasUpdateCasePermission
-			);
+			return generateCASAdvertComponents(appealDetails, appellantCaseData, mappedAppellantCaseData);
 		case APPEAL_TYPE.ADVERTISEMENT:
-			return generateAdvertComponents(
-				appealDetails,
-				appellantCaseData,
-				mappedAppellantCaseData,
-				userHasUpdateCasePermission
-			);
+			return generateAdvertComponents(appealDetails, appellantCaseData, mappedAppellantCaseData);
 		case APPEAL_TYPE.ENFORCEMENT_NOTICE:
 			if (isFeatureActive(FEATURE_FLAG_NAMES.ENFORCEMENT_NOTICE)) {
 				return generateEnforcementNoticeComponents(

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/README.md
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/README.md
@@ -1,0 +1,446 @@
+# Appellant Case Page Component Mappers
+
+## Architecture Overview
+
+The appellant case details page renders structured summary list cards and action sections for an appeal's appellant case.
+
+To support multiple appeal types (HAS, S78, S78 Expedited, S20, LDC, Enforcement Notice, Enforcement Listed, Adverts, CAS, CAS Advert), page components are modularized under `page-components/`.
+
+```
+appeals/web/src/server/appeals/appeal-details/appellant-case/
+├── appellant-case.mapper.js             # Entry point: maps full page & delegates component generation
+└── page-components/
+    ├── common-sections.mapper.js        # Shared card builders (Before You Start, Appellant Details, Site Details, etc.)
+    ├── adverts.mapper.js                # Advert appeal components
+    ├── cas-advert.mapper.js             # CAS Advert appeal components
+    ├── cas.mapper.js                    # CAS Planning appeal components
+    ├── enforcement-listed.mapper.js     # Enforcement Listed Building components
+    ├── enforcement-notice.mapper.js     # Enforcement Notice components
+    ├── has.mapper.js                    # Householder (HAS) components
+    ├── ldc.mapper.js                    # Lawful Development Certificate (LDC) components
+    ├── s20.mapper.js                    # Section 20 components
+    ├── s78-expedited.mapper.js          # Section 78 Expedited components
+    └── s78.mapper.js                    # Section 78 components
+```
+
+---
+
+## How Appellant Case Layout is Structured
+
+1. `appellant-casePage()` in [appellant-case.mapper.js](../appellant-case.mapper.js) initializes and maps appeal and appellant case data (`initialiseAndMapData`).
+2. It delegates to `generateCaseTypeSpecificComponents(appealDetails, appellantCaseData, mappedAppellantCaseData, userHasUpdateCasePermission)`.
+3. `generateCaseTypeSpecificComponents` matches `appealDetails.appealType` (and checking flags/expedited criteria) to dispatch to the corresponding generator in `page-components/`.
+4. Each generator function returns an array of `PageComponent` objects representing summary cards (e.g. `before-you-start`, `appellant-details`, `site-details`, `application-summary`, `appeal-summary`, `uploaded-documents`, `additional-documents`).
+5. Section numbers (e.g., `1. Appellant details`, `2. Site details`) are automatically prefixed sequentially by `appellant-case.mapper.js` to all cards except `before-you-start` and `additional-documents`.
+
+---
+
+## Shared Card Builders (`common-sections.mapper.js`)
+
+`common-sections.mapper.js` provides reusable builder functions and helper functions. If changes are needed to be made for individualy appeals from these functions dedicased mapper functions should be used within each appeal specific mapper file, see [Overriding Card Builders for Appeal-Specific Needs](#2-overriding-card-builders-for-appeal-specific-needs).
+
+### Core Helper: `buildSummaryListCard`
+```javascript
+buildSummaryListCard(id, title, rows, options = {})
+```
+- **Filter logic:** Filters out `null`/`undefined` row elements automatically. Returns `null` if no valid rows exist (unless `options.actions` is defined).
+- **Output:** Standard GOV.UK summary list card component schema.
+
+### Reusable Card Builders
+- **`buildBeforeYouStartCard(mappedAppellantCaseData, options)`**
+- **`buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData)`**
+- **`buildSiteDetailsCard(mappedAppellantCaseData, additionalRows)`** – accepts optional `additionalRows` appended to the card.
+- **`buildApplicationDetailsCard(mappedAppellantCaseData, additionalRows)`** – accepts optional `additionalRows`.
+- **`buildAdditionalDocumentsCard(appellantCaseData, mappedAppellantCaseData, userHasUpdateCasePermission)`**
+- **`buildFullPlanningApplicationDetailsCard`**, **`buildFullPlanningAppealDetailsCard`**, **`buildFullPlanningUploadedDocumentsCard`**
+- **`buildEnforcementBeforeYouStartCard`**, **`buildEnforcementAppellantDetailsCard`**, **`buildEnforcementLandDetailsCard`**, **`buildEnforcementApplicationDetailsCard`**
+- **`buildAdvertSiteDetailsCard`**, **`buildAdvertApplicationDetailsCard`**
+
+---
+
+## Adding or Modifying Appellant Case Pages
+
+### 1. Modifying Existing Appeal Type Rows / Cards
+To add, remove, or reorder summary rows for a specific appeal type:
+- Locate the specific mapper (e.g. [has.mapper.js](has.mapper.js) or [s78.mapper.js](s78.mapper.js)).
+- Modify the `rows` array inside the card builder or pass additional row elements.
+- Ensure conditional rows (e.g., based on date thresholds or optional data) evaluate to `null` when inactive; `buildSummaryListCard` will filter them out.
+
+### 2. Overriding Card Builders for Appeal-Specific Needs
+If an appeal type requires custom rows in standard sections (e.g. `site-details` or `application-summary`), you can either:
+- Pass extra row instructions using `additionalRows` parameter on `buildSiteDetailsCard` / `buildApplicationDetailsCard`. Or add this functionality ot other mappers where appropriate.
+- Define an appeal-specific builder function in the appeal's mapper module (e.g., `buildHASUploadedDocumentsCard` in `has.mapper.js` or `buildLdcSiteDetailsCard` in `ldc.mapper.js`).
+
+### 3. Adding a New Appeal Type
+1. Create a new mapper module in `page-components/<appeal-type>.mapper.js`.
+2. Export `generate<AppealType>Components(appealDetails, appellantCaseData, mappedAppellantCaseData, userHasUpdateCasePermission)`.
+3. Compose and return card components using `common-sections.mapper.js` builders or custom card builders.
+4. Import and add a `case` branch in `generateCaseTypeSpecificComponents` inside [appellant-case.mapper.js](../appellant-case.mapper.js).
+5. Add unit test coverage in `__tests__/appellant-case.test.js` or component-specific test suites.
+
+## Auto-Generated Rendered Rows by Appeal Type
+
+> Note: Auto-generated from component mapper contracts. Re-run `npm run generate-docs` or `node scripts/generate-appellant-case-docs.js` to update.
+> Note: This list displays all rows rendered when full mapped data is present. Dynamic conditional logic (such as application date cutoffs or optional data checks) is handled within individual mapper functions and is not annotated here.
+
+### Adverts
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Highway land
+  - Advertisement in position
+  - Green belt
+  - Site ownership
+  - Owners known
+  - Inspector access
+  - Safety risks
+  - Landowner permission
+- **Application details**
+  - Application date
+  - Advertisement description
+  - Related appeals
+  - Decision letter
+- **Appeal details**
+  - Procedure preference
+  - Procedure preference details
+  - Procedure preference duration
+  - Inquiry number of witnesses
+- **Upload documents**
+  - Application form
+  - Appeal statement
+  - Application for a award of costs
+  - Other new supporting documents
+
+### CAS Advert
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Highway land
+  - Advertisement in position
+  - Green belt
+  - Site ownership
+  - Owners known
+  - Inspector access
+  - Safety risks
+  - Landowner permission
+- **Application details**
+  - Application date
+  - Advertisement description
+  - Related appeals
+  - Decision letter
+- **Upload documents**
+  - Application form
+  - Appeal statement
+  - Application for a award of costs
+  - Other new supporting documents
+
+### CAS Planning
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Site area
+  - Green belt
+  - Site ownership
+  - Owners known
+  - Inspector access
+  - Safety risks
+- **Application details**
+  - Application date
+  - Development description
+  - Related appeals
+  - Decision letter
+- **Upload documents**
+  - Application form
+  - Appeal statement
+  - Application for a award of costs
+  - Other new supporting documents
+
+### Enforcement Listed
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Enforcement notice date
+  - Effective date of enforcement notice
+  - Date planning inspectorate contacted
+  - Enforcement reference
+- **Appellant details**
+  - Appellant name
+  - Other appellants
+- **Land**
+  - Site address
+  - Contact address
+  - Interest in land
+  - Written or verbal permission
+  - Inspector access
+  - Safety risks
+- **Grounds and facts**
+  - Facts for grounds
+  - Supporting documents for grounds
+- **Application details**
+  - Related appeals
+- **Appeal details**
+  - Procedure preference
+  - Procedure preference details
+  - Procedure preference duration
+  - Inquiry number of witnesses
+- **Upload documents**
+  - Status of planning obligation
+  - Planning obligation
+  - Application for a award of costs
+  - Other new supporting documents
+- **Additional documents**
+  - Additional documents
+
+### Enforcement Notice
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Enforcement notice date
+  - Effective date of enforcement notice
+  - Date planning inspectorate contacted
+  - Enforcement reference
+- **Appellant details**
+  - Appellant name
+  - Other appellants
+- **Land**
+  - Site address
+  - Contact address
+  - Interest in land
+  - Written or verbal permission
+  - Inspector access
+  - Safety risks
+- **Grounds and facts**
+  - Facts for grounds
+  - Supporting documents for grounds
+  - LPA application reference number
+  - Application date
+  - Development description
+  - Application decision
+  - Application decision date
+- **Application details**
+  - Related appeals
+- **Appeal details**
+  - Procedure preference
+  - Procedure preference details
+  - Procedure preference duration
+  - Inquiry number of witnesses
+- **Upload documents**
+  - Application form
+  - Decision letter
+  - Status of planning obligation
+  - Planning obligation
+  - Application for a award of costs
+  - Other new supporting documents
+- **Additional documents**
+  - Additional documents
+
+### Householder (HAS)
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Site area
+  - Green belt
+  - Site ownership
+  - Owners known
+  - Inspector access
+  - Safety risks
+- **Application details**
+  - Application date
+  - Development description
+  - Related appeals
+  - Decision letter
+- **Upload documents**
+  - Application form
+  - Appeal statement
+  - Application for a award of costs
+- **Additional documents**
+  - Additional documents
+
+### LDC
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Inspector access
+  - Safety risks
+- **Application details**
+  - Application date
+  - Development description
+  - Related appeals
+- **Appeal details**
+  - Procedure preference
+  - Procedure preference details
+  - Procedure preference duration
+  - Inquiry number of witnesses
+- **Upload documents**
+  - Application form
+  - Appeal statement
+  - Application for a award of costs
+  - Other new supporting documents
+  - Draft statement of common ground
+  - New plans or drawings
+  - Decision letter
+  - Other new supporting documents
+
+### S20
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Site area
+  - Green belt
+  - Site ownership
+  - Owners known
+  - Inspector access
+  - Safety risks
+- **Application details**
+  - Application date
+  - Development description
+  - Related appeals
+  - Development type
+- **Appeal details**
+  - Procedure preference
+  - Procedure preference details
+  - Procedure preference duration
+  - Inquiry number of witnesses
+- **Upload documents**
+  - Application form
+  - Decision letter
+  - Appeal statement
+  - Status of planning obligation
+  - Planning obligation
+  - Draft statement of common ground
+  - Ownership certificate
+  - Application for a award of costs
+  - Design and access statement
+  - Other new supporting documents
+  - New plans or drawings
+  - Other new supporting documents
+- **Additional documents**
+  - Additional documents
+
+### S78 Expedited
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Site area
+  - Green belt
+  - Site ownership
+  - Owners known
+  - Inspector access
+  - Safety risks
+- **Application details**
+  - Application date
+  - Development description
+  - Related appeals
+  - Development type
+- **Appeal details**
+  - Procedure preference
+  - Procedure preference details
+  - Procedure preference duration
+  - Inquiry number of witnesses
+- **Upload documents**
+  - Application form
+  - Decision letter
+  - Status of planning obligation
+  - Planning obligation
+  - Draft statement of common ground
+  - Ownership certificate
+  - Application for a award of costs
+  - Design and access statement
+  - Other new supporting documents
+  - New plans or drawings
+  - Other new supporting documents
+- **Additional documents**
+  - Additional documents
+
+### S78 Standard
+- **Before you start**
+  - Local planning authority
+  - Application type
+  - Application decision
+  - Application decision date
+  - LPA application reference number
+- **Appellant details**
+  - Appellant name
+- **Site details**
+  - Site address
+  - Site area
+  - Green belt
+  - Site ownership
+  - Owners known
+  - Inspector access
+  - Safety risks
+- **Application details**
+  - Application date
+  - Development description
+  - Related appeals
+  - Development type
+- **Appeal details**
+  - Procedure preference
+  - Procedure preference details
+  - Procedure preference duration
+  - Inquiry number of witnesses
+- **Upload documents**
+  - Application form
+  - Decision letter
+  - Appeal statement
+  - Status of planning obligation
+  - Planning obligation
+  - Draft statement of common ground
+  - Ownership certificate
+  - Application for a award of costs
+  - Design and access statement
+  - Other new supporting documents
+  - New plans or drawings
+  - Other new supporting documents
+- **Additional documents**
+  - Additional documents
+

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/__tests__/appellant-case-contracts.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/__tests__/appellant-case-contracts.test.js
@@ -1,15 +1,15 @@
 // @ts-nocheck
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
-import { generateAdvertComponents } from '../page-components/adverts.mapper.js';
-import { generateCASAdvertComponents } from '../page-components/cas-advert.mapper.js';
-import { generateCASComponents } from '../page-components/cas.mapper.js';
-import { generateEnforcementListedComponents } from '../page-components/enforcement-listed.mapper.js';
-import { generateEnforcementNoticeComponents } from '../page-components/enforcement-notice.mapper.js';
-import { generateHASComponents } from '../page-components/has.mapper.js';
-import { generateLdcComponents } from '../page-components/ldc.mapper.js';
-import { generateS20Components } from '../page-components/s20.mapper.js';
-import { generateS78ExpeditedComponents } from '../page-components/s78-expedited.mapper.js';
-import { generateS78Components } from '../page-components/s78.mapper.js';
+import { generateAdvertComponents } from '../adverts.mapper.js';
+import { generateCASAdvertComponents } from '../cas-advert.mapper.js';
+import { generateCASComponents } from '../cas.mapper.js';
+import { generateEnforcementListedComponents } from '../enforcement-listed.mapper.js';
+import { generateEnforcementNoticeComponents } from '../enforcement-notice.mapper.js';
+import { generateHASComponents } from '../has.mapper.js';
+import { generateLdcComponents } from '../ldc.mapper.js';
+import { generateS20Components } from '../s20.mapper.js';
+import { generateS78ExpeditedComponents } from '../s78-expedited.mapper.js';
+import { generateS78Components } from '../s78.mapper.js';
 
 describe('Appellant Case Page Component Mapper Contracts', () => {
 	const mockAppeal = {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/adverts.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/adverts.mapper.js
@@ -1,61 +1,64 @@
+import {
+	buildAdvertApplicationDetailsCard,
+	buildAdvertSiteDetailsCard,
+	buildAppellantDetailsCard,
+	buildBeforeYouStartCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
+
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} Appeal
  */
 
-import { generateCASAdvertComponents } from './cas-advert.mapper.js';
+/**
+ * Builds the Advert "Appeal details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildAdvertAppealDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('appeal-summary', 'Appeal details', [
+		mappedAppellantCaseData.procedurePreference?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDetails?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDuration?.display?.summaryListItem,
+		mappedAppellantCaseData.inquiryNumberOfWitnesses?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Advert "Upload documents" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildAdvertUploadedDocumentsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		mappedAppellantCaseData.appealStatement?.display?.summaryListItem,
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.supportingDocuments?.display?.summaryListItem
+	]);
+}
 
 /**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
- * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateAdvertComponents(
 	appealDetails,
 	appellantCaseData,
-	mappedAppellantCaseData,
-	userHasUpdateCasePermission
+	mappedAppellantCaseData
 ) {
-	const pageComponents = generateCASAdvertComponents(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
+	const components = [
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildAdvertSiteDetailsCard(mappedAppellantCaseData),
+		buildAdvertApplicationDetailsCard(mappedAppellantCaseData),
+		buildAdvertAppealDetailsCard(mappedAppellantCaseData),
+		buildAdvertUploadedDocumentsCard(mappedAppellantCaseData)
+	];
 
-	/**
-	 * @type {PageComponent}
-	 */
-	const appealSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'appeal-summary'
-			},
-			card: {
-				title: {
-					text: 'Appeal details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.procedurePreference.display.summaryListItem,
-				mappedAppellantCaseData.procedurePreferenceDetails.display.summaryListItem,
-				mappedAppellantCaseData.procedurePreferenceDuration.display.summaryListItem,
-				mappedAppellantCaseData.inquiryNumberOfWitnesses.display.summaryListItem
-			]
-		}
-	};
-	const beforeToLastPosition = pageComponents.length - 1;
-	pageComponents.splice(beforeToLastPosition, 0, appealSummary);
-
-	pageComponents[pageComponents.length - 1].parameters.card.title.text = 'Upload documents';
-
-	return pageComponents;
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas-advert.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas-advert.mapper.js
@@ -1,5 +1,14 @@
+import { isFeatureActive } from '#common/feature-flags.js';
+import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
-import { generateHASComponents } from './has.mapper.js';
+import {
+	buildAdvertApplicationDetailsCard,
+	buildAdvertSiteDetailsCard,
+	buildAppealDetailsCard,
+	buildAppellantDetailsCard,
+	buildBeforeYouStartCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -7,127 +16,52 @@ import { generateHASComponents } from './has.mapper.js';
  */
 
 /**
+ * Builds the CAS Advert "Uploaded documents" section card component.
+ * @param {SingleAppellantCaseResponse} appellantCaseData
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildCASAdvertUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+			? [mappedAppellantCaseData.appealStatement?.display?.summaryListItem]
+			: []),
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+			? [mappedAppellantCaseData.supportingDocuments?.display?.summaryListItem]
+			: [])
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
- * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateCASAdvertComponents(
 	appealDetails,
 	appellantCaseData,
-	mappedAppellantCaseData,
-	userHasUpdateCasePermission
+	mappedAppellantCaseData
 ) {
-	const pageComponents = generateHASComponents(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
+	const isExpeditedAppealsActive = isFeatureActive(FEATURE_FLAG_NAMES.EXPEDITED_APPEALS);
+	const isExpeditedEligible =
+		isExpeditedAppealsActive &&
+		(appealDetails.appealType === APPEAL_TYPE.HOUSEHOLDER ||
+			appealDetails.appealType === APPEAL_TYPE.CAS_PLANNING ||
+			appealDetails.appealType === APPEAL_TYPE.CAS_ADVERTISEMENT) &&
+		!beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate);
 
-	const siteDetailsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' && component.parameters.attributes?.id === 'site-details'
-	);
+	const components = [
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildAdvertSiteDetailsCard(mappedAppellantCaseData),
+		buildAdvertApplicationDetailsCard(mappedAppellantCaseData),
+		isExpeditedEligible ? buildAppealDetailsCard(mappedAppellantCaseData) : null,
+		buildCASAdvertUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData)
+	];
 
-	if (siteDetailsComponentIndex !== -1) {
-		const rows = pageComponents[siteDetailsComponentIndex].parameters.rows;
-
-		// remove the site area row
-		const siteAreaIndex = rows.findIndex(
-			(/** @type {{ classes: string} }} */ row) => row.classes === 'appeal-site-area'
-		);
-		if (siteAreaIndex !== -1) {
-			rows.splice(siteAreaIndex, 1);
-		}
-
-		// add the highway land row and advertisementInPosition row
-		const appealSiteAddressIndex = rows.findIndex(
-			(/** @type {{ classes: string; }} */ row) => row.classes === 'appeal-site-address'
-		);
-		const highwayLand = mappedAppellantCaseData.highwayLand.display.summaryListItem;
-
-		const advertisementInPosition =
-			mappedAppellantCaseData.advertisementInPosition.display.summaryListItem;
-
-		rows.splice(appealSiteAddressIndex + 1, 0, highwayLand, advertisementInPosition);
-
-		const landownerPermission = mappedAppellantCaseData.landownerPermission.display.summaryListItem;
-
-		rows.splice(rows.length - 1, 0, landownerPermission);
-	}
-
-	const applicationSummaryComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'application-summary'
-	);
-
-	if (applicationSummaryComponentIndex !== -1) {
-		const rows = pageComponents[applicationSummaryComponentIndex].parameters.rows;
-
-		const developmentDescriptionIndex = rows.findIndex(
-			(/** @type {{ classes: string; }} */ row) => row.classes === 'appeal-development-description'
-		);
-		const advertisementDescription =
-			mappedAppellantCaseData.advertisementDescription.display.summaryListItem;
-		const changedAdvertisementDescriptionDoc =
-			mappedAppellantCaseData.changedAdvertisementDescriptionDocument.display.summaryListItem;
-		const indexAfterDescription = developmentDescriptionIndex + 1;
-
-		rows[developmentDescriptionIndex] = advertisementDescription;
-		rows.splice(indexAfterDescription, 0, changedAdvertisementDescriptionDoc);
-	}
-
-	const uploadedDocumentsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'uploaded-documents'
-	);
-
-	if (uploadedDocumentsComponentIndex !== -1) {
-		/** @type {PageComponent} */
-		const uploadedDocuments = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'uploaded-documents'
-				},
-				card: {
-					title: {
-						text: 'Upload documents'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.applicationForm.display.summaryListItem,
-					// we want to hide the appeal statement for appeals submitted 1st April 2026 onwards
-					...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
-						? [mappedAppellantCaseData.appealStatement.display.summaryListItem]
-						: []),
-					mappedAppellantCaseData.costsDocument.display.summaryListItem,
-					...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
-						? [mappedAppellantCaseData.supportingDocuments.display.summaryListItem]
-						: [])
-				]
-			}
-		};
-		pageComponents[uploadedDocumentsComponentIndex] = uploadedDocuments;
-	}
-
-	const additionalDocumentsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'additional-documents'
-	);
-	if (additionalDocumentsComponentIndex !== -1) {
-		pageComponents.splice(additionalDocumentsComponentIndex, 1);
-	}
-
-	return pageComponents;
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
@@ -1,5 +1,14 @@
+import { isFeatureActive } from '#common/feature-flags.js';
+import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
-import { generateHASComponents } from './has.mapper.js';
+import {
+	buildAppealDetailsCard,
+	buildAppellantDetailsCard,
+	buildApplicationDetailsCard,
+	buildBeforeYouStartCard,
+	buildSiteDetailsCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -7,79 +16,56 @@ import { generateHASComponents } from './has.mapper.js';
  */
 
 /**
+ * Builds the CAS "Uploaded documents" card section.
+ * @param {SingleAppellantCaseResponse} appellantCaseData
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildCASUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		mappedAppellantCaseData.changedDevelopmentDescriptionDocument?.display?.summaryListItem,
+		...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+			? [mappedAppellantCaseData.appealStatement?.display?.summaryListItem]
+			: []),
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+			? [
+					mappedAppellantCaseData.designAndAccessStatement?.display?.summaryListItem,
+					mappedAppellantCaseData.supportingDocuments?.display?.summaryListItem
+				]
+			: [])
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
- * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
-export function generateCASComponents(
-	appealDetails,
-	appellantCaseData,
-	mappedAppellantCaseData,
-	userHasUpdateCasePermission
-) {
-	const pageComponents = generateHASComponents(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
+export function generateCASComponents(appealDetails, appellantCaseData, mappedAppellantCaseData) {
+	const isExpeditedAppealsActive = isFeatureActive(FEATURE_FLAG_NAMES.EXPEDITED_APPEALS);
+	const isExpeditedEligible =
+		isExpeditedAppealsActive &&
+		(appealDetails.appealType === APPEAL_TYPE.HOUSEHOLDER ||
+			appealDetails.appealType === APPEAL_TYPE.CAS_PLANNING ||
+			appealDetails.appealType === APPEAL_TYPE.CAS_ADVERTISEMENT) &&
+		!beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate);
 
-	const uploadedDocumentsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'uploaded-documents'
-	);
+	const components = [
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildSiteDetailsCard(mappedAppellantCaseData),
+		buildApplicationDetailsCard(mappedAppellantCaseData)
+	];
 
-	if (uploadedDocumentsComponentIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const uploadedDocuments = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'uploaded-documents'
-				},
-				card: {
-					title: {
-						text: 'Upload documents'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.applicationForm.display.summaryListItem,
-					mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-					// we want to hide the appeal statement for appeals submitted 1st April 2026 onwards
-					...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
-						? [mappedAppellantCaseData.appealStatement.display.summaryListItem]
-						: []),
-					mappedAppellantCaseData.costsDocument.display.summaryListItem,
-					...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
-						? [
-								mappedAppellantCaseData.designAndAccessStatement.display.summaryListItem,
-								mappedAppellantCaseData.supportingDocuments.display.summaryListItem
-							]
-						: [])
-				]
-			}
-		};
-		pageComponents[uploadedDocumentsComponentIndex] = uploadedDocuments;
+	if (isExpeditedEligible) {
+		components.push(buildAppealDetailsCard(mappedAppellantCaseData));
 	}
 
-	const additionalDocumentsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'additional-documents'
-	);
-	if (additionalDocumentsComponentIndex !== -1) {
-		pageComponents.splice(additionalDocumentsComponentIndex, 1);
-	}
+	components.push(buildCASUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData));
 
-	return pageComponents;
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas.mapper.js
@@ -58,14 +58,10 @@ export function generateCASComponents(appealDetails, appellantCaseData, mappedAp
 		buildBeforeYouStartCard(mappedAppellantCaseData),
 		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
 		buildSiteDetailsCard(mappedAppellantCaseData),
-		buildApplicationDetailsCard(mappedAppellantCaseData)
+		buildApplicationDetailsCard(mappedAppellantCaseData),
+		isExpeditedEligible ? buildAppealDetailsCard(mappedAppellantCaseData) : null,
+		buildCASUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData)
 	];
-
-	if (isExpeditedEligible) {
-		components.push(buildAppealDetailsCard(mappedAppellantCaseData));
-	}
-
-	components.push(buildCASUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData));
 
 	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/common-sections.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/common-sections.mapper.js
@@ -1,0 +1,342 @@
+import config from '#environment/config.js';
+import * as displayPageFormatter from '#lib/display-page-formatter.js';
+import {
+	documentUploadUrlTemplate,
+	mapDocumentManageUrl
+} from '#lib/mappers/data/appellant-case/common.js';
+import { removeSummaryListActions } from '#lib/mappers/index.js';
+import { isFolderInfo } from '#lib/ts-utilities.js';
+
+/**
+ * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
+ * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} Appeal
+ */
+
+/**
+ * Creates a standard summary list card component.
+ * @param {string} id
+ * @param {string} title
+ * @param {(any|undefined|null)[]} rows
+ * @param {object} [options]
+ * @param {string} [options.classes]
+ * @param {object} [options.actions]
+ * @returns {PageComponent|null}
+ */
+export function buildSummaryListCard(id, title, rows, options = {}) {
+	const validRows = rows.filter(Boolean);
+	if (validRows.length === 0 && !options.actions) {
+		return null;
+	}
+
+	return {
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			attributes: {
+				id
+			},
+			...(options.classes ? { classes: options.classes } : {}),
+			card: {
+				title: {
+					text: title
+				},
+				...(options.actions ? { actions: options.actions } : {})
+			},
+			rows: validRows
+		}
+	};
+}
+
+/**
+ * Builds the "Before you start" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {object} [options]
+ * @param {string} [options.lpaText]
+ * @returns {PageComponent|null}
+ */
+export function buildBeforeYouStartCard(mappedAppellantCaseData, options = {}) {
+	const lpaText = options.lpaText || 'Local planning authority';
+
+	return buildSummaryListCard('before-you-start', 'Before you start', [
+		...(mappedAppellantCaseData.localPlanningAuthority?.display?.summaryListItem
+			? [
+					{
+						...mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem,
+						key: {
+							text: lpaText
+						}
+					}
+				]
+			: []),
+		mappedAppellantCaseData.applicationType?.display?.summaryListItem
+			? removeSummaryListActions(mappedAppellantCaseData.applicationType.display.summaryListItem)
+			: null,
+		mappedAppellantCaseData.applicationDecision?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationDecisionDate?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationReference?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the "Appellant details" section card component.
+ * @param {Appeal} appealDetails
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData) {
+	return buildSummaryListCard('appellant-details', 'Appellant details', [
+		mappedAppellantCaseData.appellant?.display?.summaryListItem,
+		...(appealDetails.agent ? [mappedAppellantCaseData.agent?.display?.summaryListItem] : [])
+	]);
+}
+
+/**
+ * Builds the "Site details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {(any|undefined|null)[]} [additionalRows]
+ * @returns {PageComponent|null}
+ */
+export function buildSiteDetailsCard(mappedAppellantCaseData, additionalRows = []) {
+	return buildSummaryListCard('site-details', 'Site details', [
+		mappedAppellantCaseData.siteAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.siteArea?.display?.summaryListItem,
+		mappedAppellantCaseData.inGreenBelt?.display?.summaryListItem,
+		mappedAppellantCaseData.siteOwnership?.display?.summaryListItem,
+		mappedAppellantCaseData.ownersKnown?.display?.summaryListItem,
+		mappedAppellantCaseData.inspectorAccess?.display?.summaryListItem,
+		mappedAppellantCaseData.healthAndSafetyIssues?.display?.summaryListItem,
+		mappedAppellantCaseData.anySignificantChanges?.display?.summaryListItem,
+		...additionalRows
+	]);
+}
+
+/**
+ * Builds the "Application details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {(any|undefined|null)[]} [additionalRows]
+ * @returns {PageComponent|null}
+ */
+export function buildApplicationDetailsCard(mappedAppellantCaseData, additionalRows = []) {
+	return buildSummaryListCard('application-summary', 'Application details', [
+		mappedAppellantCaseData.applicationDate?.display?.summaryListItem,
+		mappedAppellantCaseData.developmentDescription?.display?.summaryListItem,
+		mappedAppellantCaseData.relatedAppeals?.display?.summaryListItem,
+		mappedAppellantCaseData.decisionLetter?.display?.summaryListItem,
+		...additionalRows
+	]);
+}
+
+/**
+ * Builds the "Appeal details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {(any|undefined|null)[]} [additionalRows]
+ * @returns {PageComponent|null}
+ */
+export function buildAppealDetailsCard(mappedAppellantCaseData, additionalRows = []) {
+	return buildSummaryListCard('appeal-summary', 'Appeal details', [
+		mappedAppellantCaseData.reasonForAppealAppellant?.display?.summaryListItem,
+		...additionalRows
+	]);
+}
+
+/**
+ * Builds the "Additional documents" section card component.
+ * @param {SingleAppellantCaseResponse} appellantCaseData
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {boolean} userHasUpdateCasePermission
+ * @returns {PageComponent|null}
+ */
+export function buildAdditionalDocumentsCard(
+	appellantCaseData,
+	mappedAppellantCaseData,
+	userHasUpdateCasePermission
+) {
+	const correspondenceFolder = appellantCaseData.documents?.appellantCaseCorrespondence;
+	const hasDocs =
+		isFolderInfo(correspondenceFolder) &&
+		correspondenceFolder?.documents &&
+		correspondenceFolder.documents.length > 0;
+
+	const actionsItems = [];
+
+	if (hasDocs && isFolderInfo(correspondenceFolder)) {
+		actionsItems.push({
+			text: 'Manage',
+			visuallyHiddenText: 'additional documents',
+			href: mapDocumentManageUrl(appellantCaseData.appealId, correspondenceFolder.folderId)
+		});
+	}
+
+	if (userHasUpdateCasePermission && !appellantCaseData.isEnforcementChild) {
+		actionsItems.push({
+			text: 'Add',
+			visuallyHiddenText: 'additional documents',
+			href: displayPageFormatter.formatDocumentActionLink(
+				appellantCaseData.appealId,
+				correspondenceFolder,
+				documentUploadUrlTemplate
+			)
+		});
+	}
+
+	return buildSummaryListCard(
+		'additional-documents',
+		'Additional documents',
+		mappedAppellantCaseData.additionalDocuments?.display?.summaryListItems || [],
+		{
+			classes: 'pins-summary-list--fullwidth-value',
+			actions: { items: actionsItems }
+		}
+	);
+}
+
+/**
+ * Builds the Full Planning (S20 & S78) "Application details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildFullPlanningApplicationDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('application-summary', 'Application details', [
+		mappedAppellantCaseData.applicationDate?.display?.summaryListItem,
+		mappedAppellantCaseData.developmentDescription?.display?.summaryListItem,
+		mappedAppellantCaseData.relatedAppeals?.display?.summaryListItem,
+		mappedAppellantCaseData.developmentType?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Full Planning (S20 & S78) "Appeal details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildFullPlanningAppealDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('appeal-summary', 'Appeal details', [
+		mappedAppellantCaseData.procedurePreference?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDetails?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDuration?.display?.summaryListItem,
+		mappedAppellantCaseData.inquiryNumberOfWitnesses?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Full Planning (S20 & S78) "Uploaded documents" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildFullPlanningUploadedDocumentsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		mappedAppellantCaseData.changedDevelopmentDescriptionDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.decisionLetter?.display?.summaryListItem,
+		mappedAppellantCaseData.appealStatement?.display?.summaryListItem,
+		mappedAppellantCaseData.statusPlanningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.planningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.statementCommonGround?.display?.summaryListItem,
+		mappedAppellantCaseData.ownershipCertificate?.display?.summaryListItem,
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.designAccessStatement?.display?.summaryListItem,
+		mappedAppellantCaseData.supportingDocuments?.display?.summaryListItem,
+		mappedAppellantCaseData.newPlansDrawings?.display?.summaryListItem,
+		mappedAppellantCaseData.otherNewDocuments?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Enforcement "Before you start" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementBeforeYouStartCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('before-you-start', 'Before you start', [
+		!config.featureFlags.featureFlagNewBeforeYouStart &&
+			mappedAppellantCaseData.enforcementNotice?.display?.summaryListItem,
+		mappedAppellantCaseData.localPlanningAuthority?.display?.summaryListItem,
+		config.featureFlags.featureFlagNewBeforeYouStart &&
+			mappedAppellantCaseData.applicationType?.display?.summaryListItem,
+		!config.featureFlags.featureFlagNewBeforeYouStart &&
+			mappedAppellantCaseData.enforcementNoticeListedBuilding?.display?.summaryListItem,
+		mappedAppellantCaseData.enforcementIssueDate?.display?.summaryListItem,
+		mappedAppellantCaseData.enforcementEffectiveDate?.display?.summaryListItem,
+		mappedAppellantCaseData.contactPlanningInspectorateDate?.display?.summaryListItem,
+		mappedAppellantCaseData.enforcementReference?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Enforcement "Appellant details" section card component.
+ * @param {Appeal} appealDetails
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementAppellantDetailsCard(appealDetails, mappedAppellantCaseData) {
+	return buildSummaryListCard('appellant-details', 'Appellant details', [
+		mappedAppellantCaseData.appellant?.display?.summaryListItem,
+		...(appealDetails.agent ? [mappedAppellantCaseData.agent?.display?.summaryListItem] : []),
+		mappedAppellantCaseData.otherAppellants?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Enforcement "Land" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementLandDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('site-details', 'Land', [
+		mappedAppellantCaseData.siteAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.contactAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.interestInLand?.display?.summaryListItem,
+		mappedAppellantCaseData.writtenOrVerbalPermission?.display?.summaryListItem,
+		mappedAppellantCaseData.inspectorAccess?.display?.summaryListItem,
+		mappedAppellantCaseData.healthAndSafetyIssues?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Enforcement "Application details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementApplicationDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('application-summary', 'Application details', [
+		mappedAppellantCaseData.relatedAppeals?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Advert "Site details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildAdvertSiteDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('site-details', 'Site details', [
+		mappedAppellantCaseData.siteAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.highwayLand?.display?.summaryListItem,
+		mappedAppellantCaseData.advertisementInPosition?.display?.summaryListItem,
+		mappedAppellantCaseData.inGreenBelt?.display?.summaryListItem,
+		mappedAppellantCaseData.siteOwnership?.display?.summaryListItem,
+		mappedAppellantCaseData.ownersKnown?.display?.summaryListItem,
+		mappedAppellantCaseData.inspectorAccess?.display?.summaryListItem,
+		mappedAppellantCaseData.healthAndSafetyIssues?.display?.summaryListItem,
+		mappedAppellantCaseData.landownerPermission?.display?.summaryListItem,
+		mappedAppellantCaseData.anySignificantChanges?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Advert "Application details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildAdvertApplicationDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('application-summary', 'Application details', [
+		mappedAppellantCaseData.applicationDate?.display?.summaryListItem,
+		mappedAppellantCaseData.advertisementDescription?.display?.summaryListItem,
+		mappedAppellantCaseData.changedAdvertisementDescriptionDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.relatedAppeals?.display?.summaryListItem,
+		mappedAppellantCaseData.decisionLetter?.display?.summaryListItem
+	]);
+}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/common-sections.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/common-sections.mapper.js
@@ -13,6 +13,17 @@ import { isFolderInfo } from '#lib/ts-utilities.js';
  */
 
 /**
+ * Helper to extract summaryListItem from subMapper array or object.
+ * @param {any} [subMapperList]
+ * @returns {any[]}
+ */
+export function getSummaryListItems(subMapperList) {
+	if (!subMapperList) return [];
+	const list = Array.isArray(subMapperList) ? subMapperList : [subMapperList];
+	return list.map((subMapper) => subMapper?.display?.summaryListItem).filter(Boolean);
+}
+
+/**
  * Creates a standard summary list card component.
  * @param {string} id
  * @param {string} title

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-listed.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-listed.mapper.js
@@ -5,9 +5,9 @@ import {
 	buildEnforcementBeforeYouStartCard,
 	buildEnforcementLandDetailsCard,
 	buildFullPlanningAppealDetailsCard,
-	buildSummaryListCard
+	buildSummaryListCard,
+	getSummaryListItems
 } from './common-sections.mapper.js';
-import { getSummaryListItems } from './enforcement-notice.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-listed.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-listed.mapper.js
@@ -1,4 +1,13 @@
-import { generateEnforcementNoticeComponents } from './enforcement-notice.mapper.js';
+import {
+	buildAdditionalDocumentsCard,
+	buildEnforcementAppellantDetailsCard,
+	buildEnforcementApplicationDetailsCard,
+	buildEnforcementBeforeYouStartCard,
+	buildEnforcementLandDetailsCard,
+	buildFullPlanningAppealDetailsCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
+import { getSummaryListItems } from './enforcement-notice.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -6,12 +15,43 @@ import { generateEnforcementNoticeComponents } from './enforcement-notice.mapper
  */
 
 /**
+ * Builds the Enforcement Listed Building "Grounds and facts" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementListedGroundsAndFactsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('grounds-and-facts', 'Grounds and facts', [
+		mappedAppellantCaseData.descriptionOfAllegedBreach?.display?.summaryListItem,
+		mappedAppellantCaseData.groundsForAppeal?.display?.summaryListItem,
+		...getSummaryListItems(mappedAppellantCaseData.factsForGrounds),
+		...getSummaryListItems(mappedAppellantCaseData.supportingDocumentsForGrounds)
+	]);
+}
+
+/**
+ * Builds the Enforcement Listed Building "Uploaded documents" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementListedUploadedDocumentsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.priorCorrespondenceWithPINS?.display?.summaryListItem,
+		mappedAppellantCaseData.enforcementNoticeDocuments?.display?.summaryListItem,
+		mappedAppellantCaseData.enforcementNoticePlanDocuments?.display?.summaryListItem,
+		mappedAppellantCaseData.statusPlanningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.planningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.otherNewDocuments?.display?.summaryListItem
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
  * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateEnforcementListedComponents(
 	appealDetails,
@@ -19,98 +59,20 @@ export function generateEnforcementListedComponents(
 	mappedAppellantCaseData,
 	userHasUpdateCasePermission
 ) {
-	const pageComponents = generateEnforcementNoticeComponents(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
+	const components = [
+		buildEnforcementBeforeYouStartCard(mappedAppellantCaseData),
+		buildEnforcementAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildEnforcementLandDetailsCard(mappedAppellantCaseData),
+		buildEnforcementListedGroundsAndFactsCard(mappedAppellantCaseData),
+		buildEnforcementApplicationDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningAppealDetailsCard(mappedAppellantCaseData),
+		buildEnforcementListedUploadedDocumentsCard(mappedAppellantCaseData),
+		buildAdditionalDocumentsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			userHasUpdateCasePermission
+		)
+	];
 
-	const groundsAndFactsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'grounds-and-facts'
-	);
-	if (groundsAndFactsComponentIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const groundsAndFactsSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'grounds-and-facts'
-				},
-				card: {
-					title: {
-						text: 'Grounds and facts'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.descriptionOfAllegedBreach.display.summaryListItem,
-					mappedAppellantCaseData.groundsForAppeal.display.summaryListItem,
-					// @ts-ignore
-					...getSummaryListItems(mappedAppellantCaseData.factsForGrounds),
-					// @ts-ignore
-					...getSummaryListItems(mappedAppellantCaseData.supportingDocumentsForGrounds)
-				]
-			}
-		};
-
-		pageComponents[groundsAndFactsComponentIndex] = groundsAndFactsSummary;
-	}
-
-	const uploadDocumentsComponentsIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'uploaded-documents'
-	);
-	if (uploadDocumentsComponentsIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const uploadDocumentsSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'uploaded-documents'
-				},
-				card: {
-					title: {
-						text: 'Upload documents'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.priorCorrespondenceWithPINS.display.summaryListItem,
-					mappedAppellantCaseData.enforcementNoticeDocuments.display.summaryListItem,
-					mappedAppellantCaseData.enforcementNoticePlanDocuments.display.summaryListItem,
-					mappedAppellantCaseData.statusPlanningObligation.display.summaryListItem,
-					mappedAppellantCaseData.planningObligation.display.summaryListItem,
-					mappedAppellantCaseData.costsDocument.display.summaryListItem,
-					mappedAppellantCaseData.otherNewDocuments.display.summaryListItem
-				]
-			}
-		};
-
-		pageComponents[uploadDocumentsComponentsIndex] = uploadDocumentsSummary;
-	}
-
-	return pageComponents;
+	return components.filter(Boolean);
 }
-
-/**
- *
- * @param {Instructions[]} subMapperList
- * @returns {SummaryListRowProperties[]}
- */
-const getSummaryListItems = (subMapperList) =>
-	// @ts-ignore
-	subMapperList?.map((subMapper) => subMapper.display.summaryListItem);

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-notice.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-notice.mapper.js
@@ -1,17 +1,71 @@
-import config from '#environment/config.js';
-import { generateS20Components } from './s20.mapper.js';
+import {
+	buildAdditionalDocumentsCard,
+	buildEnforcementAppellantDetailsCard,
+	buildEnforcementApplicationDetailsCard,
+	buildEnforcementBeforeYouStartCard,
+	buildEnforcementLandDetailsCard,
+	buildFullPlanningAppealDetailsCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} Appeal
  */
 
-// @ts-ignore
-const getComponentParameters = (componentId, sectionComponents = []) =>
-	sectionComponents.find(
-		(component) =>
-			component.type === 'summary-list' && component.parameters.attributes?.id === componentId
-	);
+/**
+ * Helper to extract summaryListItem from subMapper array or object.
+ * @param {any} [subMapperList]
+ * @returns {any[]}
+ */
+export function getSummaryListItems(subMapperList) {
+	if (!subMapperList) return [];
+	const list = Array.isArray(subMapperList) ? subMapperList : [subMapperList];
+	return list.map((subMapper) => subMapper?.display?.summaryListItem).filter(Boolean);
+}
+
+/**
+ * Builds the Enforcement Notice "Grounds and facts" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementGroundsAndFactsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('grounds-and-facts', 'Grounds and facts', [
+		mappedAppellantCaseData.descriptionOfAllegedBreach?.display?.summaryListItem,
+		mappedAppellantCaseData.groundsForAppeal?.display?.summaryListItem,
+		...getSummaryListItems(mappedAppellantCaseData.factsForGrounds),
+		...getSummaryListItems(mappedAppellantCaseData.supportingDocumentsForGrounds),
+		mappedAppellantCaseData.retrospectiveApplication?.display?.summaryListItem,
+		mappedAppellantCaseData.groundAFeeReceipt?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationDevelopmentAllOrPart?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationReference?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationDate?.display?.summaryListItem,
+		mappedAppellantCaseData.developmentDescription?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationDecision?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationDecisionDate?.display?.summaryListItem,
+		mappedAppellantCaseData.appealDecisionDate?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the Enforcement Notice "Uploaded documents" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildEnforcementNoticeUploadedDocumentsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.priorCorrespondenceWithPINS?.display?.summaryListItem,
+		mappedAppellantCaseData.enforcementNoticeDocuments?.display?.summaryListItem,
+		mappedAppellantCaseData.enforcementNoticePlanDocuments?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		mappedAppellantCaseData.changedDevelopmentDescriptionDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.decisionLetter?.display?.summaryListItem,
+		mappedAppellantCaseData.statusPlanningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.planningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.otherNewDocuments?.display?.summaryListItem
+	]);
+}
 
 /**
  *
@@ -19,7 +73,7 @@ const getComponentParameters = (componentId, sectionComponents = []) =>
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
  * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateEnforcementNoticeComponents(
 	appealDetails,
@@ -27,129 +81,20 @@ export function generateEnforcementNoticeComponents(
 	mappedAppellantCaseData,
 	userHasUpdateCasePermission
 ) {
-	const pageComponents = generateS20Components(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
+	const components = [
+		buildEnforcementBeforeYouStartCard(mappedAppellantCaseData),
+		buildEnforcementAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildEnforcementLandDetailsCard(mappedAppellantCaseData),
+		buildEnforcementGroundsAndFactsCard(mappedAppellantCaseData),
+		buildEnforcementApplicationDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningAppealDetailsCard(mappedAppellantCaseData),
+		buildEnforcementNoticeUploadedDocumentsCard(mappedAppellantCaseData),
+		buildAdditionalDocumentsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			userHasUpdateCasePermission
+		)
+	];
 
-	const beforeYouStartComponents = getComponentParameters('before-you-start', pageComponents);
-	if (beforeYouStartComponents) {
-		beforeYouStartComponents.parameters.rows = [
-			!config.featureFlags.featureFlagNewBeforeYouStart &&
-				mappedAppellantCaseData.enforcementNotice.display.summaryListItem,
-			mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem,
-			config.featureFlags.featureFlagNewBeforeYouStart &&
-				mappedAppellantCaseData.applicationType.display.summaryListItem,
-			!config.featureFlags.featureFlagNewBeforeYouStart &&
-				mappedAppellantCaseData.enforcementNoticeListedBuilding.display.summaryListItem,
-			mappedAppellantCaseData.enforcementIssueDate.display.summaryListItem,
-			mappedAppellantCaseData.enforcementEffectiveDate.display.summaryListItem,
-			mappedAppellantCaseData.contactPlanningInspectorateDate.display.summaryListItem,
-			mappedAppellantCaseData.enforcementReference.display.summaryListItem
-		].filter((row) => row);
-	}
-
-	if (mappedAppellantCaseData.otherAppellants?.display?.summaryListItem) {
-		getComponentParameters('appellant-details', pageComponents)?.parameters.rows.push(
-			mappedAppellantCaseData.otherAppellants.display.summaryListItem
-		);
-	}
-
-	const appealSiteAddressComponents = getComponentParameters('site-details', pageComponents);
-	if (appealSiteAddressComponents) {
-		appealSiteAddressComponents.parameters.card.title.text = 'Land';
-		appealSiteAddressComponents.parameters.rows = [
-			mappedAppellantCaseData.siteAddress.display.summaryListItem,
-			mappedAppellantCaseData.contactAddress.display.summaryListItem,
-			mappedAppellantCaseData.interestInLand.display.summaryListItem,
-			mappedAppellantCaseData.writtenOrVerbalPermission?.display?.summaryListItem,
-			mappedAppellantCaseData.inspectorAccess.display.summaryListItem,
-			mappedAppellantCaseData.healthAndSafetyIssues.display.summaryListItem
-		].filter((row) => row);
-	}
-
-	const applicationDetailsComponents = getComponentParameters(
-		'application-summary',
-		pageComponents
-	);
-	if (applicationDetailsComponents) {
-		applicationDetailsComponents.parameters.rows = [
-			mappedAppellantCaseData.relatedAppeals.display.summaryListItem
-		].filter((row) => row);
-	}
-
-	const uploadDocumentsComponents = getComponentParameters('uploaded-documents', pageComponents);
-	if (uploadDocumentsComponents) {
-		uploadDocumentsComponents.parameters.rows = [
-			mappedAppellantCaseData.priorCorrespondenceWithPINS.display.summaryListItem,
-			mappedAppellantCaseData.enforcementNoticeDocuments.display.summaryListItem,
-			mappedAppellantCaseData.enforcementNoticePlanDocuments.display.summaryListItem,
-			mappedAppellantCaseData.applicationForm.display.summaryListItem,
-			mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-			mappedAppellantCaseData.decisionLetter.display.summaryListItem,
-			mappedAppellantCaseData.statusPlanningObligation.display.summaryListItem,
-			mappedAppellantCaseData.planningObligation.display.summaryListItem,
-			mappedAppellantCaseData.costsDocument.display.summaryListItem,
-			mappedAppellantCaseData.otherNewDocuments.display.summaryListItem
-		].filter((row) => row);
-	}
-
-	/**
-	 *
-	 * @param {Instructions[]} subMapperList
-	 * @returns {SummaryListRowProperties[]}
-	 */
-	const getSummaryListItems = (subMapperList) =>
-		// @ts-ignore
-		subMapperList?.map((subMapper) => subMapper.display.summaryListItem);
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const groundsAndFactsSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'grounds-and-facts'
-			},
-			card: {
-				title: {
-					text: 'Grounds and facts'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.descriptionOfAllegedBreach.display.summaryListItem,
-				mappedAppellantCaseData.groundsForAppeal.display.summaryListItem,
-				// @ts-ignore
-				...getSummaryListItems(mappedAppellantCaseData.factsForGrounds),
-				// @ts-ignore
-				...getSummaryListItems(mappedAppellantCaseData.supportingDocumentsForGrounds),
-				mappedAppellantCaseData.retrospectiveApplication?.display?.summaryListItem,
-				mappedAppellantCaseData.groundAFeeReceipt?.display?.summaryListItem,
-				mappedAppellantCaseData.applicationDevelopmentAllOrPart?.display?.summaryListItem,
-				mappedAppellantCaseData.applicationReference.display.summaryListItem,
-				mappedAppellantCaseData.applicationDate.display.summaryListItem,
-				mappedAppellantCaseData.developmentDescription.display.summaryListItem,
-				mappedAppellantCaseData.applicationDecision.display.summaryListItem,
-				mappedAppellantCaseData.applicationDecisionDate.display.summaryListItem,
-				mappedAppellantCaseData.appealDecisionDate?.display?.summaryListItem
-			].filter((row) => row)
-		}
-	};
-
-	const insertIndex =
-		pageComponents.findIndex(
-			(component) => component.parameters.attributes?.id === 'site-details'
-		) + 1;
-
-	return pageComponents
-		.slice(0, insertIndex)
-		.concat(groundsAndFactsSummary)
-		.concat(pageComponents.slice(insertIndex));
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-notice.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/enforcement-notice.mapper.js
@@ -5,24 +5,14 @@ import {
 	buildEnforcementBeforeYouStartCard,
 	buildEnforcementLandDetailsCard,
 	buildFullPlanningAppealDetailsCard,
-	buildSummaryListCard
+	buildSummaryListCard,
+	getSummaryListItems
 } from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} Appeal
  */
-
-/**
- * Helper to extract summaryListItem from subMapper array or object.
- * @param {any} [subMapperList]
- * @returns {any[]}
- */
-export function getSummaryListItems(subMapperList) {
-	if (!subMapperList) return [];
-	const list = Array.isArray(subMapperList) ? subMapperList : [subMapperList];
-	return list.map((subMapper) => subMapper?.display?.summaryListItem).filter(Boolean);
-}
 
 /**
  * Builds the Enforcement Notice "Grounds and facts" section card component.

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
@@ -59,21 +59,15 @@ export function generateHASComponents(
 		buildBeforeYouStartCard(mappedAppellantCaseData),
 		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
 		buildSiteDetailsCard(mappedAppellantCaseData),
-		buildApplicationDetailsCard(mappedAppellantCaseData)
-	];
-
-	if (isExpeditedEligible) {
-		components.push(buildAppealDetailsCard(mappedAppellantCaseData));
-	}
-
-	components.push(
+		buildApplicationDetailsCard(mappedAppellantCaseData),
+		isExpeditedEligible ? buildAppealDetailsCard(mappedAppellantCaseData) : null,
 		buildHASUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData),
 		buildAdditionalDocumentsCard(
 			appellantCaseData,
 			mappedAppellantCaseData,
 			userHasUpdateCasePermission
 		)
-	);
+	];
 
 	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
@@ -1,13 +1,15 @@
 import { isFeatureActive } from '#common/feature-flags.js';
-import * as displayPageFormatter from '#lib/display-page-formatter.js';
-import {
-	documentUploadUrlTemplate,
-	mapDocumentManageUrl
-} from '#lib/mappers/data/appellant-case/common.js';
-import { removeSummaryListActions } from '#lib/mappers/index.js';
-import { isFolderInfo } from '#lib/ts-utilities.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/appeal-type-checks.js';
+import {
+	buildAdditionalDocumentsCard,
+	buildAppealDetailsCard,
+	buildAppellantDetailsCard,
+	buildApplicationDetailsCard,
+	buildBeforeYouStartCard,
+	buildSiteDetailsCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -15,12 +17,29 @@ import { beforeExpeditedOriginalApplicationCutOff } from '@pins/appeals/utils/ap
  */
 
 /**
+ * Builds the HAS "Uploaded documents" card section.
+ * @param {SingleAppellantCaseResponse} appellantCaseData
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildHASUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		mappedAppellantCaseData.changedDevelopmentDescriptionDocument?.display?.summaryListItem,
+		...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
+			? [mappedAppellantCaseData.appealStatement?.display?.summaryListItem]
+			: []),
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
  * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateHASComponents(
 	appealDetails,
@@ -28,225 +47,6 @@ export function generateHASComponents(
 	mappedAppellantCaseData,
 	userHasUpdateCasePermission
 ) {
-	const lpaText = 'Local planning authority';
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const beforeYouStartSectionSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'before-you-start'
-			},
-			card: {
-				title: {
-					text: 'Before you start'
-				}
-			},
-			rows: [
-				...(mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem
-					? [
-							{
-								...mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem,
-								key: {
-									text: lpaText
-								}
-							}
-						]
-					: []),
-				removeSummaryListActions(mappedAppellantCaseData.applicationType.display.summaryListItem),
-				mappedAppellantCaseData.applicationDecision.display.summaryListItem,
-				mappedAppellantCaseData.applicationDecisionDate.display.summaryListItem,
-				mappedAppellantCaseData.applicationReference.display.summaryListItem
-			]
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const appellantSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'appellant-details'
-			},
-			card: {
-				title: {
-					text: 'Appellant details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.appellant.display.summaryListItem,
-				...(appealDetails.agent ? [mappedAppellantCaseData.agent.display.summaryListItem] : [])
-			]
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const appealSiteSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'site-details'
-			},
-			card: {
-				title: {
-					text: 'Site details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.siteAddress.display.summaryListItem,
-				mappedAppellantCaseData.siteArea.display.summaryListItem,
-				mappedAppellantCaseData.inGreenBelt.display.summaryListItem,
-				mappedAppellantCaseData.siteOwnership.display.summaryListItem,
-				mappedAppellantCaseData.ownersKnown.display.summaryListItem,
-				mappedAppellantCaseData.inspectorAccess.display.summaryListItem,
-				mappedAppellantCaseData.healthAndSafetyIssues.display.summaryListItem,
-				mappedAppellantCaseData.anySignificantChanges?.display?.summaryListItem
-			].filter(Boolean)
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const applicationSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'application-summary'
-			},
-			card: {
-				title: {
-					text: 'Application details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.applicationDate.display.summaryListItem,
-				mappedAppellantCaseData.developmentDescription.display.summaryListItem,
-				mappedAppellantCaseData.relatedAppeals.display.summaryListItem,
-				mappedAppellantCaseData.decisionLetter.display.summaryListItem
-			].filter(Boolean)
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const uploadedDocuments = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'uploaded-documents'
-			},
-			card: {
-				title: {
-					text: 'Upload documents'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.applicationForm.display.summaryListItem,
-				mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-				// we want to hide the appeal statement for appeals submitted 1st April 2026 onwards
-				...(beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate)
-					? [mappedAppellantCaseData.appealStatement.display.summaryListItem]
-					: []),
-				mappedAppellantCaseData.costsDocument.display.summaryListItem
-			]
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const additionalDocumentsSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'additional-documents'
-			},
-			classes: 'pins-summary-list--fullwidth-value',
-			card: {
-				title: {
-					text: 'Additional documents'
-				},
-				actions: {
-					items:
-						isFolderInfo(appellantCaseData.documents.appellantCaseCorrespondence) &&
-						appellantCaseData.documents?.appellantCaseCorrespondence?.documents &&
-						appellantCaseData.documents?.appellantCaseCorrespondence?.documents.length > 0
-							? [
-									{
-										text: 'Manage',
-										visuallyHiddenText: 'additional documents',
-										href: mapDocumentManageUrl(
-											appellantCaseData.appealId,
-											appellantCaseData.documents.appellantCaseCorrespondence.folderId
-										)
-									},
-									...(userHasUpdateCasePermission && !appellantCaseData.isEnforcementChild
-										? [
-												{
-													text: 'Add',
-													visuallyHiddenText: 'additional documents',
-													href: displayPageFormatter.formatDocumentActionLink(
-														appellantCaseData.appealId,
-														appellantCaseData.documents.appellantCaseCorrespondence,
-														documentUploadUrlTemplate
-													)
-												}
-											]
-										: [])
-								]
-							: [
-									...(userHasUpdateCasePermission && !appellantCaseData.isEnforcementChild
-										? [
-												{
-													text: 'Add',
-													visuallyHiddenText: 'additional documents',
-													href: displayPageFormatter.formatDocumentActionLink(
-														appellantCaseData.appealId,
-														appellantCaseData.documents.appellantCaseCorrespondence,
-														documentUploadUrlTemplate
-													)
-												}
-											]
-										: [])
-								]
-				}
-			},
-			rows: mappedAppellantCaseData.additionalDocuments.display.summaryListItems
-		}
-	};
-
 	const isExpeditedAppealsActive = isFeatureActive(FEATURE_FLAG_NAMES.EXPEDITED_APPEALS);
 	const isExpeditedEligible =
 		isExpeditedAppealsActive &&
@@ -256,36 +56,24 @@ export function generateHASComponents(
 		!beforeExpeditedOriginalApplicationCutOff(appellantCaseData.applicationDate);
 
 	const components = [
-		beforeYouStartSectionSummary,
-		appellantSummary,
-		appealSiteSummary,
-		applicationSummary
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildSiteDetailsCard(mappedAppellantCaseData),
+		buildApplicationDetailsCard(mappedAppellantCaseData)
 	];
 
 	if (isExpeditedEligible) {
-		components.push({
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'appeal-summary'
-				},
-				card: {
-					title: {
-						text: 'Appeal details'
-					}
-				},
-				rows: [mappedAppellantCaseData.reasonForAppealAppellant.display.summaryListItem].filter(
-					Boolean
-				)
-			}
-		});
+		components.push(buildAppealDetailsCard(mappedAppellantCaseData));
 	}
 
-	components.push(uploadedDocuments, additionalDocumentsSummary);
+	components.push(
+		buildHASUploadedDocumentsCard(appellantCaseData, mappedAppellantCaseData),
+		buildAdditionalDocumentsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			userHasUpdateCasePermission
+		)
+	);
 
-	return components;
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/ldc.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/ldc.mapper.js
@@ -1,4 +1,8 @@
-import { removeSummaryListActions } from '#lib/mappers/index.js';
+import {
+	buildAppellantDetailsCard,
+	buildBeforeYouStartCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -6,195 +10,82 @@ import { removeSummaryListActions } from '#lib/mappers/index.js';
  */
 
 /**
+ * Builds the LDC "Site details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildLdcSiteDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('site-details', 'Site details', [
+		mappedAppellantCaseData.siteAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.inspectorAccess?.display?.summaryListItem,
+		mappedAppellantCaseData.healthAndSafetyIssues?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the LDC "Application details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildLdcApplicationDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('application-summary', 'Application details', [
+		mappedAppellantCaseData.applicationDate?.display?.summaryListItem,
+		mappedAppellantCaseData.siteUseAtTimeOfApplication?.display?.summaryListItem,
+		mappedAppellantCaseData.applicationMadeUnderActSection?.display?.summaryListItem,
+		mappedAppellantCaseData.developmentDescription?.display?.summaryListItem,
+		mappedAppellantCaseData.changedDevelopmentDescriptionDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.relatedAppeals?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the LDC "Appeal details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildLdcAppealDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('appeal-summary', 'Appeal details', [
+		mappedAppellantCaseData.procedurePreference?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDetails?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDuration?.display?.summaryListItem,
+		mappedAppellantCaseData.inquiryNumberOfWitnesses?.display?.summaryListItem
+	]);
+}
+
+/**
+ * Builds the LDC "Uploaded documents" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildLdcUploadedDocumentsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		mappedAppellantCaseData.appealStatement?.display?.summaryListItem,
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.supportingDocuments?.display?.summaryListItem,
+		mappedAppellantCaseData.statementCommonGround?.display?.summaryListItem,
+		mappedAppellantCaseData.newPlansDrawings?.display?.summaryListItem,
+		mappedAppellantCaseData.decisionLetter?.display?.summaryListItem,
+		mappedAppellantCaseData.otherNewDocuments?.display?.summaryListItem
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateLdcComponents(appealDetails, appellantCaseData, mappedAppellantCaseData) {
-	const lpaText = 'Local planning authority';
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const beforeYouStartSectionSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'before-you-start'
-			},
-			card: {
-				title: {
-					text: 'Before you start'
-				}
-			},
-			rows: [
-				...(mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem
-					? [
-							{
-								...mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem,
-								key: {
-									text: lpaText
-								}
-							}
-						]
-					: []),
-				removeSummaryListActions(mappedAppellantCaseData.applicationType.display.summaryListItem),
-				mappedAppellantCaseData.applicationDecision.display.summaryListItem,
-				mappedAppellantCaseData.applicationDecisionDate.display.summaryListItem,
-				mappedAppellantCaseData.applicationReference.display.summaryListItem
-			]
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const appellantSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'appellant-details'
-			},
-			card: {
-				title: {
-					text: 'Appellant details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.appellant.display.summaryListItem,
-				...(appealDetails.agent ? [mappedAppellantCaseData.agent.display.summaryListItem] : [])
-			]
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const appealSiteSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'site-details'
-			},
-			card: {
-				title: {
-					text: 'Site details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.siteAddress.display.summaryListItem,
-				mappedAppellantCaseData.inspectorAccess.display.summaryListItem,
-				mappedAppellantCaseData.healthAndSafetyIssues.display.summaryListItem
-			]
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const applicationSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'application-summary'
-			},
-			card: {
-				title: {
-					text: 'Application details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.applicationDate.display.summaryListItem,
-				mappedAppellantCaseData.siteUseAtTimeOfApplication.display.summaryListItem,
-				mappedAppellantCaseData.applicationMadeUnderActSection.display.summaryListItem,
-				mappedAppellantCaseData.developmentDescription.display.summaryListItem,
-				mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-				mappedAppellantCaseData.relatedAppeals.display.summaryListItem
-			]
-		}
-	};
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const appealSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'appeal-summary'
-			},
-			card: {
-				title: {
-					text: 'Appeal details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.procedurePreference.display.summaryListItem,
-				mappedAppellantCaseData.procedurePreferenceDetails.display.summaryListItem,
-				mappedAppellantCaseData.procedurePreferenceDuration.display.summaryListItem,
-				mappedAppellantCaseData.inquiryNumberOfWitnesses.display.summaryListItem
-			]
-		}
-	};
-	/** @type {PageComponent} */
-	const uploadedDocuments = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'uploaded-documents'
-			},
-			card: {
-				title: {
-					text: 'Upload documents'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.applicationForm.display.summaryListItem,
-				mappedAppellantCaseData.appealStatement.display.summaryListItem,
-				mappedAppellantCaseData.costsDocument.display.summaryListItem,
-				mappedAppellantCaseData.supportingDocuments.display.summaryListItem,
-				mappedAppellantCaseData.statementCommonGround.display.summaryListItem,
-				mappedAppellantCaseData.newPlansDrawings.display.summaryListItem,
-				mappedAppellantCaseData.decisionLetter.display.summaryListItem,
-				mappedAppellantCaseData.otherNewDocuments.display.summaryListItem
-			]
-		}
-	};
-
 	const pageComponents = [
-		beforeYouStartSectionSummary,
-		appellantSummary,
-		appealSiteSummary,
-		applicationSummary,
-		appealSummary,
-		uploadedDocuments
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildLdcSiteDetailsCard(mappedAppellantCaseData),
+		buildLdcApplicationDetailsCard(mappedAppellantCaseData),
+		buildLdcAppealDetailsCard(mappedAppellantCaseData),
+		buildLdcUploadedDocumentsCard(mappedAppellantCaseData)
 	];
 
-	return pageComponents;
+	return pageComponents.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s20.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s20.mapper.js
@@ -1,4 +1,12 @@
-import { generateHASComponents } from './has.mapper.js';
+import {
+	buildAdditionalDocumentsCard,
+	buildAppellantDetailsCard,
+	buildBeforeYouStartCard,
+	buildFullPlanningAppealDetailsCard,
+	buildFullPlanningApplicationDetailsCard,
+	buildFullPlanningUploadedDocumentsCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -6,12 +14,29 @@ import { generateHASComponents } from './has.mapper.js';
  */
 
 /**
+ * Builds the S20 "Site details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildS20SiteDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('site-details', 'Site details', [
+		mappedAppellantCaseData.siteAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.siteArea?.display?.summaryListItem,
+		mappedAppellantCaseData.inGreenBelt?.display?.summaryListItem,
+		mappedAppellantCaseData.siteOwnership?.display?.summaryListItem,
+		mappedAppellantCaseData.ownersKnown?.display?.summaryListItem,
+		mappedAppellantCaseData.inspectorAccess?.display?.summaryListItem,
+		mappedAppellantCaseData.healthAndSafetyIssues?.display?.summaryListItem
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
  * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateS20Components(
 	appealDetails,
@@ -19,164 +44,19 @@ export function generateS20Components(
 	mappedAppellantCaseData,
 	userHasUpdateCasePermission
 ) {
-	const pageComponents = generateHASComponents(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
+	const components = [
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildS20SiteDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningApplicationDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningAppealDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningUploadedDocumentsCard(mappedAppellantCaseData),
+		buildAdditionalDocumentsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			userHasUpdateCasePermission
+		)
+	];
 
-	const siteDetailsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' && component.parameters.attributes?.id === 'site-details'
-	);
-
-	if (siteDetailsComponentIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-
-		const appealSiteSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'site-details'
-				},
-				card: {
-					title: {
-						text: 'Site details'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.siteAddress.display.summaryListItem,
-					mappedAppellantCaseData.siteArea.display.summaryListItem,
-					mappedAppellantCaseData.inGreenBelt.display.summaryListItem,
-					mappedAppellantCaseData.siteOwnership.display.summaryListItem,
-					mappedAppellantCaseData.ownersKnown.display.summaryListItem,
-					mappedAppellantCaseData.inspectorAccess.display.summaryListItem,
-					mappedAppellantCaseData.healthAndSafetyIssues.display.summaryListItem
-				]
-			}
-		};
-
-		pageComponents[siteDetailsComponentIndex] = appealSiteSummary;
-	}
-
-	const applicationSummaryComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'application-summary'
-	);
-
-	if (applicationSummaryComponentIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const applicationSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'application-summary'
-				},
-				card: {
-					title: {
-						text: 'Application details'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.applicationDate.display.summaryListItem,
-					mappedAppellantCaseData.developmentDescription.display.summaryListItem,
-					mappedAppellantCaseData.relatedAppeals.display.summaryListItem,
-					mappedAppellantCaseData.developmentType.display.summaryListItem
-				]
-			}
-		};
-
-		pageComponents[applicationSummaryComponentIndex] = applicationSummary;
-	}
-
-	/**
-	 * @type {PageComponent}
-	 */
-	const appealSummary = {
-		type: 'summary-list',
-		wrapperHtml: {
-			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-			closing: '</div></div>'
-		},
-		parameters: {
-			attributes: {
-				id: 'appeal-summary'
-			},
-			card: {
-				title: {
-					text: 'Appeal details'
-				}
-			},
-			rows: [
-				mappedAppellantCaseData.procedurePreference.display.summaryListItem,
-				mappedAppellantCaseData.procedurePreferenceDetails.display.summaryListItem,
-				mappedAppellantCaseData.procedurePreferenceDuration.display.summaryListItem,
-				mappedAppellantCaseData.inquiryNumberOfWitnesses.display.summaryListItem
-			]
-		}
-	};
-	const secondToLastPosition = pageComponents.length - 2;
-	pageComponents.splice(secondToLastPosition, 0, appealSummary);
-
-	const uploadedDocumentsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'uploaded-documents'
-	);
-
-	if (uploadedDocumentsComponentIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const uploadedDocuments = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'uploaded-documents'
-				},
-				card: {
-					title: {
-						text: 'Upload documents'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.applicationForm.display.summaryListItem,
-					mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-					mappedAppellantCaseData.decisionLetter.display.summaryListItem,
-					mappedAppellantCaseData.appealStatement.display.summaryListItem,
-					mappedAppellantCaseData.statusPlanningObligation?.display.summaryListItem,
-					mappedAppellantCaseData.planningObligation?.display.summaryListItem,
-					mappedAppellantCaseData.statementCommonGround?.display.summaryListItem,
-					mappedAppellantCaseData.ownershipCertificate.display.summaryListItem,
-					mappedAppellantCaseData.costsDocument.display.summaryListItem,
-					mappedAppellantCaseData.designAccessStatement?.display.summaryListItem,
-					mappedAppellantCaseData.supportingDocuments?.display.summaryListItem,
-					mappedAppellantCaseData.newPlansDrawings?.display.summaryListItem,
-					mappedAppellantCaseData.otherNewDocuments?.display.summaryListItem
-				]
-			}
-		};
-
-		pageComponents[uploadedDocumentsComponentIndex] = uploadedDocuments;
-	}
-
-	return pageComponents;
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78-expedited.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78-expedited.mapper.js
@@ -1,6 +1,12 @@
 import { isFeatureActive } from '#common/feature-flags.js';
 import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
-import { generateS20Components } from './s20.mapper.js';
+import {
+	buildAdditionalDocumentsCard,
+	buildAppellantDetailsCard,
+	buildBeforeYouStartCard,
+	buildFullPlanningApplicationDetailsCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -8,12 +14,122 @@ import { generateS20Components } from './s20.mapper.js';
  */
 
 /**
+ * Builds the S78 Expedited "Site details" section card component.
+ * @param {SingleAppellantCaseResponse} appellantCaseData
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {boolean} isExpeditedAppealsActive
+ * @returns {PageComponent|null}
+ */
+export function buildS78ExpeditedSiteDetailsCard(
+	appellantCaseData,
+	mappedAppellantCaseData,
+	isExpeditedAppealsActive
+) {
+	return buildSummaryListCard('site-details', 'Site details', [
+		mappedAppellantCaseData.siteAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.siteArea?.display?.summaryListItem,
+		mappedAppellantCaseData.inGreenBelt?.display?.summaryListItem,
+		mappedAppellantCaseData.siteOwnership?.display?.summaryListItem,
+		mappedAppellantCaseData.ownersKnown?.display?.summaryListItem,
+		mappedAppellantCaseData.partOfAgriculturalHolding?.display?.summaryListItem,
+		mappedAppellantCaseData.tenantOfAgriculturalHolding?.display?.summaryListItem,
+		mappedAppellantCaseData.otherTenantsOfAgriculturalHolding?.display?.summaryListItem,
+		mappedAppellantCaseData.inspectorAccess?.display?.summaryListItem,
+		mappedAppellantCaseData.healthAndSafetyIssues?.display?.summaryListItem,
+		...(isExpeditedAppealsActive && appellantCaseData.anySignificantChanges != null
+			? [mappedAppellantCaseData.anySignificantChanges?.display?.summaryListItem]
+			: [])
+	]);
+}
+
+/**
+ * Builds the S78 Expedited "Appeal details" section card component.
+ * @param {SingleAppellantCaseResponse} appellantCaseData
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {boolean} isExpeditedAppealsActive
+ * @returns {PageComponent|null}
+ */
+export function buildS78ExpeditedAppealDetailsCard(
+	appellantCaseData,
+	mappedAppellantCaseData,
+	isExpeditedAppealsActive
+) {
+	const includeReason =
+		isExpeditedAppealsActive && appellantCaseData.reasonForAppealAppellant != null;
+
+	return buildSummaryListCard('appeal-summary', 'Appeal details', [
+		mappedAppellantCaseData.procedurePreference?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDetails?.display?.summaryListItem,
+		mappedAppellantCaseData.procedurePreferenceDuration?.display?.summaryListItem,
+		mappedAppellantCaseData.inquiryNumberOfWitnesses?.display?.summaryListItem,
+		...(includeReason
+			? [mappedAppellantCaseData.reasonForAppealAppellant?.display?.summaryListItem]
+			: [])
+	]);
+}
+
+/**
+ * Builds the S78 Expedited "Uploaded documents" section card component.
+ * @param {SingleAppellantCaseResponse} appellantCaseData
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @param {boolean} isExpeditedAppealsActive
+ * @returns {PageComponent|null}
+ */
+export function buildS78ExpeditedUploadedDocumentsCard(
+	appellantCaseData,
+	mappedAppellantCaseData,
+	isExpeditedAppealsActive
+) {
+	if (appellantCaseData.ownershipCertificate != null) {
+		return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+			mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+			mappedAppellantCaseData.changedDevelopmentDescriptionDocument?.display?.summaryListItem,
+			mappedAppellantCaseData.decisionLetter?.display?.summaryListItem,
+			mappedAppellantCaseData.planningObligation?.display?.summaryListItem,
+			mappedAppellantCaseData.appealStatement?.display?.summaryListItem,
+			mappedAppellantCaseData.statementCommonGround?.display?.summaryListItem,
+			mappedAppellantCaseData.ownershipCertificate?.display?.summaryListItem,
+			mappedAppellantCaseData.designAccessStatement?.display?.summaryListItem,
+			mappedAppellantCaseData.plansDrawings?.display?.summaryListItem,
+			mappedAppellantCaseData.newPlansDrawings?.display?.summaryListItem,
+			mappedAppellantCaseData.newSupportingDocuments?.display?.summaryListItem,
+			...(isExpeditedAppealsActive
+				? [mappedAppellantCaseData.ownershipCertificateExpedited?.display?.summaryListItem]
+				: []),
+			mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+			...(isExpeditedAppealsActive && appellantCaseData.screeningOpinionIndicatesEiaRequired != null
+				? [mappedAppellantCaseData.screeningOpinionIndicatesEiaRequired?.display?.summaryListItem]
+				: []),
+			...(isExpeditedAppealsActive
+				? [mappedAppellantCaseData.environmentalStatement?.display?.summaryListItem]
+				: [])
+		]);
+	}
+
+	// Legacy base s20 uploaded docs section without appealStatement
+	return buildSummaryListCard('uploaded-documents', 'Upload documents', [
+		mappedAppellantCaseData.applicationForm?.display?.summaryListItem,
+		mappedAppellantCaseData.changedDevelopmentDescriptionDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.decisionLetter?.display?.summaryListItem,
+		mappedAppellantCaseData.statusPlanningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.planningObligation?.display?.summaryListItem,
+		mappedAppellantCaseData.statementCommonGround?.display?.summaryListItem,
+		mappedAppellantCaseData.ownershipCertificate?.display?.summaryListItem,
+		mappedAppellantCaseData.costsDocument?.display?.summaryListItem,
+		mappedAppellantCaseData.designAccessStatement?.display?.summaryListItem,
+		mappedAppellantCaseData.supportingDocuments?.display?.summaryListItem,
+		mappedAppellantCaseData.newPlansDrawings?.display?.summaryListItem,
+		mappedAppellantCaseData.otherNewDocuments?.display?.summaryListItem
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
  * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateS78ExpeditedComponents(
 	appealDetails,
@@ -22,169 +138,32 @@ export function generateS78ExpeditedComponents(
 	userHasUpdateCasePermission
 ) {
 	const isExpeditedAppealsActive = isFeatureActive(FEATURE_FLAG_NAMES.EXPEDITED_APPEALS);
-	const pageComponents = generateS20Components(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
 
-	const siteDetailsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' && component.parameters.attributes?.id === 'site-details'
-	);
+	const components = [
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildS78ExpeditedSiteDetailsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			isExpeditedAppealsActive
+		),
+		buildFullPlanningApplicationDetailsCard(mappedAppellantCaseData),
+		buildS78ExpeditedAppealDetailsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			isExpeditedAppealsActive
+		),
+		buildS78ExpeditedUploadedDocumentsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			isExpeditedAppealsActive
+		),
+		buildAdditionalDocumentsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			userHasUpdateCasePermission
+		)
+	];
 
-	if (siteDetailsComponentIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const appealSiteSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'site-details'
-				},
-				card: {
-					title: {
-						text: 'Site details'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.siteAddress.display.summaryListItem,
-					mappedAppellantCaseData.siteArea.display.summaryListItem,
-					mappedAppellantCaseData.inGreenBelt.display.summaryListItem,
-					mappedAppellantCaseData.siteOwnership.display.summaryListItem,
-					mappedAppellantCaseData.ownersKnown.display.summaryListItem,
-					mappedAppellantCaseData.partOfAgriculturalHolding.display.summaryListItem,
-					mappedAppellantCaseData.tenantOfAgriculturalHolding.display.summaryListItem,
-					mappedAppellantCaseData.otherTenantsOfAgriculturalHolding.display.summaryListItem,
-					mappedAppellantCaseData.inspectorAccess.display.summaryListItem,
-					mappedAppellantCaseData.healthAndSafetyIssues.display.summaryListItem,
-					...(isExpeditedAppealsActive && appellantCaseData.anySignificantChanges != null
-						? [mappedAppellantCaseData.anySignificantChanges.display.summaryListItem]
-						: [])
-				]
-			}
-		};
-
-		pageComponents[siteDetailsComponentIndex] = appealSiteSummary;
-	}
-
-	const appealDetailsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' && component.parameters.attributes?.id === 'appeal-summary'
-	);
-
-	if (
-		appealDetailsComponentIndex !== -1 &&
-		isExpeditedAppealsActive &&
-		appellantCaseData.reasonForAppealAppellant != null
-	) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const appealDetailsSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'appeal-summary'
-				},
-				card: {
-					title: {
-						text: 'Appeal details'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.procedurePreference.display.summaryListItem,
-					mappedAppellantCaseData.procedurePreferenceDetails.display.summaryListItem,
-					mappedAppellantCaseData.procedurePreferenceDuration.display.summaryListItem,
-					mappedAppellantCaseData.inquiryNumberOfWitnesses.display.summaryListItem,
-					mappedAppellantCaseData.reasonForAppealAppellant.display.summaryListItem
-				]
-			}
-		};
-
-		pageComponents[appealDetailsComponentIndex] = appealDetailsSummary;
-	}
-
-	const uploadedDocumentsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'uploaded-documents'
-	);
-
-	if (uploadedDocumentsComponentIndex !== -1) {
-		if (appellantCaseData.ownershipCertificate != null) {
-			/**
-			 * @type {PageComponent}
-			 */
-			const uploadedDocumentsSummary = {
-				type: 'summary-list',
-				wrapperHtml: {
-					opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-					closing: '</div></div>'
-				},
-				parameters: {
-					attributes: {
-						id: 'uploaded-documents'
-					},
-					card: {
-						title: {
-							text: 'Upload documents'
-						}
-					},
-					rows: [
-						mappedAppellantCaseData.applicationForm.display.summaryListItem,
-						mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-						mappedAppellantCaseData.decisionLetter.display.summaryListItem,
-						mappedAppellantCaseData.planningObligation.display.summaryListItem,
-						mappedAppellantCaseData.appealStatement.display.summaryListItem,
-						mappedAppellantCaseData.statementCommonGround.display.summaryListItem,
-						mappedAppellantCaseData.ownershipCertificate.display.summaryListItem,
-						mappedAppellantCaseData.designAccessStatement.display.summaryListItem,
-						mappedAppellantCaseData.plansDrawings.display.summaryListItem,
-						mappedAppellantCaseData.newPlansDrawings.display.summaryListItem,
-						mappedAppellantCaseData.newSupportingDocuments.display.summaryListItem,
-						...(isExpeditedAppealsActive
-							? [mappedAppellantCaseData.ownershipCertificateExpedited.display.summaryListItem]
-							: []),
-						mappedAppellantCaseData.costsDocument.display.summaryListItem,
-						...(isExpeditedAppealsActive &&
-						appellantCaseData.screeningOpinionIndicatesEiaRequired != null
-							? [
-									mappedAppellantCaseData.screeningOpinionIndicatesEiaRequired.display
-										.summaryListItem
-								]
-							: []),
-						...(isExpeditedAppealsActive
-							? [mappedAppellantCaseData?.environmentalStatement.display.summaryListItem]
-							: [])
-					]
-				}
-			};
-
-			pageComponents[uploadedDocumentsComponentIndex] = uploadedDocumentsSummary;
-		} else {
-			// remove the appeal statement row from the base s20 uploaded docs section
-			const appealStatementRowIndex = pageComponents[
-				uploadedDocumentsComponentIndex
-			].parameters.rows.indexOf(mappedAppellantCaseData.appealStatement.display.summaryListItem);
-			if (appealStatementRowIndex !== -1) {
-				pageComponents[uploadedDocumentsComponentIndex].parameters.rows.splice(
-					appealStatementRowIndex,
-					1
-				);
-			}
-		}
-	}
-
-	return pageComponents;
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78.mapper.js
@@ -1,4 +1,12 @@
-import { generateS20Components } from './s20.mapper.js';
+import {
+	buildAdditionalDocumentsCard,
+	buildAppellantDetailsCard,
+	buildBeforeYouStartCard,
+	buildFullPlanningAppealDetailsCard,
+	buildFullPlanningApplicationDetailsCard,
+	buildFullPlanningUploadedDocumentsCard,
+	buildSummaryListCard
+} from './common-sections.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
@@ -6,12 +14,32 @@ import { generateS20Components } from './s20.mapper.js';
  */
 
 /**
+ * Builds the S78 "Site details" section card component.
+ * @param {MappedInstructions} mappedAppellantCaseData
+ * @returns {PageComponent|null}
+ */
+export function buildS78SiteDetailsCard(mappedAppellantCaseData) {
+	return buildSummaryListCard('site-details', 'Site details', [
+		mappedAppellantCaseData.siteAddress?.display?.summaryListItem,
+		mappedAppellantCaseData.siteArea?.display?.summaryListItem,
+		mappedAppellantCaseData.inGreenBelt?.display?.summaryListItem,
+		mappedAppellantCaseData.siteOwnership?.display?.summaryListItem,
+		mappedAppellantCaseData.ownersKnown?.display?.summaryListItem,
+		mappedAppellantCaseData.partOfAgriculturalHolding?.display?.summaryListItem,
+		mappedAppellantCaseData.tenantOfAgriculturalHolding?.display?.summaryListItem,
+		mappedAppellantCaseData.otherTenantsOfAgriculturalHolding?.display?.summaryListItem,
+		mappedAppellantCaseData.inspectorAccess?.display?.summaryListItem,
+		mappedAppellantCaseData.healthAndSafetyIssues?.display?.summaryListItem
+	]);
+}
+
+/**
  *
  * @param {Appeal} appealDetails
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {MappedInstructions} mappedAppellantCaseData
  * @param {boolean} userHasUpdateCasePermission
- * @returns {PageComponent[]}
+ * @returns {(PageComponent|null)[]}
  */
 export function generateS78Components(
 	appealDetails,
@@ -19,100 +47,19 @@ export function generateS78Components(
 	mappedAppellantCaseData,
 	userHasUpdateCasePermission
 ) {
-	const pageComponents = generateS20Components(
-		appealDetails,
-		appellantCaseData,
-		mappedAppellantCaseData,
-		userHasUpdateCasePermission
-	);
+	const components = [
+		buildBeforeYouStartCard(mappedAppellantCaseData),
+		buildAppellantDetailsCard(appealDetails, mappedAppellantCaseData),
+		buildS78SiteDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningApplicationDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningAppealDetailsCard(mappedAppellantCaseData),
+		buildFullPlanningUploadedDocumentsCard(mappedAppellantCaseData),
+		buildAdditionalDocumentsCard(
+			appellantCaseData,
+			mappedAppellantCaseData,
+			userHasUpdateCasePermission
+		)
+	];
 
-	const siteDetailsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' && component.parameters.attributes?.id === 'site-details'
-	);
-
-	if (siteDetailsComponentIndex !== -1) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const appealSiteSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'site-details'
-				},
-				card: {
-					title: {
-						text: 'Site details'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.siteAddress.display.summaryListItem,
-					mappedAppellantCaseData.siteArea.display.summaryListItem,
-					mappedAppellantCaseData.inGreenBelt.display.summaryListItem,
-					mappedAppellantCaseData.siteOwnership.display.summaryListItem,
-					mappedAppellantCaseData.ownersKnown.display.summaryListItem,
-					mappedAppellantCaseData.partOfAgriculturalHolding.display.summaryListItem,
-					mappedAppellantCaseData.tenantOfAgriculturalHolding.display.summaryListItem,
-					mappedAppellantCaseData.otherTenantsOfAgriculturalHolding.display.summaryListItem,
-					mappedAppellantCaseData.inspectorAccess.display.summaryListItem,
-					mappedAppellantCaseData.healthAndSafetyIssues.display.summaryListItem
-				]
-			}
-		};
-
-		pageComponents[siteDetailsComponentIndex] = appealSiteSummary;
-	}
-
-	const uploadedDocumentsComponentIndex = pageComponents.findIndex(
-		(component) =>
-			component.type === 'summary-list' &&
-			component.parameters.attributes?.id === 'uploaded-documents'
-	);
-
-	if (uploadedDocumentsComponentIndex !== -1 && appellantCaseData.ownershipCertificate != null) {
-		/**
-		 * @type {PageComponent}
-		 */
-		const uploadedDocumentsSummary = {
-			type: 'summary-list',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				attributes: {
-					id: 'uploaded-documents'
-				},
-				card: {
-					title: {
-						text: 'Upload documents'
-					}
-				},
-				rows: [
-					mappedAppellantCaseData.applicationForm.display.summaryListItem,
-					mappedAppellantCaseData.changedDevelopmentDescriptionDocument.display.summaryListItem,
-					mappedAppellantCaseData.decisionLetter.display.summaryListItem,
-					mappedAppellantCaseData.appealStatement.display.summaryListItem,
-					mappedAppellantCaseData.statusPlanningObligation.display.summaryListItem,
-					mappedAppellantCaseData.planningObligation.display.summaryListItem,
-					mappedAppellantCaseData.statementCommonGround.display.summaryListItem,
-					mappedAppellantCaseData.ownershipCertificate.display.summaryListItem,
-					mappedAppellantCaseData.costsDocument.display.summaryListItem,
-					mappedAppellantCaseData.designAccessStatement.display.summaryListItem,
-					mappedAppellantCaseData.supportingDocuments.display.summaryListItem,
-					mappedAppellantCaseData.newPlansDrawings.display.summaryListItem,
-					mappedAppellantCaseData.otherNewDocuments.display.summaryListItem
-				]
-			}
-		};
-
-		pageComponents[uploadedDocumentsComponentIndex] = uploadedDocumentsSummary;
-	}
-
-	return pageComponents;
+	return components.filter(Boolean);
 }

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/scripts/generate-docs.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/scripts/generate-docs.js
@@ -1,0 +1,180 @@
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { generateAdvertComponents } from '../adverts.mapper.js';
+import { generateCASAdvertComponents } from '../cas-advert.mapper.js';
+import { generateCASComponents } from '../cas.mapper.js';
+import { generateEnforcementListedComponents } from '../enforcement-listed.mapper.js';
+import { generateEnforcementNoticeComponents } from '../enforcement-notice.mapper.js';
+import { generateHASComponents } from '../has.mapper.js';
+import { generateLdcComponents } from '../ldc.mapper.js';
+import { generateS20Components } from '../s20.mapper.js';
+import { generateS78ExpeditedComponents } from '../s78-expedited.mapper.js';
+import { generateS78Components } from '../s78.mapper.js';
+
+/**
+ * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal
+ * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse
+ */
+
+const mappers = {
+	Adverts: generateAdvertComponents,
+	'CAS Advert': generateCASAdvertComponents,
+	'CAS Planning': generateCASComponents,
+	'Enforcement Listed': generateEnforcementListedComponents,
+	'Enforcement Notice': generateEnforcementNoticeComponents,
+	'Householder (HAS)': generateHASComponents,
+	LDC: generateLdcComponents,
+	S20: generateS20Components,
+	'S78 Expedited': generateS78ExpeditedComponents,
+	'S78 Standard': generateS78Components
+};
+
+/**
+ * @param {string} keyText
+ */
+const createMockRow = (keyText) => ({
+	display: { summaryListItem: { key: { text: keyText }, value: { text: 'Mock Value' } } }
+});
+
+const mockMappedData = /** @type {any} */ ({
+	localPlanningAuthority: createMockRow('Local planning authority'),
+	applicationType: createMockRow('Application type'),
+	applicationDecision: createMockRow('Application decision'),
+	applicationDecisionDate: createMockRow('Application decision date'),
+	applicationReference: createMockRow('LPA application reference number'),
+	appellant: createMockRow('Appellant name'),
+	agent: createMockRow('Agent name'),
+	siteAddress: createMockRow('Site address'),
+	siteArea: createMockRow('Site area'),
+	inGreenBelt: createMockRow('Green belt'),
+	inspectorAccess: createMockRow('Inspector access'),
+	healthAndSafetyIssues: createMockRow('Safety risks'),
+	developmentDescription: createMockRow('Development description'),
+	procedurePreference: createMockRow('Procedure preference'),
+	procedurePreferenceDetails: createMockRow('Procedure preference details'),
+	procedurePreferenceDuration: createMockRow('Procedure preference duration'),
+	inquiryNumberOfWitnesses: createMockRow('Inquiry number of witnesses'),
+	applicationForm: createMockRow('Application form'),
+	decisionLetter: createMockRow('Decision letter'),
+	statusPlanningObligation: createMockRow('Status of planning obligation'),
+	planningObligation: createMockRow('Planning obligation'),
+	statementCommonGround: createMockRow('Draft statement of common ground'),
+	ownershipCertificate: createMockRow('Ownership certificate'),
+	costsDocument: createMockRow('Application for a award of costs'),
+	designAccessStatement: createMockRow('Design and access statement'),
+	appealStatement: createMockRow('Appeal statement'),
+	supportingDocuments: createMockRow('Other new supporting documents'),
+	plansDrawings: createMockRow('Plans, drawings and list of plans'),
+	newPlansDrawings: createMockRow('New plans or drawings'),
+	otherNewDocuments: createMockRow('Other new supporting documents'),
+	applicationDate: createMockRow('Application date'),
+	relatedAppeals: createMockRow('Related appeals'),
+	siteOwnership: createMockRow('Site ownership'),
+	ownersKnown: createMockRow('Owners known'),
+	highwayLand: createMockRow('Highway land'),
+	advertisementInPosition: createMockRow('Advertisement in position'),
+	landownerPermission: createMockRow('Landowner permission'),
+	advertisementDescription: createMockRow('Advertisement description'),
+	developmentType: createMockRow('Development type'),
+	otherAppellants: createMockRow('Other appellants'),
+	contactAddress: createMockRow('Contact address'),
+	interestInLand: createMockRow('Interest in land'),
+	writtenOrVerbalPermission: createMockRow('Written or verbal permission'),
+	enforcementNotice: createMockRow('Enforcement notice'),
+	enforcementIssueDate: createMockRow('Enforcement notice date'),
+	enforcementEffectiveDate: createMockRow('Effective date of enforcement notice'),
+	contactPlanningInspectorateDate: createMockRow('Date planning inspectorate contacted'),
+	enforcementReference: createMockRow('Enforcement reference'),
+	factsForGrounds: createMockRow('Facts for grounds'),
+	supportingDocumentsForGrounds: createMockRow('Supporting documents for grounds'),
+	additionalDocuments: {
+		display: {
+			summaryListItems: [createMockRow('Additional documents').display.summaryListItem]
+		}
+	}
+});
+
+const emptyAppellantCaseData = /** @type {SingleAppellantCaseResponse} */ ({});
+
+export function generateDocContent() {
+	let doc = '## Auto-Generated Rendered Rows by Appeal Type\n\n';
+	doc +=
+		'> Note: Auto-generated from component mapper contracts. Re-run `npm run generate-docs` or `node scripts/generate-appellant-case-docs.js` to update.\n';
+	doc +=
+		'> Note: This list displays all rows rendered when full mapped data is present. Dynamic conditional logic (such as application date cutoffs or optional data checks) is handled within individual mapper functions and is not annotated here.\n\n';
+
+	const appealTypeMap = /** @type {Record<string, string>} */ ({
+		Adverts: APPEAL_TYPE.ADVERTISEMENT,
+		'CAS Advert': APPEAL_TYPE.CAS_ADVERTISEMENT,
+		'CAS Planning': APPEAL_TYPE.CAS_PLANNING,
+		'Enforcement Listed': APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING,
+		'Enforcement Notice': APPEAL_TYPE.ENFORCEMENT_NOTICE,
+		'Householder (HAS)': APPEAL_TYPE.HOUSEHOLDER,
+		LDC: APPEAL_TYPE.LDC,
+		S20: APPEAL_TYPE.S20,
+		'S78 Expedited': APPEAL_TYPE.S78,
+		'S78 Standard': APPEAL_TYPE.S78
+	});
+
+	for (const [typeName, fn] of Object.entries(mappers)) {
+		doc += `### ${typeName}\n`;
+		const appealType = appealTypeMap[typeName] || APPEAL_TYPE.HOUSEHOLDER;
+		const testAppeal = /** @type {WebAppeal} */ (
+			/** @type {unknown} */ ({ appealId: 1, appealType })
+		);
+
+		try {
+			const fullComps = fn(testAppeal, emptyAppellantCaseData, mockMappedData, true).filter(
+				Boolean
+			);
+
+			fullComps.forEach((c) => {
+				if (!c) return;
+				const cardTitle = c.parameters?.card?.title?.text || c.parameters?.attributes?.id;
+				const rows = (c.parameters?.rows || [])
+					.map((/** @type {any} */ r) => r?.key?.text)
+					.filter(Boolean);
+				doc += `- **${cardTitle}**\n`;
+				rows.forEach((/** @type {string} */ r) => {
+					doc += `  - ${r}\n`;
+				});
+			});
+		} catch (e) {
+			const errorMessage = e instanceof Error ? e.message : String(e);
+			doc += `  *(Error generating components: ${errorMessage})*\n`;
+		}
+		doc += '\n';
+	}
+	return doc;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+if (process.argv[1] === __filename) {
+	const readmePath = path.resolve(__dirname, '../README.md');
+	let currentContent = fs.readFileSync(readmePath, 'utf8');
+
+	const marker = '## Auto-Generated Rendered Rows by Appeal Type';
+	if (currentContent.includes(marker)) {
+		currentContent = currentContent.split(marker)[0];
+	}
+
+	const newContent = currentContent.trimEnd() + '\n\n' + generateDocContent();
+
+	if (process.argv.includes('--check')) {
+		const existingContent = fs.readFileSync(readmePath, 'utf8');
+		if (existingContent !== newContent) {
+			console.error(
+				'README.md is out of date with appellant case page-component contracts. Run `npm run generate-docs:appellant-case` to update.'
+			);
+			process.exit(1);
+		}
+		console.log('README.md rendered rows breakdown is up to date.');
+	} else {
+		fs.writeFileSync(readmePath, newContent);
+		console.log('Successfully updated README.md with auto-generated rendered rows breakdown.');
+	}
+}

--- a/packages/scripts/verify_appellant_case_docs.sh
+++ b/packages/scripts/verify_appellant_case_docs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+verify_appellant_case_docs() {
+  TMP_FILE=$(mktemp)
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+  REPO_ROOT="$SCRIPT_DIR/../.."
+
+  # Run doc generator in check mode or check git diff of README.md
+  npm run generate-docs:appellant-case --workspace=@pins/appeals.web > /dev/null 2>&1
+
+  # Check if README.md has uncommitted changes produced by running doc generator
+  README_PATH="appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/README.md"
+  
+  if ! git diff --exit-code "$REPO_ROOT/$README_PATH" > /dev/null 2>&1; then
+    echo "Appellant case mapper documentation in $README_PATH is outdated."
+    echo "Please run: npm run generate-docs:appellant-case --workspace=@pins/appeals.web and commit the updated README.md"
+    rm "$TMP_FILE"
+    return 1
+  fi
+
+  echo "Appellant case mapper documentation is up to date."
+  rm "$TMP_FILE"
+  return 0
+}
+
+verify_appellant_case_docs


### PR DESCRIPTION
## Describe your changes

### Updates
Refactored all appellant case page component mappers (has, cas, adverts, cas-advert, s20, s78, s78-expedited, ldc, enforcement-notice, enforcement-listed) to construct page card component arrays directly using dedicated section builders rather than mutating existing arrays.
Added tests to cover row rendering and logic to auto generate docs and check that docs are up to date after changes

Key Changes
Centralized Reusable Section Builders common-sections.mapper.js
Eliminated Array & Object Mutation: Removed .findIndex(), .splice(), and .push() in mapper generators to make the setuup less fragile


Currently verified that the existing setup passes existing unit tests and manually tested in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8974)
