### PR TITLE
fix(test/e2e): correcting expected case history text for site visit e…

### DIFF
--- a/appeals/e2e/cypress/page_objects/caseHistory/caseHistoryStates.js
+++ b/appeals/e2e/cypress/page_objects/caseHistory/caseHistoryStates.js
@@ -53,7 +53,7 @@ export const CASE_HISTORY_STATES = Object.freeze({
 	],
 	missedSiteVisit: [
 		{
-			detail: 'Missed site visit: {caseRef} sent to appellant',
+			detail: 'Missed site visit: {caseRef} sent to agent',
 			emailLink: 'yes',
 			emailSubject: 'Subject: Missed site visit: {caseRef}',
 			emailBody: 'Nobody was at the site to give the inspector access.'


### PR DESCRIPTION
…2e tests (no-ticket)

## Describe your changes

- Updating the expected case history message in the e2e tests following the change to using the agent emails (https://github.com/Planning-Inspectorate/appeals-back-office/pull/3993)

All tests in the site visit suite now pass locally
<img width="2057" height="1287" alt="image" src="https://github.com/user-attachments/assets/d2089b2e-c373-4426-bcbb-ca27a81ca399" />
