### PR TITLE
feat(api): new notify for enf hearing no final comments and added tes…

### DIFF
--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -21,7 +21,8 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 import {
 	APPEAL_REPRESENTATION_STATUS,
 	APPEAL_REPRESENTATION_TYPE,
-	FEATURE_FLAG_NAMES
+	FEATURE_FLAG_NAMES,
+	PROCEDURE_TYPE_NAME
 } from '@pins/appeals/constants/common.js';
 import * as CONSTANTS from '@pins/appeals/constants/support.js';
 import {
@@ -1227,10 +1228,22 @@ function notifyNoFinalComments(appeal, notifyClient, azureAdUserId, userTypeNoCo
 			? appeal.lpa?.email
 			: appeal.agent?.email || appeal.appellant?.email;
 
+	if (!recipientEmail) {
+		throw new Error(
+			`${ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL}: no ${userTypeNoCommentSubmitted} email address in appeal`
+		);
+	}
+
+	const isEnforcementOrLdc = isLdcOrEnforcementCaseType(appeal.appealType?.key);
+	const templateName =
+		isEnforcementOrLdc && appeal.procedureType?.name === PROCEDURE_TYPE_NAME.HEARING
+			? 'final-comments-none-enforcement-hearing'
+			: 'final-comments-none';
+
 	return notifyPublished({
 		appeal,
 		notifyClient,
-		templateName: 'final-comments-none',
+		templateName,
 		recipientEmail,
 		azureAdUserId,
 		userTypeNoCommentSubmitted

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-none-enforcement-hearing.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-none-enforcement-hearing.test.js
@@ -1,0 +1,163 @@
+import { notifySend } from '#notify/notify-send.js';
+import { jest } from '@jest/globals';
+
+describe('final-comments-none-enforcement-hearing.content.md', () => {
+	test('should render correct content with full hearing details', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'final-comments-none-enforcement-hearing',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				appeal_reference_number: '134526',
+				lpa_reference: '48269/APP/2021/1482',
+				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+				hearing_date: '01 January 2025',
+				hearing_time: '10:00am',
+				hearing_expected_days: '2',
+				inspector: 'Mr Test Inspector',
+				hearing_address: '123 Hearing Venue, Testtown, TE5 7ST',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+			}
+		};
+
+		const expectedContent = [
+			'Neither the local planning authority or the appellant submitted any final comments.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: 134526',
+			'Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+			'Planning application reference: 48269/APP/2021/1482',
+			'',
+			'# Hearing details',
+			'',
+			'^Date: 01 January 2025',
+			'Time: 10:00am',
+			'Expected days: 2',
+			'Inspector: Mr Test Inspector',
+			'Venue address: 123 Hearing Venue, Testtown, TE5 7ST',
+			'',
+			'',
+			'We will contact you if we make any changes to the hearing.',
+			'',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'No final comments: 134526'
+			}
+		);
+	});
+
+	test('should render correct content when hearing is not yet set up', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'final-comments-none-enforcement-hearing',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				appeal_reference_number: '134526',
+				lpa_reference: '48269/APP/2021/1482',
+				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+				hearing_date: '',
+				hearing_time: '',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+			}
+		};
+
+		const expectedContent = [
+			'Neither the local planning authority or the appellant submitted any final comments.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: 134526',
+			'Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+			'Planning application reference: 48269/APP/2021/1482',
+			'',
+			'We will contact you by email when we set up the hearing.',
+			'',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'No final comments: 134526'
+			}
+		);
+	});
+
+	test('should render hearing details without optional fields', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'final-comments-none-enforcement-hearing',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				appeal_reference_number: '134526',
+				lpa_reference: '48269/APP/2021/1482',
+				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+				hearing_date: '01 January 2025',
+				hearing_time: '10:00am',
+				hearing_expected_days: '',
+				inspector: '',
+				hearing_address: '',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+			}
+		};
+
+		const expectedContent = [
+			'Neither the local planning authority or the appellant submitted any final comments.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: 134526',
+			'Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+			'Planning application reference: 48269/APP/2021/1482',
+			'',
+			'# Hearing details',
+			'',
+			'^Date: 01 January 2025',
+			'Time: 10:00am',
+			'',
+			'',
+			'We will contact you if we make any changes to the hearing.',
+			'',
+			'',
+			'Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'No final comments: 134526'
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/notify/templates/final-comments-none-enforcement-hearing.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-none-enforcement-hearing.content.md
@@ -1,0 +1,26 @@
+Neither the local planning authority or the appellant submitted any final comments.
+
+{% include 'parts/appeal-details.md' %}
+
+{% if hearing_date -%}
+# Hearing details
+
+^Date: {{hearing_date}}
+Time: {{hearing_time}}
+{% if hearing_expected_days -%}
+Expected days: {{hearing_expected_days}}
+{% endif -%}
+{% if inspector -%}
+Inspector: {{inspector}}
+{% endif -%}
+{% if hearing_address -%}
+Venue address: {{hearing_address}}
+{% endif %}
+
+We will contact you if we make any changes to the hearing.
+{% else -%}
+We will contact you by email when we set up the hearing.
+{% endif %}
+
+Planning Inspectorate
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/final-comments-none-enforcement-hearing.subject.md
+++ b/appeals/api/src/server/notify/templates/final-comments-none-enforcement-hearing.subject.md
@@ -1,0 +1,1 @@
+No final comments: {{appeal_reference_number}}

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -932,6 +932,14 @@ these [Notify Templates](../appeals/api/src/server/notify/templates):
 - **Notify Content Template:** [final-comments-none](../appeals/api/src/server/notify/templates/final-comments-none.content.md)
 - **Trigger:**
 
+### Final comments none - Enf/ELB/LDC Hearing
+
+- **Appeal type:**
+- **Notify Subject Template:** [final-comments-none](../appeals/api/src/server/notify/templates/final-comments-none-enforcement-hearing.subject.md)
+- **Notify Content Template:** [final-comments-none](../appeals/api/src/server/notify/templates/final-comments-none-enforcement-hearing.content.md)
+- - **GOV notify template:** [Hearing updated - GOV.UK Notify](https://www.notifications.service.gov.uk/services/c46d894e-d10e-4c46-a467-019576cd906a/templates/1105f639-569d-4bc0-8c4f-ef9373afc182)
+- **Trigger:** Progress from final comments in Enf/ELB/LDC case hearing procedure and no final comments have been received from any party. Sent to appellant/agent and LPA.
+
 ## Decision
 
 ### Decision is (allowed, split, or dismissed) appellant


### PR DESCRIPTION
- Added new notify template for enf/elb/ldc hearing cases where no final comments received
- Created enf conditions for selecting new template
- Added tests
- Updated notifications and triggers

Ticket: https://pins-ds.atlassian.net/browse/A2-8910