### PR TITLE
feat(web): give inspectors read access to poe docs (A2-8831)

### DIFF
--- a/appeals/web/environment/permissions.js
+++ b/appeals/web/environment/permissions.js
@@ -33,7 +33,8 @@ export const calculatePermissions = (currentUserGroups) => {
 		setCaseOutcome: isCaseOfficer || isInspector,
 		setEvents: isCaseOfficer || isInspector,
 		reIssueDecisionLetter: isCaseOfficer || isCqtTeam,
-		viewRedactionStatusColumn: !isInspector || isCaseOfficer
+		viewRedactionStatusColumn: !isInspector || isCaseOfficer,
+		readOnlyDocumentsFolder: isInspector
 	};
 
 	return perms;
@@ -49,5 +50,6 @@ export const permissionNames = {
 	setCaseOutcome: 'setCaseOutcome',
 	setEvents: 'setEvents',
 	reIssueDecisionLetter: 'reIssueDecisionLetter',
-	viewRedactionStatusColumn: 'viewRedactionStatusColumn'
+	viewRedactionStatusColumn: 'viewRedactionStatusColumn',
+	readOnlyDocumentsFolder: 'readOnlyDocumentsFolder'
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/manage-documents.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/manage-documents.router.js
@@ -25,7 +25,7 @@ router
 router
 	.route('/:folderId/')
 	.get(
-		assertUserHasPermission(permissionNames.updateCase),
+		assertUserHasPermission(permissionNames.updateCase, permissionNames.readOnlyDocumentsFolder),
 		asyncHandler(controller.getManageFolder)
 	);
 


### PR DESCRIPTION
## Describe your changes

Create new permission just for inspectors, pass it as the special fallback when accessing manage-document routes.

All edit action functionality already hidden from inspectors.

## Issue ticket number and link

[8831](https://pins-ds.atlassian.net.mcas.ms/browse/A2-8831)
