### PR TITLE
fix(api): import ELB grounds of appeal correctly (A2-8932)

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
@@ -130,7 +130,8 @@ describe('/appeals/case-submission', () => {
 			expect(response.status).toEqual(400);
 		});
 	});
-	describe('POST successful appeal gets ingested', () => {
+
+	describe('POST successful appeal gets ingested - non-enforcement', () => {
 		beforeEach(() => {
 			// @ts-ignore
 			databaseConnector.appeal.findUnique.mockResolvedValue({});
@@ -165,21 +166,7 @@ describe('/appeals/case-submission', () => {
 				{ id: 1 },
 				1
 			],
-			['ADVERTISEMENT', appealIngestionInputAdverts, validAppellantCaseAdverts, { id: 1 }, 1],
-			[
-				'ENFORCEMENT_NOTICE',
-				appealIngestionInputEnforcementNotice,
-				validAppellantCaseEnforcementNotice,
-				{ id: 2 },
-				2
-			],
-			[
-				'ENFORCEMENT_LISTED_BUILDING',
-				appealIngestionInputEnforcementListedBuilding,
-				validAppellantCaseEnforcementListedBuilding,
-				{ id: 2 },
-				2
-			]
+			['ADVERTISEMENT', appealIngestionInputAdverts, validAppellantCaseAdverts, { id: 1 }, 1]
 		])(
 			'POST valid %s appellant case payload and create appeal',
 			async (
@@ -219,11 +206,110 @@ describe('/appeals/case-submission', () => {
 					})
 				);
 
+				expect(mockNotifySend).not.toHaveBeenCalled();
+
+				expect(databaseConnector.document.createMany).toHaveBeenCalled();
+				expect(databaseConnector.documentVersion.createMany).toHaveBeenCalled();
+				expect(databaseConnector.documentVersion.findMany).toHaveBeenCalled();
+
+				expect(databaseConnector.appealGround.createMany).not.toHaveBeenCalled();
+				// Will not be called as non-enforcement appeals so no linked appeal created at this point
+				expect(databaseConnector.appealRelationship.create).not.toHaveBeenCalled();
+
+				expect(databaseConnector.appeal.findUnique).toHaveBeenCalled();
+				expect(response.status).toEqual(201);
+				expect(response.body).toEqual(result);
+			}
+		);
+	});
+
+	describe('POST successful appeal gets ingested - enforcement', () => {
+		beforeEach(() => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue({});
+		});
+		test.each([
+			[
+				'ENFORCEMENT_NOTICE',
+				appealIngestionInputEnforcementNotice,
+				validAppellantCaseEnforcementNotice,
+				{ id: 2 },
+				2,
+				1
+			],
+			[
+				'ENFORCEMENT_LISTED_BUILDING',
+				appealIngestionInputEnforcementListedBuilding,
+				validAppellantCaseEnforcementListedBuilding,
+				{ id: 2 },
+				2,
+				3
+			]
+		])(
+			'POST valid %s appellant case payload and create appeal',
+			async (
+				appealType,
+				appealIngestionInput,
+				validAppellantCase,
+				expectedTeamQueryParam,
+				expectedAssignedTeamId,
+				expectedAppealGroundId
+			) => {
+				const result = createIntegrationMocks(appealIngestionInput);
+				const payload = validAppellantCase;
+
+				const response = await request.post('/appeals/case-submission').send(payload);
+
+				expect(databaseConnector.appeal.create).toHaveBeenCalledWith({
+					data: {
+						reference: expect.any(String),
+						submissionId: expect.any(String),
+						...appealIngestionInput
+					}
+				});
+				// Will be called twice for Enforcement Notice as there is a named individual as well as appellant
+				// Therefore a child appeal is created and linked
+				expect(databaseConnector.appeal.create).toHaveBeenCalledTimes(
+					appealType === 'ENFORCEMENT_NOTICE' ? 2 : 1
+				);
+				expect(databaseConnector.appealRelationship.create).toHaveBeenCalledTimes(
+					appealType === 'ENFORCEMENT_NOTICE' ? 1 : 0
+				);
+
+				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
+					where: { id: 100 },
+					data: {
+						reference: expect.any(String),
+						appealStatus: {
+							create: {
+								status: APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+								createdAt: expect.any(String)
+							}
+						},
+						assignedTeamId: expectedAssignedTeamId
+					}
+				});
+				expect(databaseConnector.team.findUnique).toHaveBeenCalledWith(
+					expect.objectContaining({
+						where: expectedTeamQueryParam
+					})
+				);
+
 				expect(mockNotifySend).toHaveBeenCalledTimes(appealType === 'ENFORCEMENT_NOTICE' ? 2 : 0);
 
 				expect(databaseConnector.document.createMany).toHaveBeenCalled();
 				expect(databaseConnector.documentVersion.createMany).toHaveBeenCalled();
 				expect(databaseConnector.documentVersion.findMany).toHaveBeenCalled();
+
+				expect(databaseConnector.appealGround.createMany).toHaveBeenCalledWith({
+					data: [
+						{
+							appealId: 100,
+							factsForGround: validAppellantCase.casedata.appealGrounds[0].factsForGround,
+							groundId: expectedAppealGroundId
+						}
+					]
+				});
 
 				expect(databaseConnector.appeal.findUnique).toHaveBeenCalled();
 				expect(response.status).toEqual(201);

--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -5,6 +5,7 @@ import { createAppealReference } from '#utils/appeal-reference.js';
 import { databaseConnector } from '#utils/database-connector.js';
 import { PROCEDURE_TYPE_ID_MAP, TEAM_NAME_MAP } from '@pins/appeals/constants/common.js';
 import { CASE_RELATIONSHIP_RELATED } from '@pins/appeals/constants/support.js';
+import { appealCaseTypeToAppealTypeMapper } from '@pins/appeals/utils/appeal-type-case.mapper.js';
 import { isLdcOrDiscontinuanceOrEnforcementCaseType } from '@pins/appeals/utils/appeal-type-checks.js';
 import { APPEAL_CASE_STATUS, APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 import { getAppealTypeByTypeId } from './appeal-type.repository.js';
@@ -94,7 +95,8 @@ export const createAppeal = async (
 			);
 			await setAppealRelationships(tx, appeal.id, appeal.reference, relatedReferences);
 
-			await setAppealGrounds(tx, appeal.id, appealGrounds);
+			const appealTypeString = appealCaseTypeToAppealTypeMapper(caseType);
+			await setAppealGrounds(tx, appeal.id, appealTypeString, appealGrounds);
 
 			const appealDetails = await tx.appeal.findUnique({
 				where: { id: appeal.id }
@@ -382,16 +384,20 @@ const attachToRepresentation = async (tx, repId, documents) => {
  *
  * @param {import('#db-client/client.ts').Prisma.TransactionClient} tx
  * @param {number} appealId
+ * @param {string} appealTypeString
  * @param {{groundRef:string, factsForGround:string}[]} appealGrounds
  * @returns {Promise<void>}
  */
 // @ts-ignore
-const setAppealGrounds = async (tx, appealId, appealGrounds) => {
+const setAppealGrounds = async (tx, appealId, appealTypeString, appealGrounds) => {
 	if (appealGrounds?.length) {
 		const grounds = await tx.ground.findMany();
+
 		await tx.appealGround.createMany({
 			data: appealGrounds.map((appealGround) => {
-				const groundId = grounds.find((g) => g.groundRef === appealGround.groundRef)?.id;
+				const groundId = grounds.find(
+					(g) => g.groundRef === appealGround.groundRef && g.appealType === appealTypeString
+				)?.id;
 				return {
 					appealId,
 					groundId,

--- a/appeals/api/src/server/tests/integrations/mocks.js
+++ b/appeals/api/src/server/tests/integrations/mocks.js
@@ -341,8 +341,8 @@ export const validAppellantCaseEnforcementListedBuilding = {
 		namedIndividuals: [],
 		appealGrounds: [
 			{
-				groundRef: 'a',
-				factsForGround: 'I like Christmas'
+				groundRef: 'c',
+				factsForGround: 'I like a listed Christmas'
 			}
 		]
 	}

--- a/appeals/api/src/server/tests/shared/mocks.js
+++ b/appeals/api/src/server/tests/shared/mocks.js
@@ -1,3 +1,4 @@
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import {
 	VALIDATION_OUTCOME_COMPLETE,
 	VALIDATION_OUTCOME_INCOMPLETE,
@@ -176,16 +177,19 @@ export const grounds = [
 	{
 		id: 1,
 		groundRef: 'a',
-		groundDescription: 'Ground A'
+		groundDescription: 'Ground A',
+		appealType: APPEAL_TYPE.ENFORCEMENT_NOTICE
 	},
 	{
 		id: 2,
 		groundRef: 'b',
-		groundDescription: 'Ground B'
+		groundDescription: 'Ground B',
+		appealType: APPEAL_TYPE.ENFORCEMENT_NOTICE
 	},
 	{
 		id: 3,
 		groundRef: 'c',
-		groundDescription: 'Ground C'
+		groundDescription: 'Ground C',
+		appealType: APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
 	}
 ];


### PR DESCRIPTION
## Describe your changes

Update appealGround createMany call on importing enforcement and elb cases, finds relevant ground based on ground letter and appeal type to avoid enforcement notice grounds always being selected where ground letter is the same.

Updated tests.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8932)
