### PR TITLE
fix(web): improve reliability of zip download (A2-9011)

### DIFF
--- a/appeals/web/src/server/app/components/__tests__/file-downloader.component.test.js
+++ b/appeals/web/src/server/app/components/__tests__/file-downloader.component.test.js
@@ -1,12 +1,22 @@
 // @ts-nocheck
 
 import { jest } from '@jest/globals';
+let archiveEntryCallback;
 const mockArchive = {
 	pipe: jest.fn(),
-	append: jest.fn(),
+	append: jest.fn(() => {
+		archiveEntryCallback?.();
+		archiveEntryCallback = undefined;
+	}),
 	finalize: jest.fn().mockResolvedValue(),
 	on: jest.fn(),
-	once: jest.fn(),
+	once: jest.fn((event, callback) => {
+		if (event === 'entry') {
+			archiveEntryCallback = callback;
+		}
+		return mockArchive;
+	}),
+	removeListener: jest.fn(),
 	destroyed: false,
 	destroy: jest.fn()
 };
@@ -20,7 +30,7 @@ jest.unstable_mockModule('archiver', () => ({
 const mockGenerateAllPdfs = jest.fn();
 
 const mockConfig = { featureFlags: { featureFlagPdfDownload: false } };
-const mockLogger = { warn: jest.fn(), error: jest.fn() };
+const mockLogger = { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() };
 
 jest.unstable_mockModule('@pins/appeals.web/environment/config.js', () => ({
 	__esModule: true,
@@ -48,6 +58,7 @@ const mockBlobInstance = {
 };
 const BlobStorageClient = jest.fn(() => mockBlobInstance);
 BlobStorageClient.fromUrlAndToken = jest.fn(() => mockBlobInstance);
+BlobStorageClient.fromUrlAndCredential = jest.fn(() => mockBlobInstance);
 jest.unstable_mockModule('@pins/blob-storage-client', () => ({
 	BlobStorageClient
 }));
@@ -79,7 +90,10 @@ describe('getBulkDocumentDownload', () => {
 		mockArchive.on.mockClear();
 		mockArchive.once.mockClear();
 		mockArchive.destroyed = false;
+		archiveEntryCallback = undefined;
 		mockConfig.featureFlags.featureFlagPdfDownload = false;
+		mockBlobInstance.getBlobProperties.mockReset();
+		mockBlobInstance.downloadStream.mockReset();
 	});
 
 	it('downloads files and finalizes archive (no pdfs)', async () => {
@@ -101,12 +115,8 @@ describe('getBulkDocumentDownload', () => {
 				]
 			}
 		]);
-		// Patch blob client
-		const blobClientMod = await import('@pins/blob-storage-client');
-		blobClientMod.BlobStorageClient.mockImplementation(() => ({
-			getBlobProperties: jest.fn().mockResolvedValue({}),
-			downloadStream: jest.fn().mockResolvedValue({ readableStreamBody: { pipe: jest.fn() } })
-		}));
+		mockBlobInstance.getBlobProperties.mockResolvedValue({});
+		mockBlobInstance.downloadStream.mockResolvedValue({ readableStreamBody: { pipe: jest.fn() } });
 
 		const { getBulkDocumentDownload } = await import('../file-downloader.component.js');
 		await getBulkDocumentDownload(
@@ -146,11 +156,8 @@ describe('getBulkDocumentDownload', () => {
 				]
 			}
 		]);
-		const blobClientMod = await import('@pins/blob-storage-client');
-		blobClientMod.BlobStorageClient.mockImplementation(() => ({
-			getBlobProperties: jest.fn().mockResolvedValue({}),
-			downloadStream: jest.fn().mockResolvedValue({ readableStreamBody: { pipe: jest.fn() } })
-		}));
+		mockBlobInstance.getBlobProperties.mockResolvedValue({});
+		mockBlobInstance.downloadStream.mockResolvedValue({ readableStreamBody: { pipe: jest.fn() } });
 		mockGenerateAllPdfs.mockResolvedValue([{ name: 'foo.pdf', buffer: Buffer.from('a') }]);
 		await getBulkDocumentDownload(
 			{
@@ -187,6 +194,67 @@ describe('getBulkDocumentDownload', () => {
 		expect(mockArchive.finalize).toHaveBeenCalled();
 		expect(mockResponse.status).toHaveBeenCalledWith(200);
 		expect(mockResponse.send).not.toHaveBeenCalled();
+	});
+
+	it('skips a failed blob download and still finalizes the zip', async () => {
+		const docService = await import('#appeals/appeal-documents/appeal.documents.service.js');
+		docService.getAllCaseFolders.mockResolvedValue([
+			{
+				path: 'folder',
+				documents: [
+					{
+						latestDocumentVersion: {
+							blobStorageContainer: 'c',
+							blobStoragePath: 'bad',
+							documentURI: 'uri'
+						},
+						name: 'bad.pdf',
+						guid: 'bad',
+						id: 'bad'
+					},
+					{
+						latestDocumentVersion: {
+							blobStorageContainer: 'c',
+							blobStoragePath: 'good',
+							documentURI: 'uri'
+						},
+						name: 'good.pdf',
+						guid: 'good',
+						id: 'good'
+					}
+				]
+			}
+		]);
+
+		mockBlobInstance.getBlobProperties.mockResolvedValue({});
+		mockBlobInstance.downloadStream.mockImplementation((container, blobPath) => {
+			if (blobPath === 'bad') {
+				return Promise.reject(new Error('blob failed'));
+			}
+
+			return Promise.resolve({ readableStreamBody: { pipe: jest.fn() } });
+		});
+
+		const { getBulkDocumentDownload } = await import('../file-downloader.component.js');
+		await getBulkDocumentDownload(
+			{
+				apiClient: mockApiClient,
+				params: { caseId: '1' },
+				session: mockSession,
+				currentAppeal: mockAppeal
+			},
+			mockResponse
+		);
+
+		expect(mockArchive.append).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({ name: 'Folder/good.pdf' })
+		);
+		expect(mockArchive.append).toHaveBeenCalledWith(expect.any(Buffer), {
+			name: 'missing-files.json'
+		});
+		expect(mockArchive.finalize).toHaveBeenCalled();
+		expect(mockResponse.status).toHaveBeenCalledWith(200);
 	});
 
 	it('handles error and destroys archive/response', async () => {

--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -49,8 +49,10 @@ const createBlobStorageClient = async (session) => {
 	if (config.useBlobEmulator === true) {
 		return new BlobStorageClient(new BlobServiceClient(config.blobEmulatorSasUrl));
 	} else {
-		const accessToken = await getActiveDirectoryAccessToken(session);
-		return BlobStorageClient.fromUrlAndToken(config.blobStorageUrl, accessToken);
+		// re-acquire per request so long downloads survive the initial token expiring
+		/** @type {import("@azure/storage-blob").StorageSharedKeyCredential | import("@azure/storage-blob").AnonymousCredential | import("@azure/core-auth").TokenCredential} */
+		const credential = { getToken: () => getActiveDirectoryAccessToken(session) };
+		return BlobStorageClient.fromUrlAndCredential(config.blobStorageUrl, credential);
 	}
 };
 
@@ -229,30 +231,49 @@ const createBlobDownloadStream = async (
 	blobStoragePath
 ) => {
 	const documentKey = blobStoragePath.startsWith('/') ? blobStoragePath.slice(1) : blobStoragePath;
+	const maxAttempts = 3;
 
-	let blobProperties;
-	try {
-		blobProperties = await blobStorageClient.getBlobProperties(blobStorageContainer, documentKey);
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			const blobProperties = await blobStorageClient.getBlobProperties(
+				blobStorageContainer,
+				documentKey
+			);
 
-		if (!blobProperties) {
-			return null;
+			if (!blobProperties) {
+				logger.warn(`Blob properties missing for ${documentKey}`);
+				return null;
+			}
+
+			const blobDownloadResponseParsed = await blobStorageClient.downloadStream(
+				blobStorageContainer,
+				documentKey
+			);
+
+			if (!blobDownloadResponseParsed?.readableStreamBody) {
+				throw new Error(`Document ${documentKey} missing stream body`);
+			}
+
+			//@ts-ignore
+			return blobDownloadResponseParsed.readableStreamBody;
+		} catch (error) {
+			if (attempt === maxAttempts) {
+				logger.warn(
+					error,
+					`Skipping blob after failed download: ${documentKey} attempts=${maxAttempts}`
+				);
+				return null;
+			}
+
+			logger.warn(
+				error,
+				`Retrying blob download: ${documentKey} attempt=${attempt}/${maxAttempts}`
+			);
+			await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
 		}
-	} catch (error) {
-		console.error(`Error getting blob properties for ${documentKey}:`, error);
-		return null;
 	}
 
-	const blobDownloadResponseParsed = await blobStorageClient.downloadStream(
-		blobStorageContainer,
-		documentKey
-	);
-
-	if (!blobDownloadResponseParsed?.readableStreamBody) {
-		throw new Error(`Document ${documentKey} missing stream body`);
-	}
-
-	// @ts-ignore
-	return blobDownloadResponseParsed.blobDownloadStream;
+	return null;
 };
 
 /**
@@ -262,34 +283,16 @@ const createBlobDownloadStream = async (
  * @param {string[]} missingFiles
  */
 const addBlobsToArchive = async (archive, blobStorageClient, bulkFileInfo, missingFiles) => {
-	let nextDownloadPromise = null;
-	for (let i = 0; i < bulkFileInfo.length; i++) {
-		const fileInfo = bulkFileInfo[i];
+	// download and append one blob at a time; idle blob streams are disconnected by Azure
+	for (const fileInfo of bulkFileInfo) {
+		const blobStream = await createBlobDownloadStream(
+			blobStorageClient,
+			fileInfo.blobStorageContainer,
+			fileInfo.blobStoragePath
+		);
 
-		let downloadPromise;
-		if (nextDownloadPromise) {
-			downloadPromise = nextDownloadPromise;
-			nextDownloadPromise = null;
-		} else {
-			downloadPromise = createBlobDownloadStream(
-				blobStorageClient,
-				fileInfo.blobStorageContainer,
-				fileInfo.blobStoragePath
-			);
-		}
-
-		// Start next download in background so it's ready when for next loop after append completes
-		if (i + 1 < bulkFileInfo.length) {
-			const nextInfo = bulkFileInfo[i + 1];
-			nextDownloadPromise = createBlobDownloadStream(
-				blobStorageClient,
-				nextInfo.blobStorageContainer,
-				nextInfo.blobStoragePath
-			);
-		}
-
-		const blobStream = await downloadPromise;
 		if (!blobStream) {
+			logger.warn(`Skipping blob for archive: fullName=${fileInfo.fullName}`);
 			missingFiles.push(fileInfo.fullName);
 			continue;
 		}
@@ -330,6 +333,10 @@ export const getBulkDocumentDownload = async (
 	{ apiClient, params, session, currentAppeal },
 	response
 ) => {
+	const start = performance.now();
+	logger.info(
+		`getBulkDocumentDownload for caseId ${params.caseId}, representationType ${params.representationType || 'all'}`
+	);
 	const { filename = '', caseId, representationType = '' } = params;
 	const zipFileName = buildZipFileName(caseId, filename);
 
@@ -382,7 +389,7 @@ export const getBulkDocumentDownload = async (
 
 	response.once('close', () => {
 		if (!response.writableFinished) {
-			logger.warn('getBulkDocumentDownload aborted');
+			logger.warn(`getBulkDocumentDownload aborted for caseId ${caseId}`);
 			return handleUnexpectedClose();
 		}
 	});
@@ -416,9 +423,18 @@ export const getBulkDocumentDownload = async (
 			archive.append(Buffer.from(JSON.stringify(missingFiles)), { name: 'missing-files.json' });
 		}
 
+		const durationMs = performance.now() - start;
+
 		// Avoid awaiting finalize despite it being a promise https://github.com/archiverjs/node-archiver/issues/772
 		// avoid calling send on response as it will end the stream potentially before archiver has finalised
-		archive.finalize().catch(handleError);
+		archive
+			.finalize()
+			.then(() => {
+				logger.info(
+					`getBulkDocumentDownload completed: caseId=${caseId} representationType=${representationType || 'all'} missingFiles=${missingFiles.length} durationMs=${durationMs.toFixed(0)}`
+				);
+			})
+			.catch(handleError);
 	} catch (error) {
 		handleError(error);
 	}


### PR DESCRIPTION
## Describe your changes

Attempts to improve reliability of zip download
- avoids pre fetching next file details in case this is timing out between last file finishing and next starting on slow connections
- uses a new connection to blob storage on each request in case token times out
- retries connection to blob
- additional logging

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-9011
