### PR TITLE
fix(web): get all representation attachments for case download (A2-9013)

### DIFF
--- a/appeals/web/src/server/app/components/__tests__/file-downloader.component.test.js
+++ b/appeals/web/src/server/app/components/__tests__/file-downloader.component.test.js
@@ -49,7 +49,8 @@ jest.unstable_mockModule('#appeals/appeal-documents/appeal.documents.service.js'
 	getAllCaseFolders: jest.fn(),
 	getFileInfo: jest.fn(),
 	getFileVersionsInfo: jest.fn(),
-	getRepresentationAttachments: jest.fn()
+	getRepresentationAttachments: jest.fn(),
+	getAllRepresentationAttachments: jest.fn().mockResolvedValue([])
 }));
 
 const mockBlobInstance = {
@@ -273,5 +274,95 @@ describe('getBulkDocumentDownload', () => {
 		);
 		expect(mockArchive.destroy).toHaveBeenCalled();
 		expect(mockResponse.destroy).toHaveBeenCalled();
+	});
+
+	it('maps published representation attachments correctly', async () => {
+		const { getRepresentationAttachmentFullNames } =
+			await import('../file-downloader.component.js');
+		const docService = await import('#appeals/appeal-documents/appeal.documents.service.js');
+		docService.getAllRepresentationAttachments.mockResolvedValue([
+			{
+				representationType: 'comment',
+				status: 'published',
+				attachments: [
+					{
+						documentGuid: 'guid-1',
+						documentVersion: {
+							document: { guid: 'guid-1', name: 'attachment1.pdf' }
+						}
+					}
+				]
+			}
+		]);
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '11175');
+		expect(docService.getAllRepresentationAttachments).toHaveBeenCalledWith(mockApiClient, '11175');
+		expect(result['guid-1']).toBe(
+			'Representations/Interested party comments/Accepted/Comment 1/attachment1.pdf'
+		);
+	});
+
+	it('handles hundreds of IP comments with attachments', async () => {
+		const { getRepresentationAttachmentFullNames, getBulkFileInfo } =
+			await import('../file-downloader.component.js');
+		const docService = await import('#appeals/appeal-documents/appeal.documents.service.js');
+
+		// Generate 350 mock representations with attachments on #5, #35, #250, #350
+		const mockReps = Array.from({ length: 350 }, (_, idx) => {
+			const repNum = idx + 1;
+			const hasAttachment = [5, 35, 250, 350].includes(repNum);
+			return {
+				id: repNum,
+				representationType: 'comment',
+				status: repNum % 2 === 0 ? 'published' : 'valid',
+				attachments: hasAttachment
+					? [
+							{
+								documentGuid: `guid-${repNum}`,
+								documentVersion: {
+									document: { guid: `guid-${repNum}`, name: `doc-${repNum}.pdf` }
+								}
+							}
+						]
+					: []
+			};
+		});
+
+		docService.getAllRepresentationAttachments.mockResolvedValue(mockReps);
+
+		mockApiClient.get = jest.fn().mockReturnValue({
+			json: jest.fn().mockResolvedValue([
+				{
+					path: 'representation/representationAttachments',
+					documents: [5, 35, 250, 350].map((num) => ({
+						id: `guid-${num}`,
+						name: `doc-${num}.pdf`,
+						latestDocumentVersion: {
+							blobStorageContainer: 'container',
+							blobStoragePath: `path/doc-${num}.pdf`,
+							documentURI: `http://blob/doc-${num}.pdf`
+						}
+					}))
+				}
+			])
+		});
+
+		const attachmentNames = await getRepresentationAttachmentFullNames(mockApiClient, '11175');
+		expect(docService.getAllRepresentationAttachments).toHaveBeenCalledWith(mockApiClient, '11175');
+		expect(attachmentNames['guid-35']).toBe(
+			'Representations/Interested party comments/Accepted/Comment 35/doc-35.pdf'
+		);
+		expect(attachmentNames['guid-350']).toBe(
+			'Representations/Interested party comments/Accepted/Comment 350/doc-350.pdf'
+		);
+
+		const bulkFileInfo = await getBulkFileInfo(mockApiClient, '11175', 'ip-comments');
+		expect(bulkFileInfo).toHaveLength(4);
+		expect(bulkFileInfo.find((f) => f.fullName.includes('Comment 35'))?.fullName).toBe(
+			'Representations/Interested party comments/Accepted/Comment 35/doc-35.pdf'
+		);
+		expect(bulkFileInfo.find((f) => f.fullName.includes('Comment 350'))?.fullName).toBe(
+			'Representations/Interested party comments/Accepted/Comment 350/doc-350.pdf'
+		);
 	});
 });

--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -1,9 +1,9 @@
 import { generateAllPdfs } from '#app/components/download-all-generated-pdfs.component.js';
 import {
 	getAllCaseFolders,
+	getAllRepresentationAttachments,
 	getFileInfo,
-	getFileVersionsInfo,
-	getRepresentationAttachments
+	getFileVersionsInfo
 } from '#appeals/appeal-documents/appeal.documents.service.js';
 import getActiveDirectoryAccessToken from '#lib/active-directory-token.js';
 import logger from '#lib/logger.js';
@@ -467,25 +467,26 @@ const buildZipFileName = (caseId, filename) => {
  */
 
 export const getRepresentationAttachmentFullNames = async (apiClient, caseId) => {
-	const representations = await getRepresentationAttachments(apiClient, caseId);
+	const allReps = (await getAllRepresentationAttachments(apiClient, caseId)) || [];
+
+	/** @type {Record<string, string>} */
 	const fullAttachmentNames = {};
 	const statusCounts = {};
 
-	// @ts-ignore
-	representations?.items?.forEach((representation) => {
+	allReps.forEach((representation) => {
 		// Skip comments with invalid status
 		if (representation.representationType === 'comment' && representation.status === 'invalid') {
 			return; // Skip this representation
 		}
 		let representationStatus = representation.status;
-		if (representation.status === 'valid') {
+		if (representation.status === 'valid' || representation.status === 'published') {
 			representationStatus = 'accepted';
 		} else if (representation.status === 'invalid') {
 			representationStatus = 'rejected';
 		}
 
 		// Keep a count of each representation type and status so that we can give each ip comment a unique folder name
-		const statusCountKey = `${representation.representationType}-${representation.status}`;
+		const statusCountKey = `${representation.representationType}-${representationStatus}`;
 		// @ts-ignore
 		if (statusCounts[statusCountKey] === undefined) {
 			// @ts-ignore
@@ -501,10 +502,16 @@ export const getRepresentationAttachmentFullNames = async (apiClient, caseId) =>
 				: toSentenceCase(representation.representationType).replace('Lpa', 'LPA');
 
 		// @ts-ignore
-		representation.attachments.forEach((attachment) => {
-			const { document } = attachment.documentVersion || {};
-			// @ts-ignore
-			fullAttachmentNames[document.guid] = `Representations/${representationType}/${document.name}`;
+		representation.attachments?.forEach((attachment) => {
+			const { document } = attachment?.documentVersion || {};
+			const guid = document?.guid || attachment?.documentGuid;
+			const name =
+				document?.name ||
+				attachment?.documentVersion?.fileName ||
+				attachment?.documentVersion?.originalFilename;
+			if (guid && name) {
+				fullAttachmentNames[guid] = `Representations/${representationType}/${name}`;
+			}
 		});
 	});
 	return fullAttachmentNames;

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.service.test.js
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.service.test.js
@@ -1,0 +1,67 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+const mockGet = jest.fn();
+const mockApiClient = {
+	get: mockGet
+};
+
+describe('appeal.documents.service', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getAllRepresentationAttachments', () => {
+		it('fetches single page when pageCount is 1', async () => {
+			const { getAllRepresentationAttachments } = await import('../appeal.documents.service.js');
+
+			mockGet.mockReturnValueOnce({
+				json: jest.fn().mockResolvedValue({
+					pageCount: 1,
+					items: [{ id: 1, name: 'rep1' }]
+				})
+			});
+
+			const result = await getAllRepresentationAttachments(mockApiClient, '100');
+			expect(mockGet).toHaveBeenCalledTimes(1);
+			expect(mockGet).toHaveBeenCalledWith('appeals/100/reps?pageSize=100&pageNumber=1');
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('rep1');
+		});
+
+		it('fetches remaining pages in concurrency-limited batches when pageCount > 1', async () => {
+			const { getAllRepresentationAttachments } = await import('../appeal.documents.service.js');
+			mockGet
+				.mockReturnValueOnce({
+					json: jest.fn().mockResolvedValue({
+						pageCount: 7,
+						items: [{ id: 1 }]
+					})
+				})
+				.mockReturnValueOnce({
+					json: jest.fn().mockResolvedValue({ pageCount: 7, items: [{ id: 2 }] })
+				})
+				.mockReturnValueOnce({
+					json: jest.fn().mockResolvedValue({ pageCount: 7, items: [{ id: 3 }] })
+				})
+				.mockReturnValueOnce({
+					json: jest.fn().mockResolvedValue({ pageCount: 7, items: [{ id: 4 }] })
+				})
+				.mockReturnValueOnce({
+					json: jest.fn().mockResolvedValue({ pageCount: 7, items: [{ id: 5 }] })
+				})
+				.mockReturnValueOnce({
+					json: jest.fn().mockResolvedValue({ pageCount: 7, items: [{ id: 6 }] })
+				})
+				.mockReturnValueOnce({
+					json: jest.fn().mockResolvedValue({ pageCount: 7, items: [{ id: 7 }] })
+				});
+
+			// Set concurrencyLimit = 2 to verify batching behavior across 7 pages
+			const result = await getAllRepresentationAttachments(mockApiClient, '100', 200, 2);
+			expect(mockGet).toHaveBeenCalledTimes(7);
+			expect(result).toHaveLength(7);
+			expect(result.map((r) => r.id)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
@@ -242,12 +242,21 @@ export const deleteDocument = async (apiClient, documentId, versionId, appellant
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
+ * @param {number} [pageSize]
+ * @param {number} [pageNumber]
  * @returns {Promise<*>}
  */
-export const getRepresentationAttachments = async (apiClient, appealId) => {
+export const getRepresentationAttachments = async (apiClient, appealId, pageSize, pageNumber) => {
 	try {
 		const ids = assertValidNumericIds({ appealId });
-		return await apiClient.get(`appeals/${ids.appealId}/reps`).json();
+		const params = new URLSearchParams();
+		if (pageSize) params.append('pageSize', String(pageSize));
+		if (pageNumber) params.append('pageNumber', String(pageNumber));
+		const queryString = params.toString();
+		const url = queryString
+			? `appeals/${ids.appealId}/reps?${queryString}`
+			: `appeals/${ids.appealId}/reps`;
+		return await apiClient.get(url).json();
 	} catch (error) {
 		logger.error(
 			error,
@@ -256,4 +265,47 @@ export const getRepresentationAttachments = async (apiClient, appealId) => {
 				: `An error occurred while attempting to retrieve the representation attachments for appeal ID ${appealId}`
 		);
 	}
+};
+
+/**
+ * Retrieves all representation attachments across all pages using batched concurrency limits.
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {number} [pageSize=100]
+ * @param {number} [concurrencyLimit=5]
+ * @returns {Promise<Array<*>>}
+ */
+export const getAllRepresentationAttachments = async (
+	apiClient,
+	appealId,
+	pageSize = 100,
+	concurrencyLimit = 5
+) => {
+	const firstPage = await getRepresentationAttachments(apiClient, appealId, pageSize, 1);
+	const allReps = [...(firstPage?.items || [])];
+	const pageCount = firstPage?.pageCount || 1;
+
+	if (pageCount > 1) {
+		const remainingPageNumbers = [];
+		for (let page = 2; page <= pageCount; page++) {
+			remainingPageNumbers.push(page);
+		}
+
+		for (let i = 0; i < remainingPageNumbers.length; i += concurrencyLimit) {
+			const batchPageNumbers = remainingPageNumbers.slice(i, i + concurrencyLimit);
+			const batchResults = await Promise.all(
+				batchPageNumbers.map((pageNum) =>
+					getRepresentationAttachments(apiClient, appealId, pageSize, pageNum)
+				)
+			);
+			batchResults.forEach((pageData) => {
+				if (pageData?.items) {
+					allReps.push(...pageData.items);
+				}
+			});
+		}
+	}
+
+	return allReps;
 };


### PR DESCRIPTION
## Describe your changes

This PR addressed the Prod issue identified that representation attachments for IP comments were not being included in the case download.

The issue was that the representation attachments were being limited to 30 reps and published docs not being picked up.

Updates:
Updated the download component to get all reps with batched promises to run concurrent requests that are scalable for the larger cases on prod.
Updated docs to be included in the download to include published docs.
Added test for scenarios.




## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-9013)
